### PR TITLE
feat: add origin filters section to hca-dcp (#3704)

### DIFF
--- a/explorer/site-config/hca-dcp/category.ts
+++ b/explorer/site-config/hca-dcp/category.ts
@@ -45,7 +45,7 @@ export const HCA_DCP_CATEGORY_LABEL = {
   AZUL_FILE_DOWNLOAD: " ",
   BIOLOGICAL_SEX: "Biological Sex",
   CELL_COUNT: "Cell Count Estimate",
-  CONTACT_NAME: "Contact Name",
+  CONTACT_NAME: "Contributor Name",
   CONTENT_DESCRIPTION: "Content Description",
   DEVELOPMENT_STAGE: "Development Stage",
   DONOR_DISEASE: "Donor Disease",

--- a/explorer/site-config/hca-dcp/dev/config.ts
+++ b/explorer/site-config/hca-dcp/dev/config.ts
@@ -42,6 +42,22 @@ const config: SiteConfig = {
     {
       categoryConfigs: [
         {
+          key: HCA_DCP_CATEGORY_KEY.PROJECT_TITLE,
+          label: HCA_DCP_CATEGORY_LABEL.PROJECT_TITLE,
+        },
+        {
+          key: HCA_DCP_CATEGORY_KEY.CONTACT_NAME,
+          label: HCA_DCP_CATEGORY_LABEL.CONTACT_NAME,
+        },
+        {
+          key: HCA_DCP_CATEGORY_KEY.INSTITUTION,
+          label: HCA_DCP_CATEGORY_LABEL.INSTITUTION,
+        },
+      ],
+    },
+    {
+      categoryConfigs: [
+        {
           key: HCA_DCP_CATEGORY_KEY.ANALYSIS_PROTOCOL, // workflow
           label: HCA_DCP_CATEGORY_LABEL.ANALYSIS_PROTOCOL,
         },
@@ -104,10 +120,6 @@ const config: SiteConfig = {
         {
           key: HCA_DCP_CATEGORY_KEY.PRESERVATION_METHOD,
           label: HCA_DCP_CATEGORY_LABEL.PRESERVATION_METHOD,
-        },
-        {
-          key: HCA_DCP_CATEGORY_KEY.PROJECT_TITLE,
-          label: HCA_DCP_CATEGORY_LABEL.PROJECT_TITLE,
         },
         {
           key: HCA_DCP_CATEGORY_KEY.SAMPLE_ENTITY_TYPE,


### PR DESCRIPTION
Question: is `contactName` the correct property to use for contributor name? (I'm not sure what kinds of objects are being used to populate the filters)

Other notes:
- Since the ticket says "Contributor Name", I've updated `HCA_DCP_CATEGORY_LABEL.CONTACT_NAME` to be that instead of "Contact Name"
- Most of the names seem to be comma-separated lists, which I guess is how they are in the Azul response?