### PR TITLE
fix: fix unwanted rerender from ErrorBoundary component (#3756)

### DIFF
--- a/explorer/pages/_app.tsx
+++ b/explorer/pages/_app.tsx
@@ -19,7 +19,6 @@ import { CssBaseline } from "@mui/material";
 import { ThemeProvider } from "@mui/material/styles";
 import { config } from "app/config/config";
 import type { AppProps } from "next/app";
-import { useRouter } from "next/router";
 import { useEffect } from "react";
 import TagManager from "react-gtm-module";
 
@@ -28,7 +27,6 @@ const SESSION_TIMEOUT = 15 * 60 * 1000; // 15 minutes
 function MyApp({ Component, pageProps }: AppProps): JSX.Element {
   // Set up the site configuration, layout and theme.
   const appConfig = config();
-  const { asPath } = useRouter();
   const { analytics, layout, redirectRootToPath, themeOptions } = appConfig;
   const { gtmAuth, gtmId, gtmPreview } = analytics || {};
   const theme = createAppTheme(themeOptions);
@@ -54,7 +52,6 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
                 <FileManifestStateProvider>
                   <Main>
                     <ErrorBoundary
-                      key={asPath}
                       fallbackRender={(
                         error: DataExplorerError
                       ): JSX.Element => (


### PR DESCRIPTION
### Ticket
Closes #3756.

### Reviewers
@NoopDog.

### Changes
- Removed `key` with value `asPath` from ErrorBoundary component.
