### PR TITLE
feat: make header logo link to the AnVIL Explorer datasets page instead of the AnVIL portal (#3724)

### DIFF
--- a/explorer/site-config/anvil-cmg/dev/config.ts
+++ b/explorer/site-config/anvil-cmg/dev/config.ts
@@ -159,7 +159,7 @@ export function makeConfig(
         ],
       },
       header: {
-        Logo: C.ANVILExplorer({ url: browserUrl }),
+        Logo: C.ANVILExplorer({ url: "/datasets" }),
         authenticationEnabled: true,
         navAlignment: ELEMENT_ALIGNMENT.RIGHT,
         navLinks: [


### PR DESCRIPTION
### Ticket
Closes #3724

### Reviewers
@NoopDog.

### Changes
- Changed header logo to link to the datasets page.
