### PR TITLE
chore: upgrade findable to 0.21.0 (#3419)

### DIFF
--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "0.1.0",
       "dependencies": {
-        "@clevercanary/data-explorer-ui": "0.20.1",
+        "@clevercanary/data-explorer-ui": "0.21.0",
         "@emotion/react": "11.10.4",
         "@emotion/styled": "11.10.4",
         "@mdx-js/loader": "^2.3.0",
@@ -2122,9 +2122,9 @@
       "dev": true
     },
     "node_modules/@clevercanary/data-explorer-ui": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.20.1.tgz",
-      "integrity": "sha512-HC3blaB9TzqW+J92N1QgBa3HKEMZAQDEU5yOBkTC/+0SKRsjDeOxB3yv6awkXF0LWI94geK9slFOQKp/BPVefg==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.21.0.tgz",
+      "integrity": "sha512-POJvIKveyu5suR/mGI5qjkk78OMMN6Wy3/rK6v23n0Yhl0tbt9AZVww/fpvX+g11KC7Frp2fT7qSf3pUl4orFw==",
       "peerDependencies": {
         "@emotion/react": "11.10.4",
         "@emotion/styled": "11.10.4",
@@ -31584,9 +31584,9 @@
       "dev": true
     },
     "@clevercanary/data-explorer-ui": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.20.1.tgz",
-      "integrity": "sha512-HC3blaB9TzqW+J92N1QgBa3HKEMZAQDEU5yOBkTC/+0SKRsjDeOxB3yv6awkXF0LWI94geK9slFOQKp/BPVefg==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.21.0.tgz",
+      "integrity": "sha512-POJvIKveyu5suR/mGI5qjkk78OMMN6Wy3/rK6v23n0Yhl0tbt9AZVww/fpvX+g11KC7Frp2fT7qSf3pUl4orFw==",
       "requires": {}
     },
     "@colors/colors": {

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -32,7 +32,7 @@
     "test:anvil-catalog": "playwright test -c playwright_anvil-catalog.config.ts"
   },
   "dependencies": {
-    "@clevercanary/data-explorer-ui": "0.20.1",
+    "@clevercanary/data-explorer-ui": "0.21.0",
     "@emotion/react": "11.10.4",
     "@emotion/styled": "11.10.4",
     "@mdx-js/loader": "^2.3.0",


### PR DESCRIPTION
### Ticket
Closes https://github.com/DataBiosphere/data-browser/issues/3419

### Reviewers
@NoopDog 

### Changes
- Upgrade findable to `0.21.0`.
