### PR TITLE
Learn link updated, header links back to grey

### DIFF
--- a/spa/src/app/shared/hca-toolbar/hca-toolbar.component.html
+++ b/spa/src/app/shared/hca-toolbar/hca-toolbar.component.html
@@ -25,7 +25,7 @@
                 </a>
             </cc-toolbar-nav-item>
             <cc-toolbar-nav-item>
-                <a href="https://dev.data.humancellatlas.org/learn/how-it-works/data-lifecycle">
+                <a href="https://dev.data.humancellatlas.org/learn/overview/overview">
                     <span>Learn</span>
                     <span>Find user guides and how-to’s here</span>
                 </a>

--- a/spa/src/app/shared/hca-toolbar/hca-toolbar.component.scss
+++ b/spa/src/app/shared/hca-toolbar/hca-toolbar.component.scss
@@ -29,7 +29,7 @@ mat-toolbar {
         padding: 0 16px; /* Gutter 16px */
 
         > a {
-            height: 48px; /* Image height */
+            height: 40px; /* Image height */
         }
     }
 
@@ -39,7 +39,7 @@ mat-toolbar {
     }
 
     img {
-        height: 45px;
+        height: 40px;
     }
 
     /* Override default cc-toolbar-nav left margin */
@@ -68,11 +68,10 @@ mat-toolbar {
             display: flex;
             flex-direction: column;
             font-family: "Montserrat", sans-serif;
-            font-size: 14px; /* TODO review with typography */
-            font-weight: 700; /* TODO review with typography */
-            letter-spacing: 1.2px;
+            font-size: 15px; /* TODO review with typography */
+            font-weight: 600; /* TODO review with typography */
             margin: 0 24px;
-            text-transform: capitalize;
+            text-transform: uppercase;
 
             &:hover {
                 color: $hca-black;
@@ -153,8 +152,9 @@ mat-toolbar {
             padding: 0 16px; /* HCA specific override */
 
             a {
-                color: $hca-black;
+                color: $hca-gray-dark;
                 margin: 0;
+                text-transform: capitalize;
 
                 span:nth-of-type(2) {
                     display: none;


### PR DESCRIPTION
- **Learn link in header goes to new overview page**
- Header links back to grey, active link black etc, and font size to match portal
- Img size reduced to match portal