### PR TITLE
fix: run commitlint in explorer directory (#4004)

### DIFF
--- a/explorer/.husky/commit-msg
+++ b/explorer/.husky/commit-msg
@@ -13,6 +13,8 @@ if ! grep -iqE "$commit_regex" "$1"; then
     exit 1
 fi
 
+cd explorer
+
 # Check for Conventional Commits format
 
-npx commitlint --config ./explorer/commitlint.config.js --edit $1
+npx commitlint --config ./commitlint.config.js --edit $1


### PR DESCRIPTION
The checks for commit messages matching Conventional Commits format should now:
- Not have any missing packages that get installed when a commit is made
- Not throw any errors related to missing code