### PR TITLE
fix: tos link on sign-in form goes to the wrong location (#3779)

### DIFF
--- a/explorer/app/components/common/MDXContent/anvil-cmg/loginTermsOfService.mdx
+++ b/explorer/app/components/common/MDXContent/anvil-cmg/loginTermsOfService.mdx
@@ -1,1 +1,7 @@
-I have read and agree to [privacy notice](https://anvilproject.org/privacy) and [terms of use](https://anvilproject.org/anvil-explorer-tos)
+import { Link } from "@clevercanary/data-explorer-ui/lib/components/Links/components/Link/link";
+
+<span>
+  I have read and agree to{" "}
+  <Link label="privacy notice" url="https://anvilproject.org/privacy" /> and{" "}
+  <Link label="terms of service" url="/terms-of-service" />
+</span>


### PR DESCRIPTION
### Ticket
Closes #3779.

### Reviewers
@NoopDog.

### Changes
- Updated TOS link on the sign on form.
