### PR TITLE
feat: passing reset callback to error component #910

### DIFF
--- a/explorer/pages/_app.tsx
+++ b/explorer/pages/_app.tsx
@@ -63,13 +63,18 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
                 <FileManifestStateProvider>
                   <Main>
                     <ErrorBoundary
-                      fallbackRender={(
-                        error: DataExplorerError
-                      ): JSX.Element => (
+                      fallbackRender={({
+                        error,
+                        reset,
+                      }: {
+                        error: DataExplorerError;
+                        reset: () => void;
+                      }): JSX.Element => (
                         <Error
                           errorMessage={error.message}
                           requestUrlMessage={error.requestUrlMessage}
                           rootPath={redirectRootToPath}
+                          onReset={reset}
                         />
                       )}
                     >


### PR DESCRIPTION
### Ticket
Closes https://github.com/DataBiosphere/data-browser/issues/3756

### Reviewers
@.

### Changes
- Passing onReset to `Error` component

### Definition of Done (from ticket)

### QA steps (optional)

### Known Issues
