### PR TITLE
Download manifest css update

### DIFF
--- a/spa/src/app/files/facet-file-list/facet-file-list.component.scss
+++ b/spa/src/app/files/facet-file-list/facet-file-list.component.scss
@@ -66,3 +66,12 @@
         }
     }
 }
+
+/* Download manifest summary */
+:host-context(.hca-card-content .facet-term-list) {
+
+    /* Term count */
+    .facet-term .term-summary .term-count {
+        flex-basis: 100px;
+    }
+}

--- a/spa/src/app/files/hca-facet-term-list/hca-facet-term-list.component.html
+++ b/spa/src/app/files/hca-facet-term-list/hca-facet-term-list.component.html
@@ -3,7 +3,7 @@
      (click)="onClickFacetTerm(fileFacet, term)">
     <div class="chart-legend-bar" [ngStyle]="getLegendStyle(term)"><mat-icon *ngIf="term.selected">check</mat-icon></div>
     <div class="term-summary">
-        <div class="term-name" [ngClass]="getTruncatedClass(fileFacet.name)">
+        <div class="term-name" [ngClass]="getTruncatedClass(term.name)">
             <ng-container [ngSwitch]="isTermNameTruncated(term.name)">
                 <span *ngSwitchCase="true"
                       matTooltip="{{formatTermName(term.name)}}" 

--- a/spa/src/app/files/hca-facet-term-list/hca-facet-term-list.component.ts
+++ b/spa/src/app/files/hca-facet-term-list/hca-facet-term-list.component.ts
@@ -93,13 +93,14 @@ export class HCAFacetTermListComponent {
     }
 
     /**
-     * Returns class truncate if fileFacet is protocol
+     * Returns class truncate if termName is not spaced and words are joined by an underscore
      * @param fileFacetName
      * @returns {string}
      */
-    public getTruncatedClass(fileFacetName) {
+    public getTruncatedClass(termName) {
 
-        if ( fileFacetName === "protocol" ) {
+        if ( termName.indexOf(" ") == -1 && termName.indexOf("_") >= 0 ) {
+            console.log(termName);
             return "truncate";
         }
     }


### PR DESCRIPTION
- css fix for spacing on download manifest
- also includes code to handle terms without spacing, joined by `_`

#186 