### PR TITLE
chore: update data-explorer-ui to v0.27.0 (#871)

### DIFF
--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "0.1.0",
       "dependencies": {
-        "@clevercanary/data-explorer-ui": "0.25.0",
+        "@clevercanary/data-explorer-ui": "0.27.1",
         "@emotion/react": "11.10.4",
         "@emotion/styled": "11.10.4",
         "@mdx-js/loader": "^2.3.0",
@@ -2122,9 +2122,9 @@
       "dev": true
     },
     "node_modules/@clevercanary/data-explorer-ui": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.25.0.tgz",
-      "integrity": "sha512-sSzQwLAMalFkkQW2VDfFzDVu/uju71VU3IDnfgYsGpRqBH13WISsbNTz/71HiQGtlVepMNnQcnsh4g3bxtDlfw==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.27.1.tgz",
+      "integrity": "sha512-Ry3Sj0fOsathjfgakHUZHfi4lurRCteLAycI281AXb5+1O7o6Ixc16/9nAy71GiMeVdkJpe+4EtfHAs9hT///g==",
       "peerDependencies": {
         "@emotion/react": "11.10.4",
         "@emotion/styled": "11.10.4",
@@ -31595,9 +31595,9 @@
       "dev": true
     },
     "@clevercanary/data-explorer-ui": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.25.0.tgz",
-      "integrity": "sha512-sSzQwLAMalFkkQW2VDfFzDVu/uju71VU3IDnfgYsGpRqBH13WISsbNTz/71HiQGtlVepMNnQcnsh4g3bxtDlfw==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.27.1.tgz",
+      "integrity": "sha512-Ry3Sj0fOsathjfgakHUZHfi4lurRCteLAycI281AXb5+1O7o6Ixc16/9nAy71GiMeVdkJpe+4EtfHAs9hT///g==",
       "requires": {}
     },
     "@colors/colors": {

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -32,7 +32,7 @@
     "test:anvil-catalog": "playwright test -c playwright_anvil-catalog.config.ts"
   },
   "dependencies": {
-    "@clevercanary/data-explorer-ui": "0.25.0",
+    "@clevercanary/data-explorer-ui": "0.27.1",
     "@emotion/react": "11.10.4",
     "@emotion/styled": "11.10.4",
     "@mdx-js/loader": "^2.3.0",


### PR DESCRIPTION
### Ticket
Closes clevercanary/data-browser#871.

### Reviewers
@NoopDog.

### Changes
- Package `data-explorer-ui` updated to `v.0.27.1`.
