### PR TITLE
feat: display a string other than "none" when duos has yet to be populated. (#3865)

### DIFF
--- a/explorer/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
@@ -238,11 +238,12 @@ export const buildDatasetDescription = (
   datasetsResponse: DatasetsResponse
 ): React.ComponentProps<typeof C.Markdown> => {
   return {
-    content: processEntityValue(
-      datasetsResponse.datasets,
-      "description",
-      LABEL.NONE
-    ),
+    content:
+      processEntityValue(
+        datasetsResponse.datasets,
+        "description",
+        LABEL.EMPTY
+      ) || "To be provided.",
   };
 };
 


### PR DESCRIPTION
### Ticket
Closes #3865.

### Reviewers
@NoopDog.

### Changes
- Updated AnVIL entity description field to display "To be provided." when description is undefined.
