### PR TITLE
feat: download search results via curl (#3238)

### DIFF
--- a/explorer/app/components/index.tsx
+++ b/explorer/app/components/index.tsx
@@ -34,6 +34,8 @@ export { ExportSummary } from "@clevercanary/data-explorer-ui/lib/components/Exp
 export { ExportToTerraForm } from "@clevercanary/data-explorer-ui/lib/components/Export/components/ExportToTerra/components/ExportToTerraForm/exportToTerraForm";
 export { TerraSetUpForm } from "@clevercanary/data-explorer-ui/lib/components/Export/components/ExportToTerra/components/TerraSetUpForm/terraSetUpForm";
 export { ExportToTerra } from "@clevercanary/data-explorer-ui/lib/components/Export/components/ExportToTerra/exportToTerra";
+export { ManifestDownloadForm } from "@clevercanary/data-explorer-ui/lib/components/Export/components/ManifestDownload/components/ManifestDownloadForm/manifestDownloadForm";
+export { ManifestDownload } from "@clevercanary/data-explorer-ui/lib/components/Export/components/ManifestDownload/manifestDownload";
 export { AzulFileDownload } from "@clevercanary/data-explorer-ui/lib/components/Index/components/AzulFileDownload/azulFileDownload";
 export { Cell } from "@clevercanary/data-explorer-ui/lib/components/Index/components/Cell/cell";
 export { Summaries } from "@clevercanary/data-explorer-ui/lib/components/Index/components/Hero/components/Summaries/summaries";

--- a/explorer/app/content/hca-dcp/index.tsx
+++ b/explorer/app/content/hca-dcp/index.tsx
@@ -13,4 +13,6 @@ export { default as DownloadCurlCommandStart } from "./downloadCurlCommandStart.
 export { default as DownloadCurlCommandSuccess } from "./downloadCurlCommandSuccess.mdx";
 export { default as ExportToTerraStart } from "./exportToTerraStart.mdx";
 export { default as ExportToTerraSuccessWithWarning } from "./exportToTerraSuccessWithWarning.mdx";
+export { default as ManifestDownloadStart } from "./manifestDownloadStart.mdx";
+export { default as ManifestDownloadSuccess } from "./manifestDownloadSuccess.mdx";
 export { default as MatrixQuestionnaire } from "./matrixQuestionnaire.mdx";

--- a/explorer/app/content/hca-dcp/manifestDownloadStart.mdx
+++ b/explorer/app/content/hca-dcp/manifestDownloadStart.mdx
@@ -1,0 +1,3 @@
+### Confirm Species Selection and Select Manifest File Types
+
+Please explicitly select at least one species and file type for inclusion in the manifest.

--- a/explorer/app/content/hca-dcp/manifestDownloadSuccess.mdx
+++ b/explorer/app/content/hca-dcp/manifestDownloadSuccess.mdx
@@ -1,0 +1,12 @@
+import { BatchCorrectionWarning } from "../../components/Export/components/BatchCorrectionWarning/batchCorrectionWarning";
+
+### Your File Manifest is Ready
+
+<BatchCorrectionWarning
+  label={"Matrix Normalization and Batch Correction"}
+  url={
+    "https://data.humancellatlas.org/guides/consumer-vignettes/matrices#matrix-normalization-and-batch-correction"
+  }
+/>
+
+This link expires in 7 days.

--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
@@ -52,6 +52,7 @@ import { PROJECTS_URL } from "../../../../../site-config/hca-dcp/dev/config";
 import {
   ROUTE_BULK_DOWNLOAD,
   ROUTE_EXPORT_TO_TERRA,
+  ROUTE_MANIFEST_DOWNLOAD,
 } from "../../../../../site-config/hca-dcp/dev/export/constants";
 import {
   processAggregatedOrArrayValue,
@@ -563,6 +564,23 @@ export const buildExportMethodHeroCurlCommand = (
 };
 
 /**
+ * Build props for manifest download Hero component.
+ * @param _ - Unused.
+ * @param viewContext - View context.
+ * @returns model to be used as props for the Hero component.
+ */
+export const buildExportMethodHeroManifestDownload = (
+  _: Unused,
+  viewContext: ViewContext
+): React.ComponentProps<typeof C.BackPageHero> => {
+  const title = "Request File Manifest";
+  const {
+    exploreState: { tabValue },
+  } = viewContext;
+  return getExportMethodHero(tabValue, title);
+};
+
+/**
  * Build props for export to terra Hero component.
  * @param _ - Unused.
  * @param viewContext - View context.
@@ -578,6 +596,21 @@ export const buildExportMethodHeroTerra = (
   } = viewContext;
   return getExportMethodHero(tabValue, title);
 };
+
+/**
+ * Build props for ExportMethod component for display of the manifest download section.
+ * @returns model to be used as props for the ExportMethod component.
+ */
+export const buildExportMethodManifestDownload = (): React.ComponentProps<
+  typeof C.ExportMethod
+> => ({
+  buttonLabel: "Request File Manifest",
+  description:
+    "Request a file manifest for the current query containing the full list of selected files and the metadata for each file.",
+  disabled: false,
+  route: ROUTE_MANIFEST_DOWNLOAD,
+  title: "Download a File Manifest with Metadata for the Selected Data",
+});
 
 /**
  * Build props for ExportMethod component for display of the export to terra section.
@@ -794,6 +827,34 @@ export const buildLibraryConstructionApproach = (
       entityResponse.protocols,
       HCA_DCP_CATEGORY_KEY.LIBRARY_CONSTRUCTION_METHOD
     ),
+  };
+};
+
+/**
+ * Build props for ManifestDownload component.
+ * @param _ - Unused.
+ * @param viewContext - View context.
+ * @returns model to be used as props for the ManifestDownload component.
+ */
+export const buildManifestDownload = (
+  _: Unused,
+  viewContext: ViewContext
+): React.ComponentProps<typeof C.ManifestDownload> => {
+  const {
+    exploreState: { filterState },
+    fileManifestState,
+  } = viewContext;
+  // Get the form facets.
+  const formFacet = getFormFacets(fileManifestState);
+  return {
+    ManifestDownloadForm: C.ManifestDownloadForm,
+    ManifestDownloadStart: MDX.ManifestDownloadStart,
+    ManifestDownloadSuccess: MDX.ManifestDownloadSuccess,
+    fileManifestState,
+    fileManifestType: FILE_MANIFEST_TYPE.DOWNLOAD_MANIFEST,
+    fileSummaryFacetName: HCA_DCP_CATEGORY_KEY.FILE_FORMAT,
+    filters: filterState,
+    formFacet,
   };
 };
 

--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "0.1.0",
       "dependencies": {
-        "@clevercanary/data-explorer-ui": "0.42.0",
+        "@clevercanary/data-explorer-ui": "0.43.0",
         "@emotion/react": "11.11.1",
         "@emotion/styled": "11.11.0",
         "@mdx-js/loader": "^2.3.0",
@@ -2119,9 +2119,9 @@
       "dev": true
     },
     "node_modules/@clevercanary/data-explorer-ui": {
-      "version": "0.42.0",
-      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.42.0.tgz",
-      "integrity": "sha512-gmkE0C4XuyrwIlsFNBmf0d2QmwhfXxEhxFDKRLxcX6K5YqhWUoxnGWD+wcNNRhI43Iq3PQyftxDu9Kb2NBSmoQ==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.43.0.tgz",
+      "integrity": "sha512-Ny4C3HGEDTeyMrW7dQQ7IUvXDSe48lxgHNzrODzwEtrLB+WMK3XdC9q7/yOcZu5yBQLHg+oujNnfoXf/c6Qbrg==",
       "peerDependencies": {
         "@emotion/react": "11.11.1",
         "@emotion/styled": "11.11.0",
@@ -25217,9 +25217,9 @@
       "dev": true
     },
     "@clevercanary/data-explorer-ui": {
-      "version": "0.42.0",
-      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.42.0.tgz",
-      "integrity": "sha512-gmkE0C4XuyrwIlsFNBmf0d2QmwhfXxEhxFDKRLxcX6K5YqhWUoxnGWD+wcNNRhI43Iq3PQyftxDu9Kb2NBSmoQ==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.43.0.tgz",
+      "integrity": "sha512-Ny4C3HGEDTeyMrW7dQQ7IUvXDSe48lxgHNzrODzwEtrLB+WMK3XdC9q7/yOcZu5yBQLHg+oujNnfoXf/c6Qbrg==",
       "requires": {}
     },
     "@colors/colors": {

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -33,7 +33,7 @@
     "test:anvil-catalog": "playwright test -c playwright_anvil-catalog.config.ts"
   },
   "dependencies": {
-    "@clevercanary/data-explorer-ui": "0.42.0",
+    "@clevercanary/data-explorer-ui": "0.43.0",
     "@emotion/react": "11.11.1",
     "@emotion/styled": "11.11.0",
     "@mdx-js/loader": "^2.3.0",

--- a/explorer/pages/export/download-manifest.tsx
+++ b/explorer/pages/export/download-manifest.tsx
@@ -1,0 +1,12 @@
+import { ExportMethodView } from "@clevercanary/data-explorer-ui/lib/views/ExportMethodView/exportMethodView";
+import React from "react";
+
+/**
+ * Export method page.
+ * @returns export method view component.
+ */
+const ExportMethodPage = (): JSX.Element => {
+  return <ExportMethodView />;
+};
+
+export default ExportMethodPage;

--- a/explorer/site-config/hca-dcp/dev/export/constants.ts
+++ b/explorer/site-config/hca-dcp/dev/export/constants.ts
@@ -1,2 +1,3 @@
 export const ROUTE_BULK_DOWNLOAD = "/export/get-curl-command";
 export const ROUTE_EXPORT_TO_TERRA = "/export/export-to-terra";
+export const ROUTE_MANIFEST_DOWNLOAD = "/export/download-manifest";

--- a/explorer/site-config/hca-dcp/dev/export/export.ts
+++ b/explorer/site-config/hca-dcp/dev/export/export.ts
@@ -5,7 +5,11 @@ import {
 import * as C from "app/components";
 import * as MDX from "../../../../app/content/hca-dcp";
 import * as V from "../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
-import { ROUTE_BULK_DOWNLOAD, ROUTE_EXPORT_TO_TERRA } from "./constants";
+import {
+  ROUTE_BULK_DOWNLOAD,
+  ROUTE_EXPORT_TO_TERRA,
+  ROUTE_MANIFEST_DOWNLOAD,
+} from "./constants";
 
 export const exportConfig: ExportConfig = {
   exportMethods: [
@@ -21,6 +25,21 @@ export const exportConfig: ExportConfig = {
         {
           component: C.BackPageHero,
           viewBuilder: V.buildExportMethodHeroCurlCommand,
+        } as ComponentConfig<typeof C.BackPageHero>,
+      ],
+    },
+    {
+      mainColumn: [
+        {
+          component: C.ManifestDownload,
+          viewBuilder: V.buildManifestDownload,
+        } as ComponentConfig<typeof C.ManifestDownload>,
+      ],
+      route: ROUTE_MANIFEST_DOWNLOAD,
+      top: [
+        {
+          component: C.BackPageHero,
+          viewBuilder: V.buildExportMethodHeroManifestDownload,
         } as ComponentConfig<typeof C.BackPageHero>,
       ],
     },
@@ -48,6 +67,10 @@ export const exportConfig: ExportConfig = {
         {
           component: C.ExportMethod,
           viewBuilder: V.buildExportMethodBulkDownload,
+        } as ComponentConfig<typeof C.ExportMethod>,
+        {
+          component: C.ExportMethod,
+          viewBuilder: V.buildExportMethodManifestDownload,
         } as ComponentConfig<typeof C.ExportMethod>,
         {
           component: C.ExportMethod,


### PR DESCRIPTION
### Ticket
Closes #3238.

### Reviewers
@NoopDog.

### Changes
- Added download search results via curl.
- Updated `clevercanary/data-explorer-ui` to `v0.43.0`.
