### PR TITLE
feat: preventing usage of inline images #879

### DIFF
--- a/explorer/next.config.mjs
+++ b/explorer/next.config.mjs
@@ -8,9 +8,10 @@ export default withPlugins(
     [
       withOptimizedImages,
       {
-        optimizeImagesInDev: true,
         handleImages: ["jpeg", "png", "svg"],
         imagesFolder: "images",
+        inlineImageLimit: -1,
+        optimizeImagesInDev: true,
       },
     ],
     withMDX,


### PR DESCRIPTION
### Ticket
Closes https://github.com/clevercanary/data-browser/issues/879

### Reviewers
@.

### Changes
- Added config to prevent inline images using `data:`

### Definition of Done (from ticket)

### QA steps (optional)

### Known Issues
