### PR TITLE
feat: use verbatim.pfb manifest format for exports to terra in anvil (#4015)

### DIFF
--- a/explorer/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
@@ -1,5 +1,6 @@
 import {
   LABEL,
+  ManifestDownloadFormat,
   MANIFEST_DOWNLOAD_FORMAT,
 } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
 import {
@@ -100,6 +101,7 @@ import * as C from "../../../../components";
 import * as MDX from "../../../../components/common/MDXContent/anvil-cmg";
 import { METADATA_KEY } from "../../../../components/Index/common/entities";
 import { getPluralizedMetadataLabel } from "../../../../components/Index/common/indexTransformer";
+import { FEATURE_FLAGS } from "../../../common/contants";
 import { Unused } from "../../../common/entities";
 import { SUMMARY_DISPLAY_TEXT } from "./summaryMapper/constants";
 import { mapExportSummary } from "./summaryMapper/summaryMapper";
@@ -430,8 +432,9 @@ export const buildExportEntityToTerra = (
     fileSummaryFacetName: ANVIL_CMG_CATEGORY_KEY.FILE_FILE_FORMAT,
     filters,
     formFacet,
-    manifestDownloadFormat: MANIFEST_DOWNLOAD_FORMAT.TERRA_PFB,
-    manifestDownloadFormats: [MANIFEST_DOWNLOAD_FORMAT.TERRA_PFB],
+    manifestDownloadFormat: getExportToTerraManifestDownloadFormat(viewContext),
+    manifestDownloadFormats:
+      getExportToTerraManifestDownloadFormats(viewContext),
   };
 };
 
@@ -573,8 +576,9 @@ export const buildExportToTerra = (
     fileSummaryFacetName: ANVIL_CMG_CATEGORY_KEY.FILE_FILE_FORMAT,
     filters: filterState,
     formFacet,
-    manifestDownloadFormat: MANIFEST_DOWNLOAD_FORMAT.TERRA_PFB,
-    manifestDownloadFormats: [MANIFEST_DOWNLOAD_FORMAT.TERRA_PFB],
+    manifestDownloadFormat: getExportToTerraManifestDownloadFormat(viewContext),
+    manifestDownloadFormats:
+      getExportToTerraManifestDownloadFormats(viewContext),
   };
 };
 
@@ -959,6 +963,38 @@ export function getExportSelectedDataSummary(
     SUMMARY_DISPLAY_TEXT[key] || key,
     value,
   ]);
+}
+
+/**
+ * Returns export to terra manifest download format.
+ * @param viewContext - View context.
+ * @returns manifest download format.
+ */
+function getExportToTerraManifestDownloadFormat(
+  viewContext: ViewContext
+): ManifestDownloadFormat | undefined {
+  const { exploreState } = viewContext;
+  const { featureFlagState } = exploreState;
+  if (featureFlagState?.includes(FEATURE_FLAGS.VERBATIM)) {
+    return MANIFEST_DOWNLOAD_FORMAT.VERBATIM_PFB;
+  }
+  return MANIFEST_DOWNLOAD_FORMAT.TERRA_PFB;
+}
+
+/**
+ * Returns export to terra manifest download formats.
+ * @param viewContext - View context.
+ * @returns manifest download formats.
+ */
+function getExportToTerraManifestDownloadFormats(
+  viewContext: ViewContext
+): ManifestDownloadFormat[] {
+  const { exploreState } = viewContext;
+  const { featureFlagState } = exploreState;
+  if (featureFlagState?.includes(FEATURE_FLAGS.VERBATIM)) {
+    return [MANIFEST_DOWNLOAD_FORMAT.VERBATIM_PFB];
+  }
+  return [MANIFEST_DOWNLOAD_FORMAT.TERRA_PFB];
 }
 
 /**

--- a/explorer/app/viewModelBuilders/common/contants.ts
+++ b/explorer/app/viewModelBuilders/common/contants.ts
@@ -5,3 +5,6 @@ export const DATE_TIME_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
   year: "numeric",
 };
 export const DATE_TIME_LOCALES = "en-US";
+export const FEATURE_FLAGS = {
+  VERBATIM: "verbatim",
+};

--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "0.1.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "0.0.0",
+        "@databiosphere/findable-ui": "1.0.0",
         "@emotion/react": "11.11.1",
         "@emotion/styled": "11.11.0",
         "@mdx-js/loader": "^3.0.1",
@@ -2727,9 +2727,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-0.0.0.tgz",
-      "integrity": "sha512-BEz8isJt4VtrA8wzPRqatpB2OYNS86jTFCVsDpBrXtNnAHyus1TTeGobCLTln/s4LDBwP08kIRhccq7V7OMswA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-1.0.0.tgz",
+      "integrity": "sha512-FTyKFwbZii0zQg4wYkU9ECdojVWYc5UmBolLXM1rZt20kkWUds2IrYOFOH7tEGfCkjBF5hbmnawXQGBvDyZpRw==",
       "engines": {
         "node": "20.10.0"
       },
@@ -32389,9 +32389,9 @@
       }
     },
     "@databiosphere/findable-ui": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-0.0.0.tgz",
-      "integrity": "sha512-BEz8isJt4VtrA8wzPRqatpB2OYNS86jTFCVsDpBrXtNnAHyus1TTeGobCLTln/s4LDBwP08kIRhccq7V7OMswA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-1.0.0.tgz",
+      "integrity": "sha512-FTyKFwbZii0zQg4wYkU9ECdojVWYc5UmBolLXM1rZt20kkWUds2IrYOFOH7tEGfCkjBF5hbmnawXQGBvDyZpRw==",
       "requires": {}
     },
     "@digitak/esrun": {

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -36,7 +36,7 @@
     "test:anvil-catalog": "playwright test -c playwright_anvil-catalog.config.ts --trace retain-on-failure"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "0.0.0",
+    "@databiosphere/findable-ui": "1.0.0",
     "@emotion/react": "11.11.1",
     "@emotion/styled": "11.11.0",
     "@mdx-js/loader": "^3.0.1",


### PR DESCRIPTION
### Ticket
Closes #4015.

### Reviewers
@NoopDog 

### Changes
- Added feature flag to request `verbatim.pfb` manifest format.
- Updated `findable-ui` to `v1.0.0`.
