### PR TITLE
Data Browser is gong to mobile/tablet portrait mode too quickly showing only 3 columns on a 13 inch MBP when not in full screen. Resolves #768.

### DIFF
--- a/spa/src/app/files/hca-table-files/hca-table-files.component.scss
+++ b/spa/src/app/files/hca-table-files/hca-table-files.component.scss
@@ -50,7 +50,8 @@
 
         mat-table {
             margin: 0 16px; /* Gutter 16px - margin to maintain RHS gutter in mobile view */
-            min-width: 1220px; /* Fixed table width for horizontal scroll - snap at 1280px */
+            max-width: 1540px; /* Required to prevent table from fully expanding on small screens - prod environment only. Width variation for files table. */
+            min-width: 1540px; /* Fixed table width for horizontal scroll. Width variation for files table. */
 
             /* Row - header and cell */
             mat-header-row, mat-row {
@@ -69,7 +70,7 @@
 
             /* Cell - header and cell */
             mat-header-cell, mat-cell {
-                flex: 0 1 10%;
+                flex: 0 1 10%; /* NB: flex variation to project and samples tables */
                 padding: 0;
             }
 
@@ -156,6 +157,8 @@
 
             mat-table {
                 margin: 0;
+                max-width: unset; /* Required */
+                min-width: 1220px; /* Fixed table width for horizontal scroll - snap at 1280px */
 
                 /* Snapped header row */
                 mat-header-row.snapped {

--- a/spa/src/app/files/hca-table-projects/hca-table-projects.component.scss
+++ b/spa/src/app/files/hca-table-projects/hca-table-projects.component.scss
@@ -61,6 +61,7 @@
         mat-table {
             margin: 0 16px; /* Gutter 16px - margin to maintain RHS gutter in mobile view */
             min-width: 1220px; /* Fixed table width for horizontal scroll - snap at 1280px */
+            max-width: 1220px; /* Required to prevent table from fully expanding on small screens - prod environment only */
 
             /* Row - header and cell */
             mat-header-row, mat-row {
@@ -98,7 +99,7 @@
 
             /* Cell - header and cell */
             mat-header-cell, mat-cell {
-                flex: 0 1 8%;
+                flex: 1;
                 padding: 0;
             }
 
@@ -214,6 +215,7 @@
 
             mat-table {
                 margin: 0;
+                max-width: unset; /* Required */
 
                 /* Snapped header row */
                 mat-header-row.snapped {

--- a/spa/src/app/files/hca-table-samples/hca-table-samples.component.scss
+++ b/spa/src/app/files/hca-table-samples/hca-table-samples.component.scss
@@ -51,6 +51,7 @@
         mat-table {
             margin: 0 16px; /* Gutter 16px - margin to maintain RHS gutter in mobile view */
             min-width: 1220px; /* Fixed table width for horizontal scroll - snap at 1280px */
+            max-width: 1220px; /* Required to prevent table from fully expanding on small screens - prod environment only */
 
             /* Row - header and cell */
             mat-header-row, mat-row {
@@ -68,7 +69,7 @@
 
             /* Cell - header and cell */
             mat-header-cell, mat-cell {
-                flex: 0 1 10%;
+                flex: 1;
                 padding: 0;
             }
 
@@ -141,6 +142,7 @@
 
             mat-table {
                 margin: 0;
+                max-width: unset; /* Required */
 
                 /* Snapped header row */
                 mat-header-row.snapped {


### PR DESCRIPTION
- The css solutions for local and dev environments behave differently to prod hence the appearance of the 3 columns on reduced screen size (in prod only).
- I have applied a css fix to align prod with the other environments.
- Additional width applied to the files table due to number of columns... however, given we have #600 [Allow horizontal scroll for tables in desktop large and extra large] in the pipeline, I have applied minimal adjustments.