### PR TITLE
feat: view project sample type (#786)

### DIFF
--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/dataSummaryMapper/constants.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/dataSummaryMapper/constants.ts
@@ -1,9 +1,12 @@
+import { HCA_DCP_CATEGORY_LABEL } from "../../../../../../site-config/hca-dcp/category";
+
 /**
  * Possible set of data summaries.
  */
 export const enum DATA_SUMMARY {
   GENUS_SPECIES = "GENUS_SPECIES",
   PROJECT_SHORTNAME = "PROJECT_SHORTNAME",
+  SAMPLE_ENTITY_TYPE = "SAMPLE_ENTITY_TYPE",
 }
 
 /**
@@ -12,4 +15,5 @@ export const enum DATA_SUMMARY {
 export const DATA_SUMMARY_DISPLAY_TEXT = {
   [DATA_SUMMARY.GENUS_SPECIES]: "Species",
   [DATA_SUMMARY.PROJECT_SHORTNAME]: "Project Label",
+  [DATA_SUMMARY.SAMPLE_ENTITY_TYPE]: HCA_DCP_CATEGORY_LABEL.SAMPLE_ENTITY_TYPE,
 };

--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/dataSummaryMapper/dataSummaryMapper.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/dataSummaryMapper/dataSummaryMapper.ts
@@ -33,6 +33,6 @@ export function mapProjectDataSummary(
   details.set(
     DATA_SUMMARY.SAMPLE_ENTITY_TYPE,
     stringifyValues(sampleEntityType)
-  );
+  ); // Sample Type
   return details;
 }

--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/dataSummaryMapper/dataSummaryMapper.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/dataSummaryMapper/dataSummaryMapper.ts
@@ -24,7 +24,15 @@ export function mapProjectDataSummary(
     projectsResponse.projects,
     "projectShortname"
   );
+  const sampleEntityType = processAggregatedOrArrayValue(
+    projectsResponse.samples,
+    HCA_DCP_CATEGORY_KEY.SAMPLE_ENTITY_TYPE
+  );
   details.set(DATA_SUMMARY.PROJECT_SHORTNAME, projectShortname);
   details.set(DATA_SUMMARY.GENUS_SPECIES, stringifyValues(genusSpecies));
+  details.set(
+    DATA_SUMMARY.SAMPLE_ENTITY_TYPE,
+    stringifyValues(sampleEntityType)
+  );
   return details;
 }


### PR DESCRIPTION
### Ticket
Closes clevercanary/data-browser#786.

### Reviewers
@NoopDog 

### Changes
- Added sample type to project detail page.

### Definition of Done (from ticket)
- Sample Type (`sampleEntityType`) is added to the project detail page.

<img width="364" alt="image" src="https://user-images.githubusercontent.com/18710366/235892293-ba0a7af6-db1e-47a9-b21f-db5519a6d400.png">
