### PR TITLE
Scrollbar adjustments for filter

### DIFF
--- a/spa/src/app/files/hca-file-facet/hca-file-facet.component.scss
+++ b/spa/src/app/files/hca-file-facet/hca-file-facet.component.scss
@@ -11,7 +11,20 @@
     display: flex; /* Scroll content */
     flex-direction: column; /* Scroll content */
     padding: 18px;
+    position: relative; /* Positions fade on vertical scroll */
     width: 220px;
+
+    /* Fade on vertical scroll */
+    &::after {
+        bottom: 0;
+        background: linear-gradient(-180deg, rgba(255,255,255,0.00) 0%, rgba(255,255,255,0.80) 60%, #FFFFFF 100%);
+        content: "";
+        height: 36px;
+        position: absolute;
+        right: 0;
+        width: 100%;
+        z-index: 80;
+    }
 
     /* Facet title */
     .facet-title {
@@ -38,10 +51,15 @@
 
     /* Facet term list - container */
     .facet-term-list {
-        margin: 14px -18px 0;
-        max-height: 237.5px; /* For display of 9.5 terms at 237.5px total */
-        -ms-overflow-style: -ms-autohiding-scrollbar; // Hide scrollbar in IE unless actively scrolling
-        overflow-y: auto; // Scrollbar hidden on WebKit/Mac unless actively scrolling, scrollbar always visible for content that overflows on WebKit/Windows 
-        padding: 0 18px;
+        margin: 14px -8px 0;
+        max-height: 229.5px; /* For display of 8.5 terms at 229.5px total */
+        -ms-overflow-style: none; // IE 10+, scrollbar hidden
+        overflow-y: auto; // Firefox, scrollbar hidden unless actively scrolling
+        padding: 0 8px;
+
+        // Safari and Chrome, scrollbar hidden
+        &::-webkit-scrollbar {
+            display: none;
+        }
     }
 }

--- a/spa/src/app/files/hca-file-filter/hca-file-filter.component.scss
+++ b/spa/src/app/files/hca-file-filter/hca-file-filter.component.scss
@@ -153,7 +153,7 @@
 
         /* Wrapper around terms */
         .facet-term-list {
-            max-height: 237.5px;
+            max-height: 229.5px; /* For display of 8.5 terms at 229.5px total */
             -ms-overflow-style: -ms-autohiding-scrollbar; // Hide scrollbar in IE unless actively scrolling.
             overflow-y: auto; // Hide webkit scrollbar unless actively scrolling.
             padding: 2px 20px 0;


### PR DESCRIPTION
#217 

- Scrollbar removed - fade on 9th-ish term added to indicate term list scrolls.
- Excludes Firefox - scrollbar appears on scroll (Mac), or visible to indicate scrollable (Windows)