### PR TITLE
feat: selecting explorer logo should take you to /projects instead of the data portal (#3742)

### DIFF
--- a/explorer/site-config/hca-dcp/dev/config.ts
+++ b/explorer/site-config/hca-dcp/dev/config.ts
@@ -185,7 +185,7 @@ const config: SiteConfig = {
       Logo: C.Logo({
         alt: HCA_DATA_COORDINATION_PLATFORM,
         height: 32.5,
-        link: BROWSER_URL,
+        link: "/projects",
         src: hcaExplorer,
       }),
       authenticationEnabled: false,


### PR DESCRIPTION
### Ticket
Closes #3742.

### Reviewers
@NoopDog.

### Changes
- Updated logo link to route to "projects".
