### PR TITLE
feat: on files tab change 'file format' with 'analysis protocol' and reorder (#4019)

### DIFF
--- a/explorer/site-config/hca-dcp/dev/index/filesEntityConfig.ts
+++ b/explorer/site-config/hca-dcp/dev/index/filesEntityConfig.ts
@@ -48,6 +48,7 @@ export const filesEntityConfig: EntityConfig<FilesResponse> = {
         width: { max: "2fr", min: "240px" },
       },
       {
+        columnVisible: false,
         componentConfig: {
           component: C.Cell,
           viewBuilder: V.buildFileFormat,
@@ -63,6 +64,15 @@ export const filesEntityConfig: EntityConfig<FilesResponse> = {
         } as ComponentConfig<typeof C.Cell, FilesResponse>,
         header: HCA_DCP_CATEGORY_LABEL.FILE_SIZE,
         id: HCA_DCP_CATEGORY_KEY.FILE_SIZE,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedProtocolWorkflow,
+        } as ComponentConfig<typeof C.NTagCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.WORKFLOW,
+        id: HCA_DCP_CATEGORY_KEY.WORKFLOW,
         width: { max: "1fr", min: "120px" },
       },
       {
@@ -191,16 +201,6 @@ export const filesEntityConfig: EntityConfig<FilesResponse> = {
         } as ComponentConfig<typeof C.Cell, FilesResponse>,
         header: HCA_DCP_CATEGORY_LABEL.PAIRED_END,
         id: HCA_DCP_CATEGORY_KEY.PAIRED_END,
-        width: { max: "1fr", min: "120px" },
-      },
-      {
-        columnVisible: false,
-        componentConfig: {
-          component: C.NTagCell,
-          viewBuilder: V.buildAggregatedProtocolWorkflow,
-        } as ComponentConfig<typeof C.NTagCell, FilesResponse>,
-        header: HCA_DCP_CATEGORY_LABEL.WORKFLOW,
-        id: HCA_DCP_CATEGORY_KEY.WORKFLOW,
         width: { max: "1fr", min: "120px" },
       },
       {


### PR DESCRIPTION
### Ticket
Closes #4019.

### Reviewers
@NoopDog.

### Changes
On the files tab:
- File format is no longer a default column.
- Analysis Protocol is now a default column.
- Default columns are reordered.

<img width="1125" alt="image" src="https://github.com/DataBiosphere/data-browser/assets/18710366/3046cb1e-edfa-4b76-9c25-873469bae536">

<img width="1125" alt="image" src="https://github.com/DataBiosphere/data-browser/assets/18710366/b6f00aad-bc1c-4820-8dfd-06e38481891d">
