### PR TITLE
feat: add consent code descriptions to anvil catalog (#708)

### DIFF
--- a/explorer/app/apis/catalog/anvil-catalog/common/entities.ts
+++ b/explorer/app/apis/catalog/anvil-catalog/common/entities.ts
@@ -8,6 +8,7 @@ export type AnVILCatalogEntity =
 export interface AnVILCatalogConsortium {
   bucketSize: number;
   consentCode: string[];
+  consentLongName: Record<string, string>;
   consortium: string;
   consortiumOverview: MDXRemoteSerializeResult | null;
   dataType: string[];
@@ -25,6 +26,7 @@ export interface AnVILCatalogConsortium {
 export interface AnVILCatalogStudy {
   bucketSize: number;
   consentCode: string[];
+  consentLongName: Record<string, string>;
   consortium: string;
   dataType: string[];
   dbGapId: string;
@@ -48,6 +50,7 @@ export type AnVILCatalogStudyAny =
 export interface AnVILCatalogWorkspace {
   bucketSize: number;
   consentCode: string;
+  consentLongName: Record<string, string>;
   consortium: string;
   dataType: string[];
   dbGapId: string;

--- a/explorer/app/apis/catalog/ncpi-catalog-dug/common/utils.ts
+++ b/explorer/app/apis/catalog/ncpi-catalog-dug/common/utils.ts
@@ -26,7 +26,7 @@ export function DugStudyInputMapper(dugStudy: DugStudy): DugCatalogStudy {
 function sanitizeStudy(dugStudy: DugStudy): DugCatalogStudy {
   return {
     consentCode: sanitizeStringArray(dugStudy.consentCodes),
-    consentLongName: sanitizeStringArray(dugStudy.consentLongNames),
+    consentLongName: dugStudy.consentLongNames,
     dataType: sanitizeStringArray(dugStudy.dataTypes),
     dbGapId: dugStudy.dbGapId,
     focus: sanitizeString(dugStudy.focus),

--- a/explorer/app/apis/catalog/ncpi-catalog/common/entities.ts
+++ b/explorer/app/apis/catalog/ncpi-catalog/common/entities.ts
@@ -6,7 +6,7 @@ export interface PlatformStudy {
 }
 
 export interface NCPIStudy extends DbGapStudy {
-  consentLongNames: string[];
+  consentLongNames: Record<string, string>;
   platforms: string[];
 }
 
@@ -16,7 +16,7 @@ export type NCPICatalogEntity = NCPICatalogPlatform | NCPICatalogStudy;
 
 export interface NCPICatalogPlatform {
   consentCode: string[];
-  consentLongName: string[];
+  consentLongName: Record<string, string>;
   dataType: string[];
   dbGapId: string[];
   focus: string[];
@@ -29,7 +29,7 @@ export interface NCPICatalogPlatform {
 
 export interface NCPICatalogStudy {
   consentCode: string[];
-  consentLongName: string[];
+  consentLongName: Record<string, string>;
   dataType: string[];
   dbGapId: string;
   focus: string;

--- a/explorer/app/apis/catalog/ncpi-catalog/common/utils.ts
+++ b/explorer/app/apis/catalog/ncpi-catalog/common/utils.ts
@@ -7,7 +7,7 @@ import { NCPICatalogPlatform, NCPICatalogStudy, NCPIStudy } from "./entities";
 export function NCPIStudyInputMapper(ncpiStudy: NCPIStudy): NCPICatalogStudy {
   const ncpiCatalogStudy: NCPICatalogStudy = {
     consentCode: sanitizeStringArray(ncpiStudy.consentCodes),
-    consentLongName: sanitizeStringArray(ncpiStudy.consentLongNames),
+    consentLongName: ncpiStudy.consentLongNames,
     dataType: sanitizeStringArray(ncpiStudy.dataTypes),
     dbGapId: ncpiStudy.dbGapId,
     focus: sanitizeString(ncpiStudy.focus),
@@ -26,7 +26,7 @@ export function NCPIPlatformInputMapper(
 ): NCPICatalogPlatform {
   const ncpiCatalogPlatform: NCPICatalogPlatform = {
     consentCode: sanitizeStringArray(ncpiPlatform.consentCode),
-    consentLongName: sanitizeStringArray(ncpiPlatform.consentLongName),
+    consentLongName: ncpiPlatform.consentLongName,
     dataType: sanitizeStringArray(ncpiPlatform.dataType),
     dbGapId: sanitizeStringArray(ncpiPlatform.dbGapId),
     focus: sanitizeStringArray(ncpiPlatform.focus),

--- a/explorer/app/components/Detail/components/ConsentCodeList/consentCodeList.tsx
+++ b/explorer/app/components/Detail/components/ConsentCodeList/consentCodeList.tsx
@@ -1,0 +1,26 @@
+import { ConsentTooltip } from "../ConsentTooltip/consentTooltip";
+
+interface ConsentCodeListProps {
+  consentCode: string[];
+  consentLongName: Record<string, string>;
+  separator?: string;
+}
+
+export const ConsentCodeList = ({
+  consentCode,
+  consentLongName,
+  separator = ", ",
+}: ConsentCodeListProps): JSX.Element => {
+  return (
+    <>
+      {consentCode.map((code, i) => [
+        i ? separator : "",
+        <ConsentTooltip
+          consentCode={code}
+          consentLongName={consentLongName[code]}
+          key={code}
+        />,
+      ])}
+    </>
+  );
+};

--- a/explorer/app/components/Detail/components/ConsentTooltip/consentTooltip.tsx
+++ b/explorer/app/components/Detail/components/ConsentTooltip/consentTooltip.tsx
@@ -2,14 +2,15 @@ import { Tooltip } from "@mui/material";
 
 interface ConsentTooltipProps {
   consentCode: string;
-  consentLongName: string;
+  consentLongName?: string;
 }
 
 export const ConsentTooltip = ({
   consentCode,
   consentLongName,
 }: ConsentTooltipProps): JSX.Element => {
-  if (/^unspecified$|^error/i.test(consentLongName)) consentLongName = "";
+  if (!consentLongName || /^unspecified$|^error/i.test(consentLongName))
+    consentLongName = "";
   return (
     <Tooltip arrow={true} placement="top" title={consentLongName}>
       <span>{consentCode}</span>

--- a/explorer/app/components/Index/components/ConsentCodesCell/consentCodesCell.tsx
+++ b/explorer/app/components/Index/components/ConsentCodesCell/consentCodesCell.tsx
@@ -2,7 +2,7 @@ import { ConsentTooltip, NTagCell } from "app/components";
 
 interface ConsentCodesCellProps {
   consentCode: string[];
-  consentLongName: string[];
+  consentLongName: Record<string, string>;
   label: string;
 }
 
@@ -14,7 +14,7 @@ export const ConsentCodesCell = ({
   return consentCode.length === 1 ? (
     <ConsentTooltip
       consentCode={consentCode[0]}
-      consentLongName={consentLongName[0]}
+      consentLongName={consentLongName[consentCode[0]]}
     />
   ) : (
     <NTagCell label={label} values={consentCode} />

--- a/explorer/app/components/index.tsx
+++ b/explorer/app/components/index.tsx
@@ -41,6 +41,7 @@ export { Publications } from "@clevercanary/data-explorer-ui/lib/components/Proj
 export { SupplementaryLinks } from "@clevercanary/data-explorer-ui/lib/components/Project/components/SupplementaryLinks/supplementaryLinks";
 export { TitledText } from "@clevercanary/data-explorer-ui/lib/components/Project/components/TitledText/titledText";
 export { MdxMarkdown } from "./common/MDXMarkdown/mdxMarkdown";
+export { ConsentCodeList } from "./Detail/components/ConsentCodeList/consentCodeList";
 export { ConsentTooltip } from "./Detail/components/ConsentTooltip/consentTooltip";
 export { ConsortiumOverview } from "./Detail/components/Consortium/ConsortiumOverview/consortiumOverview";
 export { FileLocationArchivePreview } from "./Detail/components/GeneratedMatricesTables/components/FileLocationArchivePreview/fileLocationArchivePreview";

--- a/explorer/app/viewModelBuilders/catalog/anvil-catalog/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/catalog/anvil-catalog/common/viewModelBuilders.ts
@@ -45,9 +45,11 @@ export const buildBucketSize = (
  */
 export const buildConsentCode = (
   anvilCatalogWorkspace: AnVILCatalogWorkspace
-): React.ComponentProps<typeof C.Cell> => {
+): React.ComponentProps<typeof C.ConsentCodesCell> => {
   return {
-    value: anvilCatalogWorkspace.consentCode,
+    consentCode: [anvilCatalogWorkspace.consentCode],
+    consentLongName: anvilCatalogWorkspace.consentLongName,
+    label: getPluralizedMetadataLabel(METADATA_KEY.CONSENT_CODE),
   };
 };
 
@@ -58,10 +60,11 @@ export const buildConsentCode = (
  */
 export const buildConsentCodes = (
   anvilCatalogEntity: Exclude<AnVILCatalogEntity, AnVILCatalogWorkspace>
-): React.ComponentProps<typeof C.NTagCell> => {
+): React.ComponentProps<typeof C.ConsentCodesCell> => {
   return {
+    consentCode: anvilCatalogEntity.consentCode,
+    consentLongName: anvilCatalogEntity.consentLongName,
     label: getPluralizedMetadataLabel(METADATA_KEY.CONSENT_CODE),
-    values: anvilCatalogEntity.consentCode,
   };
 };
 
@@ -137,10 +140,19 @@ export const buildConsortiumOverview = (
 export const buildConsortiumSummary = (
   anVILCatalogConsortium: AnVILCatalogConsortium
 ): React.ComponentProps<typeof C.Details> => {
-  const { consentCode, dataType, disease, participantCount, studyDesign } =
-    anVILCatalogConsortium;
+  const {
+    consentCode,
+    consentLongName,
+    dataType,
+    disease,
+    participantCount,
+    studyDesign,
+  } = anVILCatalogConsortium;
   const keyValuePairs = new Map<Key, Value>();
-  keyValuePairs.set("Consent Codes", stringifyValues(consentCode));
+  keyValuePairs.set(
+    "Consent Codes",
+    C.ConsentCodeList({ consentCode, consentLongName })
+  );
   keyValuePairs.set("Diseases", stringifyValues(disease));
   keyValuePairs.set("Study Design", stringifyValues(studyDesign));
   keyValuePairs.set("Data Types", stringifyValues(dataType));
@@ -386,10 +398,19 @@ export const buildStudyName = (
 export const buildStudySummary = (
   anVILCatalogStudy: AnVILCatalogStudy
 ): React.ComponentProps<typeof C.Details> => {
-  const { consentCode, dataType, disease, participantCount, studyDesign } =
-    anVILCatalogStudy;
+  const {
+    consentCode,
+    consentLongName,
+    dataType,
+    disease,
+    participantCount,
+    studyDesign,
+  } = anVILCatalogStudy;
   const keyValuePairs = new Map<Key, Value>();
-  keyValuePairs.set("Consent Codes", stringifyValues(consentCode));
+  keyValuePairs.set(
+    "Consent Codes",
+    C.ConsentCodeList({ consentCode, consentLongName })
+  );
   keyValuePairs.set("Diseases", stringifyValues(disease));
   keyValuePairs.set("Study Design", stringifyValues(studyDesign));
   keyValuePairs.set("Data Types", stringifyValues(dataType));

--- a/explorer/app/viewModelBuilders/catalog/ncpi-catalog/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/catalog/ncpi-catalog/common/viewModelBuilders.ts
@@ -251,13 +251,7 @@ export const buildStudySummary = (
   const keyValuePairs = new Map<Key, Value>();
   keyValuePairs.set(
     "Consent Codes",
-    consentCode.map((code, i) => [
-      i ? ", " : "",
-      C.ConsentTooltip({
-        consentCode: code,
-        consentLongName: consentLongName[i],
-      }),
-    ])
+    C.ConsentCodeList({ consentCode, consentLongName })
   );
   keyValuePairs.set("Focus / Diseases", focus);
   keyValuePairs.set("Study Design", stringifyValues(studyDesign));

--- a/explorer/files/anvil-catalog/build-consortia.ts
+++ b/explorer/files/anvil-catalog/build-consortia.ts
@@ -69,6 +69,11 @@ function buildAnVILCatalogConsortium(
     anvilCatalogConsortium.consentCode, // consentCodes - a list of consent codes.
     workspace.consentCode
   );
+  const consentLongNames = Object.assign(
+    {},
+    anvilCatalogConsortium.consentLongName,
+    workspace.consentLongName
+  );
   const consortium = workspace.consortium;
   const dataTypes = accumulateValues(
     anvilCatalogConsortium.dataType,
@@ -114,6 +119,7 @@ function buildAnVILCatalogConsortium(
   return {
     bucketSize,
     consentCode: consentCodes,
+    consentLongName: consentLongNames,
     consortium,
     consortiumOverview,
     dataType: dataTypes,

--- a/explorer/files/anvil-catalog/build-studies.ts
+++ b/explorer/files/anvil-catalog/build-studies.ts
@@ -47,6 +47,11 @@ export function buildAnVILCatalogStudy(
     study.consentCode, // consentCodes - a list of consent codes.
     workspace.consentCode
   );
+  const consentLongNames = Object.assign(
+    {},
+    study.consentLongName,
+    workspace.consentLongName
+  );
   const consortium = workspace.consortium;
   const dataTypes = accumulateValues(study.dataType, workspace.dataType);
   const dbGapId = workspace.dbGapId;
@@ -74,6 +79,7 @@ export function buildAnVILCatalogStudy(
   return {
     bucketSize,
     consentCode: consentCodes,
+    consentLongName: consentLongNames,
     consortium,
     dataType: dataTypes,
     dbGapId,

--- a/explorer/files/ncpi-catalog/build-plaftorms.ts
+++ b/explorer/files/ncpi-catalog/build-plaftorms.ts
@@ -50,7 +50,8 @@ function buildNCPICatalogPlatform(
     ncpiCatalogPlatform.consentCode,
     ncpiStudy.consentCodes
   );
-  const consentLongName = accumulateValues(
+  const consentLongName = Object.assign(
+    {},
     ncpiCatalogPlatform.consentLongName,
     ncpiStudy.consentLongNames
   );

--- a/explorer/files/ncpi-catalog/build-platform-studies.ts
+++ b/explorer/files/ncpi-catalog/build-platform-studies.ts
@@ -35,12 +35,12 @@ export async function buildNCPIPlatformStudies(
       continue;
     }
 
-    const consentLongNames = [];
+    const consentLongNames: Record<string, string> = {};
 
     for (const code of study.consentCodes) {
-      consentLongNames.push(
-        (await generateConsentDescriptions(code)).consentLongName
-      );
+      consentLongNames[code] = (
+        await generateConsentDescriptions(code)
+      ).consentLongName;
     }
 
     const ncpiStudy = {

--- a/explorer/site-config/anvil-catalog/dev/index/consortiaEntityConfig.ts
+++ b/explorer/site-config/anvil-catalog/dev/index/consortiaEntityConfig.ts
@@ -72,9 +72,9 @@ export const consortiaEntityConfig: EntityConfig<AnVILCatalogConsortium> = {
       },
       {
         componentConfig: {
-          component: Components.NTagCell,
+          component: Components.ConsentCodesCell,
           viewBuilder: ViewBuilder.buildConsentCodes,
-        } as ComponentConfig<typeof Components.NTagCell>,
+        } as ComponentConfig<typeof Components.ConsentCodesCell>,
         header: "Consent Codes", // TODO revisit header
         id: ANVIL_CATALOG_CATEGORY_KEY.CONSENT_CODE,
         width: { max: "1fr", min: "120px" },

--- a/explorer/site-config/anvil-catalog/dev/index/studiesEntityConfig.ts
+++ b/explorer/site-config/anvil-catalog/dev/index/studiesEntityConfig.ts
@@ -75,9 +75,9 @@ export const studiesEntityConfig: EntityConfig<AnVILCatalogStudy> = {
       },
       {
         componentConfig: {
-          component: Components.NTagCell,
+          component: Components.ConsentCodesCell,
           viewBuilder: ViewBuilder.buildConsentCodes,
-        } as ComponentConfig<typeof Components.NTagCell>,
+        } as ComponentConfig<typeof Components.ConsentCodesCell>,
         header: "Consent Codes", // TODO revisit header
         id: ANVIL_CATALOG_CATEGORY_KEY.CONSENT_CODE,
         width: { max: "1fr", min: "120px" },

--- a/explorer/site-config/anvil-catalog/dev/index/workspaceEntityConfig.ts
+++ b/explorer/site-config/anvil-catalog/dev/index/workspaceEntityConfig.ts
@@ -68,9 +68,9 @@ export const workspaceEntityConfig: EntityConfig<AnVILCatalogWorkspace> = {
       },
       {
         componentConfig: {
-          component: Components.Cell,
+          component: Components.ConsentCodesCell,
           viewBuilder: ViewBuilder.buildConsentCode,
-        } as ComponentConfig<typeof Components.Cell>,
+        } as ComponentConfig<typeof Components.ConsentCodesCell>,
         header: ANVIL_CATALOG_CATEGORY_LABEL.CONSENT_CODE,
         id: ANVIL_CATALOG_CATEGORY_KEY.CONSENT_CODE,
         width: { max: "1.6fr", min: "160px" },


### PR DESCRIPTION
Closes clevercanary/data-browser#708
(Also updates consent description implementation in NCPI catalog)