### PR TITLE
feat: add Consortia link to header (#3379)

### DIFF
--- a/explorer/site-config/anvil-catalog/dev/config.ts
+++ b/explorer/site-config/anvil-catalog/dev/config.ts
@@ -16,7 +16,9 @@ import { consortiaEntityConfig } from "./index/consortiaEntityConfig";
 import { studiesEntityConfig } from "./index/studiesEntityConfig";
 import { workspaceEntityConfig } from "./index/workspaceEntityConfig";
 
+// Template constants
 const BROWSER_URL = process.env.NEXT_PUBLIC_SITEMAP_DOMAIN || "";
+const PORTAL_URL = "https://anvilproject.dev.clevercanary.com";
 const SLOGAN = "NHGRI Analysis Visualization and Informatics Lab-space";
 const LOGO: LogoProps = {
   alt: SLOGAN,
@@ -129,6 +131,10 @@ const config: SiteConfig = {
         {
           label: "Datasets",
           url: `/`,
+        },
+        {
+          label: "Consortia",
+          url: `${PORTAL_URL}/consortia`,
         },
         {
           label: "News",

--- a/explorer/site-config/anvil-cmg/dev/config.ts
+++ b/explorer/site-config/anvil-cmg/dev/config.ts
@@ -19,6 +19,7 @@ import { summary } from "./index/summary";
 
 // Template constants
 const BROWSER_URL = "https://anvil.gi.ucsc.edu";
+const PORTAL_URL = "https://anvilproject.dev.clevercanary.com";
 const SLOGAN = "NHGRI Analysis Visualization and Informatics Lab-space";
 export const URL_DATASETS = "/datasets";
 const LOGO: LogoProps = {
@@ -164,6 +165,10 @@ const config: SiteConfig = {
           url: URL_DATASETS,
         },
         {
+          label: "Consortia",
+          url: `${PORTAL_URL}/consortia`,
+        },
+        {
           label: "News",
           url: `${BROWSER_URL}/news`,
         },
@@ -172,16 +177,22 @@ const config: SiteConfig = {
           url: `${BROWSER_URL}/events`,
         },
         {
-          label: "Team",
-          url: `${BROWSER_URL}/team`,
-        },
-        {
-          label: "FAQ",
-          url: `${BROWSER_URL}/faq`,
-        },
-        {
-          label: "Help",
-          url: `${BROWSER_URL}/help`,
+          label: "More",
+          menuItems: [
+            {
+              label: "Team",
+              url: `${BROWSER_URL}/team`,
+            },
+            {
+              label: "FAQ",
+              url: `${BROWSER_URL}/faq`,
+            },
+            {
+              label: "Help",
+              url: `${BROWSER_URL}/help`,
+            },
+          ],
+          url: "",
         },
       ],
       searchEnabled: true,


### PR DESCRIPTION
### Ticket
Closes #3379.

### Reviewers
@NoopDog

### Changes
- Added consortia link to AnVIL CMG and AnVIL Catalog header `dev` configuration only.
- Modified AnVIL CMG header to nest menu items under the "More" button.

### Definition of Done (from ticket)
- Consortia added to header for AnVIL CMG / Catalog.
