### PR TITLE
feat: fix mapping of specimen disease on export summary (#3542)

### DIFF
--- a/spa/src/app/files/get-data/get-data-summary/get-data-summary.component.spec.ts
+++ b/spa/src/app/files/get-data/get-data-summary/get-data-summary.component.spec.ts
@@ -29,7 +29,7 @@ describe("GetDataSummaryComponent", () => {
     // Search terms with file format selected
     const SEARCH_TERMS = [
         new SearchFacetTerm("fileFormat", "fastq", 123),
-        new SearchFacetTerm("disease", "ESRD", 8),
+        new SearchFacetTerm("specimenDisease", "ESRD", 8),
         new SearchFacetTerm("genusSpecies", "Homo sapiens", 20),
     ];
 

--- a/spa/src/app/files/get-data/get-data-summary/get-data-summary.component.ts
+++ b/spa/src/app/files/get-data/get-data-summary/get-data-summary.component.ts
@@ -34,7 +34,10 @@ export class GetDataSummaryComponent {
      * @returns {Term[]}
      */
     public listSelectedDiseases(fileFacets: FileFacet[]): Term[] {
-        return this.listSelectedTermsOfFacet(fileFacets, FileFacetName.DISEASE);
+        return this.listSelectedTermsOfFacet(
+            fileFacets,
+            FileFacetName.SPECIMEN_DISEASE
+        );
     }
 
     /**


### PR DESCRIPTION
### Ticket
Closes #3542.

### Reviewers
@NoopDog

### Changes
- Modified mapping of disease on export summary.

### Definition of Done (from ticket)
- Disease on export summary is mapped to "specimenDisease".
