### PR TITLE
`totalCells` moved to `hits[*].cellSuspensions`

### DIFF
--- a/spa/src/app/files/hca-table/hca-table.component.ts
+++ b/spa/src/app/files/hca-table/hca-table.component.ts
@@ -292,6 +292,7 @@ class TableElementDataSource extends DataSource<any> {
 
 
                 let specimens = this.rollUpMetadata(row.specimens);
+                let cellSuspensions = this.rollUpMetadata(row.cellSuspensions);
                 let processes = this.rollUpMetadata(row.processes);
 
                 /* File counts for primary file format (fastq.qz) and other */
@@ -323,7 +324,7 @@ class TableElementDataSource extends DataSource<any> {
                     disease: specimens.disease,
                     fileTypePrimary: fileCounts.primaryCount,
                     fileTypeSecondary: fileCounts.secondaryCount,
-                    totalCells: specimens.totalCells
+                    totalCells: cellSuspensions.totalCells
                 };
             });
         });


### PR DESCRIPTION
Don't merge this now or at all. It's meant as a heads-up to what's coming down the pipe as a fix to https://github.com/DataBiosphere/azul/issues/499 which will ultimately fix #252.