### PR TITLE
feat: add tsv download for study and platform pages (#849)

### DIFF
--- a/explorer/site-config/ncpi-catalog/dev/index/platformsEntityConfig.ts
+++ b/explorer/site-config/ncpi-catalog/dev/index/platformsEntityConfig.ts
@@ -110,6 +110,7 @@ export const platformsEntityConfig: EntityConfig<NCPICatalogPlatform> = {
   } as ListConfig<NCPICatalogPlatform>,
   listView: {
     disablePagination: true,
+    enableDownload: true,
   },
   route: "platforms",
   staticEntityImportMapper: NCPIPlatformInputMapper,

--- a/explorer/site-config/ncpi-catalog/dev/index/studiesEntityConfig.ts
+++ b/explorer/site-config/ncpi-catalog/dev/index/studiesEntityConfig.ts
@@ -120,6 +120,7 @@ export const studiesEntityConfig: EntityConfig<NCPICatalogStudy> = {
   } as ListConfig<NCPICatalogStudy>,
   listView: {
     disablePagination: true,
+    enableDownload: true,
   },
   route: "studies",
   staticEntityImportMapper: NCPIStudyInputMapper,


### PR DESCRIPTION
### Ticket
Closes clevercanary/data-browser#849

### Reviewers
@NoopDog

### Changes
- TSV download is configured for study and platform entity lists.

### Definition of Done (from ticket)
- TSV download is configured for study and platform entity lists.