### PR TITLE
feat: first draft of anvil-cmg filter tests (#4068)

### DIFF
--- a/explorer/e2e/anvil/anvil-filters.spec.ts
+++ b/explorer/e2e/anvil/anvil-filters.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "@playwright/test";
+import { testFilterPresence } from "../testFunctions";
+import { anvilFilters, anvilTabs, anvilTabTestOrder } from "./anvil-tabs";
+
+test.describe.configure({ mode: "parallel" });
+
+const filter_regex = (filter: string): RegExp =>
+  new RegExp(filter + "\\s+\\([0-9]+\\)\\s*");
+
+test("Check that all filters exist on the Datasets tab and are clickable", async ({
+  page,
+}) => {
+  await testFilterPresence(page, anvilTabs.datasets);
+});
+
+test("Check that all filters exist on the Donors tab and are clickable", async ({
+  page,
+}) => {
+  await testFilterPresence(page, anvilTabs.donors);
+});
+
+test("Check that all filters exist on the BioSamples tab and are clickable", async ({
+  page,
+}) => {
+  await testFilterPresence(page, anvilTabs.biosamples);
+});
+
+test("Check that all filters exist on the Activities tab and are clickable", async ({
+  page,
+}) => {
+  await testFilterPresence(page, anvilTabs.activities);
+});
+
+test("Check that all filters exist on the Files tab and are clickable", async ({
+  page,
+}) => {
+  await testFilterPresence(page, anvilTabs.files);
+});
+
+test("Check that the first filter on the Datasets tab creates at least one checkbox, and that checking up to the first five does not cause an error and does not cause there to be no entries in the table", async ({
+  page,
+}) => {
+  // Goto the datasets tab
+  await page.goto(anvilTabs.datasets.url);
+  await expect(
+    page.getByRole("tab").getByText(anvilTabs.datasets.tabName)
+  ).toBeVisible();
+
+  // Select a filter
+  await page
+    .getByRole("button")
+    .getByText(filter_regex(anvilFilters[4]))
+    .click();
+  // Expect all checkboxes to be unchecked initially and to work properly
+  await expect(page.getByRole("checkbox").first()).toBeVisible();
+  const all_checkboxes = await page.getByRole("checkbox").all();
+  for (let i = 0; i < all_checkboxes.length && i < 5; i++) {
+    const checkbox = all_checkboxes[i];
+    await checkbox.scrollIntoViewIfNeeded();
+    await expect(checkbox).not.toBeChecked();
+    await checkbox.click();
+    await expect(checkbox).toBeChecked();
+  }
+  await page.locator("body").click();
+  const firstElementTextLocator = page
+    .getByRole("rowgroup")
+    .nth(1)
+    .getByRole("row")
+    .nth(0)
+    .getByRole("cell")
+    .first();
+  await expect(firstElementTextLocator).toBeVisible();
+});
+
+test("Check that filter checkboxes are persistent across pages", async ({
+  page,
+}) => {
+  await page.goto(anvilTabs.datasets.url);
+  await expect(
+    page.getByRole("tab").getByText(anvilTabs.datasets.tabName)
+  ).toBeVisible();
+  await page.getByText(filter_regex(anvilFilters[3])).click(); // maybe should select a random one instead;
+  await expect(page.getByRole("checkbox").first()).not.toBeChecked();
+  await page.getByRole("checkbox").first().click();
+  await expect(page.getByRole("checkbox").first()).toBeChecked();
+  await page.locator("body").click();
+  for (const blah of anvilTabTestOrder) {
+    console.log(blah);
+    await page.getByRole("tab").getByText(anvilTabs[blah].tabName).click();
+    const firstElementTextLocator = page
+      .getByRole("rowgroup")
+      .nth(1)
+      .getByRole("row")
+      .nth(0)
+      .getByRole("cell")
+      .first();
+    await expect(firstElementTextLocator).toBeVisible();
+    await expect(page.getByText(filter_regex(anvilFilters[3]))).toBeVisible();
+    await page.getByText(filter_regex(anvilFilters[3])).click();
+    await expect(page.getByRole("checkbox").first()).toBeChecked();
+    await page.locator("body").click();
+  }
+});

--- a/explorer/e2e/anvil/anvil-filters.spec.ts
+++ b/explorer/e2e/anvil/anvil-filters.spec.ts
@@ -1,15 +1,15 @@
 import { expect, test } from "@playwright/test";
 import {
   filterRegex,
-  getFirstElementTextLocator,
+  getFirstRowNthColumnCellLocator,
   testClearAll,
-  testFilterBubbles,
   testFilterCounts,
   testFilterPersistence,
   testFilterPresence,
+  testFilterTags,
 } from "../testFunctions";
 import {
-  anvilFilters,
+  anvilFilterNames,
   anvilTabs,
   anvilTabTestOrder,
   BIOSAMPLE_TYPE_INDEX,
@@ -38,31 +38,31 @@ const FILTER_INDEX_LIST_SHORT = [
 test("Check that all filters exist on the Datasets tab and are clickable", async ({
   page,
 }) => {
-  await testFilterPresence(page, anvilTabs.datasets, anvilFilters);
+  await testFilterPresence(page, anvilTabs.datasets, anvilFilterNames);
 });
 
 test("Check that all filters exist on the Donors tab and are clickable", async ({
   page,
 }) => {
-  await testFilterPresence(page, anvilTabs.donors, anvilFilters);
+  await testFilterPresence(page, anvilTabs.donors, anvilFilterNames);
 });
 
 test("Check that all filters exist on the BioSamples tab and are clickable", async ({
   page,
 }) => {
-  await testFilterPresence(page, anvilTabs.biosamples, anvilFilters);
+  await testFilterPresence(page, anvilTabs.biosamples, anvilFilterNames);
 });
 
 test("Check that all filters exist on the Activities tab and are clickable", async ({
   page,
 }) => {
-  await testFilterPresence(page, anvilTabs.activities, anvilFilters);
+  await testFilterPresence(page, anvilTabs.activities, anvilFilterNames);
 });
 
 test("Check that all filters exist on the Files tab and are clickable", async ({
   page,
 }) => {
-  await testFilterPresence(page, anvilTabs.files, anvilFilters);
+  await testFilterPresence(page, anvilTabs.files, anvilFilterNames);
 });
 
 test("Check that the first filter on the Datasets tab creates at least one checkbox, and that checking up to the first five does not cause an error and does not cause there to be no entries in the table", async ({
@@ -79,7 +79,9 @@ test("Check that the first filter on the Datasets tab creates at least one check
   await page
     .getByRole("button")
     .getByText(
-      filterRegex(anvilFilters[Math.floor(Math.random() * anvilFilters.length)])
+      filterRegex(
+        anvilFilterNames[Math.floor(Math.random() * anvilFilterNames.length)]
+      )
     )
     .click();
   // Expect all checkboxes to be unchecked initially and to work properly
@@ -93,18 +95,21 @@ test("Check that the first filter on the Datasets tab creates at least one check
     await expect(checkbox).toBeChecked();
   }
   await page.locator("body").click();
-  await expect(getFirstElementTextLocator(page, 0)).toBeVisible();
+  await expect(getFirstRowNthColumnCellLocator(page, 0)).toBeVisible();
 });
 
 test("Check that filter checkboxes are persistent across pages on an arbitrary filter", async ({
   page,
 }) => {
   test.setTimeout(120000);
-  await testFilterPersistence(
+  const result = await testFilterPersistence(
     page,
-    anvilFilters[FILE_FORMAT_INDEX],
+    anvilFilterNames[FILE_FORMAT_INDEX],
     anvilTabTestOrder.map((x) => anvilTabs[x])
   );
+  if (!result) {
+    test.fail();
+  }
 });
 
 test("Check that filter menu counts match actual counts on the Datasets tab", async ({
@@ -114,7 +119,7 @@ test("Check that filter menu counts match actual counts on the Datasets tab", as
   const result = await testFilterCounts(
     page,
     anvilTabs.datasets,
-    FILTER_INDEX_LIST.map((x) => anvilFilters[x]),
+    FILTER_INDEX_LIST.map((x) => anvilFilterNames[x]),
     anvilTabs.datasets.maxPages ?? 0
   );
   if (!result) {
@@ -129,30 +134,30 @@ test("Check that filter menu counts match actual counts on the Activities tab", 
   await testFilterCounts(
     page,
     anvilTabs.activities,
-    FILTER_INDEX_LIST.map((x) => anvilFilters[x]),
+    FILTER_INDEX_LIST.map((x) => anvilFilterNames[x]),
     anvilTabs.activities.maxPages ?? 0
   );
 });
 
-test("Check that the blue filter bubbles match the selected filter for an arbitrary filter on the Files tab", async ({
+test("Check that the filter tags match the selected filter for an arbitrary filter on the Files tab", async ({
   page,
 }) => {
   test.setTimeout(120000);
-  await testFilterBubbles(
+  await testFilterTags(
     page,
     anvilTabs.files,
-    FILTER_INDEX_LIST_SHORT.map((x) => anvilFilters[x])
+    FILTER_INDEX_LIST_SHORT.map((x) => anvilFilterNames[x])
   );
 });
 
-test("Check that the blue filter bubbles match the selected filter for an arbitrary filter on the BioSamples tab", async ({
+test("Check that the filter tags match the selected filter for an arbitrary filter on the BioSamples tab", async ({
   page,
 }) => {
   test.setTimeout(120000);
-  await testFilterBubbles(
+  await testFilterTags(
     page,
     anvilTabs.biosamples,
-    FILTER_INDEX_LIST_SHORT.map((x) => anvilFilters[x])
+    FILTER_INDEX_LIST_SHORT.map((x) => anvilFilterNames[x])
   );
 });
 
@@ -163,6 +168,6 @@ test("Check that the clear all button functions on the files tab", async ({
   await testClearAll(
     page,
     anvilTabs.files,
-    FILTER_INDEX_LIST_SHORT.map((x) => anvilFilters[x])
+    FILTER_INDEX_LIST_SHORT.map((x) => anvilFilterNames[x])
   );
 });

--- a/explorer/e2e/anvil/anvil-filters.spec.ts
+++ b/explorer/e2e/anvil/anvil-filters.spec.ts
@@ -68,6 +68,7 @@ test("Check that all filters exist on the Files tab and are clickable", async ({
 test("Check that the first filter on the Datasets tab creates at least one checkbox, and that checking up to the first five does not cause an error and does not cause there to be no entries in the table", async ({
   page,
 }) => {
+  test.setTimeout(120000);
   // Goto the datasets tab
   await page.goto(anvilTabs.datasets.url);
   await expect(
@@ -98,6 +99,7 @@ test("Check that the first filter on the Datasets tab creates at least one check
 test("Check that filter checkboxes are persistent across pages on an arbitrary filter", async ({
   page,
 }) => {
+  test.setTimeout(120000);
   await testFilterPersistence(
     page,
     anvilFilters[FILE_FORMAT_INDEX],
@@ -108,6 +110,7 @@ test("Check that filter checkboxes are persistent across pages on an arbitrary f
 test("Check that filter menu counts match actual counts on the Datasets tab", async ({
   page,
 }) => {
+  test.setTimeout(120000);
   const result = await testFilterCounts(
     page,
     anvilTabs.datasets,
@@ -122,6 +125,7 @@ test("Check that filter menu counts match actual counts on the Datasets tab", as
 test("Check that filter menu counts match actual counts on the Activities tab", async ({
   page,
 }) => {
+  test.setTimeout(120000);
   await testFilterCounts(
     page,
     anvilTabs.activities,

--- a/explorer/e2e/anvil/anvil-filters.spec.ts
+++ b/explorer/e2e/anvil/anvil-filters.spec.ts
@@ -10,7 +10,6 @@ import {
 } from "../testFunctions";
 import { anvilFilters, anvilTabs, anvilTabTestOrder } from "./anvil-tabs";
 
-test.describe.configure({ mode: "parallel", timeout: 60 * 1000 });
 const filter_index_list = [3, 4, 5, 10, 6, 2];
 const filter_index_list_short = [1, 10, 3];
 test("Check that all filters exist on the Datasets tab and are clickable", async ({
@@ -108,10 +107,10 @@ test("Check that filter menu counts match actual counts on the Activities tab", 
   );
 });
 
-test.setTimeout(120000);
 test("Check that the blue filter bubbles match the selected filter for an arbitrary filter on the Files tab", async ({
   page,
 }) => {
+  test.setTimeout(120000);
   await testFilterBubbles(
     page,
     anvilTabs.files,
@@ -119,10 +118,10 @@ test("Check that the blue filter bubbles match the selected filter for an arbitr
   );
 });
 
-test.setTimeout(120000);
 test("Check that the blue filter bubbles match the selected filter for an arbitrary filter on the BioSamples tab", async ({
   page,
 }) => {
+  test.setTimeout(120000);
   await testFilterBubbles(
     page,
     anvilTabs.biosamples,
@@ -130,10 +129,10 @@ test("Check that the blue filter bubbles match the selected filter for an arbitr
   );
 });
 
-test.setTimeout(120000);
 test("Check that the clear all button functions on the files tab", async ({
   page,
 }) => {
+  test.setTimeout(120000);
   await testClearAll(
     page,
     anvilTabs.files,

--- a/explorer/e2e/anvil/anvil-filters.spec.ts
+++ b/explorer/e2e/anvil/anvil-filters.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import {
   filterRegex,
   getFirstElementTextLocator,
+  testClearAll,
   testFilterBubbles,
   testFilterCounts,
   testFilterPersistence,
@@ -123,6 +124,16 @@ test("Check that the blue filter bubbles match the selected filter for an arbitr
   await testFilterBubbles(
     page,
     anvilTabs.biosamples,
+    filter_index_list.map((x) => anvilFilters[x])
+  );
+});
+
+test("Check that the clear all button functions on the files tab", async ({
+  page,
+}) => {
+  await testClearAll(
+    page,
+    anvilTabs.files,
     filter_index_list.map((x) => anvilFilters[x])
   );
 });

--- a/explorer/e2e/anvil/anvil-filters.spec.ts
+++ b/explorer/e2e/anvil/anvil-filters.spec.ts
@@ -10,8 +10,8 @@ import {
 } from "../testFunctions";
 import { anvilFilters, anvilTabs, anvilTabTestOrder } from "./anvil-tabs";
 
-const filter_index_list = [3, 4, 5, 10, 6, 2];
-const filter_index_list_short = [1, 10, 3];
+const filterIndexList = [3, 4, 5, 10, 6, 2];
+const filterIndexListShort = [1, 10, 3];
 test("Check that all filters exist on the Datasets tab and are clickable", async ({
   page,
 }) => {
@@ -60,9 +60,9 @@ test("Check that the first filter on the Datasets tab creates at least one check
     .click();
   // Expect all checkboxes to be unchecked initially and to work properly
   await expect(page.getByRole("checkbox").first()).toBeVisible();
-  const all_checkboxes = await page.getByRole("checkbox").all();
-  for (let i = 0; i < all_checkboxes.length && i < 5; i++) {
-    const checkbox = all_checkboxes[i];
+  const allCheckboxes = await page.getByRole("checkbox").all();
+  for (let i = 0; i < allCheckboxes.length && i < 5; i++) {
+    const checkbox = allCheckboxes[i];
     await checkbox.scrollIntoViewIfNeeded();
     await expect(checkbox).not.toBeChecked();
     await checkbox.click();
@@ -88,7 +88,7 @@ test("Check that filter menu counts match actual counts on the Datasets tab", as
   const result = await testFilterCounts(
     page,
     anvilTabs.datasets,
-    filter_index_list.map((x) => anvilFilters[x]),
+    filterIndexList.map((x) => anvilFilters[x]),
     25
   );
   if (!result) {
@@ -102,7 +102,7 @@ test("Check that filter menu counts match actual counts on the Activities tab", 
   await testFilterCounts(
     page,
     anvilTabs.activities,
-    filter_index_list.map((x) => anvilFilters[x]),
+    filterIndexList.map((x) => anvilFilters[x]),
     25
   );
 });
@@ -114,7 +114,7 @@ test("Check that the blue filter bubbles match the selected filter for an arbitr
   await testFilterBubbles(
     page,
     anvilTabs.files,
-    filter_index_list_short.map((x) => anvilFilters[x])
+    filterIndexListShort.map((x) => anvilFilters[x])
   );
 });
 
@@ -125,7 +125,7 @@ test("Check that the blue filter bubbles match the selected filter for an arbitr
   await testFilterBubbles(
     page,
     anvilTabs.biosamples,
-    filter_index_list_short.map((x) => anvilFilters[x])
+    filterIndexListShort.map((x) => anvilFilters[x])
   );
 });
 
@@ -136,6 +136,6 @@ test("Check that the clear all button functions on the files tab", async ({
   await testClearAll(
     page,
     anvilTabs.files,
-    filter_index_list_short.map((x) => anvilFilters[x])
+    filterIndexListShort.map((x) => anvilFilters[x])
   );
 });

--- a/explorer/e2e/anvil/anvil-filters.spec.ts
+++ b/explorer/e2e/anvil/anvil-filters.spec.ts
@@ -8,10 +8,33 @@ import {
   testFilterPersistence,
   testFilterPresence,
 } from "../testFunctions";
-import { anvilFilters, anvilTabs, anvilTabTestOrder } from "./anvil-tabs";
+import {
+  anvilFilters,
+  anvilTabs,
+  anvilTabTestOrder,
+  BIOSAMPLE_TYPE_INDEX,
+  CONSENT_GROUP_INDEX,
+  DATASET_INDEX,
+  DATA_MODALITY_INDEX,
+  DIAGNOSIS_INDEX,
+  FILE_FORMAT_INDEX,
+  REPORTED_ETHNICITY_INDEX,
+} from "./anvil-tabs";
 
-const filterIndexList = [3, 4, 5, 10, 6, 2];
-const filterIndexListShort = [1, 10, 3];
+const FILTER_INDEX_LIST = [
+  DATA_MODALITY_INDEX,
+  DATASET_INDEX,
+  DIAGNOSIS_INDEX,
+  REPORTED_ETHNICITY_INDEX,
+  FILE_FORMAT_INDEX,
+  CONSENT_GROUP_INDEX,
+];
+const FILTER_INDEX_LIST_SHORT = [
+  BIOSAMPLE_TYPE_INDEX,
+  FILE_FORMAT_INDEX,
+  DIAGNOSIS_INDEX,
+];
+
 test("Check that all filters exist on the Datasets tab and are clickable", async ({
   page,
 }) => {
@@ -77,7 +100,7 @@ test("Check that filter checkboxes are persistent across pages on an arbitrary f
 }) => {
   await testFilterPersistence(
     page,
-    anvilFilters[3],
+    anvilFilters[FILE_FORMAT_INDEX],
     anvilTabTestOrder.map((x) => anvilTabs[x])
   );
 });
@@ -88,8 +111,8 @@ test("Check that filter menu counts match actual counts on the Datasets tab", as
   const result = await testFilterCounts(
     page,
     anvilTabs.datasets,
-    filterIndexList.map((x) => anvilFilters[x]),
-    25
+    FILTER_INDEX_LIST.map((x) => anvilFilters[x]),
+    anvilTabs.datasets.maxPages ?? 0
   );
   if (!result) {
     test.fail();
@@ -102,8 +125,8 @@ test("Check that filter menu counts match actual counts on the Activities tab", 
   await testFilterCounts(
     page,
     anvilTabs.activities,
-    filterIndexList.map((x) => anvilFilters[x]),
-    25
+    FILTER_INDEX_LIST.map((x) => anvilFilters[x]),
+    anvilTabs.activities.maxPages ?? 0
   );
 });
 
@@ -114,7 +137,7 @@ test("Check that the blue filter bubbles match the selected filter for an arbitr
   await testFilterBubbles(
     page,
     anvilTabs.files,
-    filterIndexListShort.map((x) => anvilFilters[x])
+    FILTER_INDEX_LIST_SHORT.map((x) => anvilFilters[x])
   );
 });
 
@@ -125,7 +148,7 @@ test("Check that the blue filter bubbles match the selected filter for an arbitr
   await testFilterBubbles(
     page,
     anvilTabs.biosamples,
-    filterIndexListShort.map((x) => anvilFilters[x])
+    FILTER_INDEX_LIST_SHORT.map((x) => anvilFilters[x])
   );
 });
 
@@ -136,6 +159,6 @@ test("Check that the clear all button functions on the files tab", async ({
   await testClearAll(
     page,
     anvilTabs.files,
-    filterIndexListShort.map((x) => anvilFilters[x])
+    FILTER_INDEX_LIST_SHORT.map((x) => anvilFilters[x])
   );
 });

--- a/explorer/e2e/anvil/anvil-filters.spec.ts
+++ b/explorer/e2e/anvil/anvil-filters.spec.ts
@@ -11,8 +11,8 @@ import {
 import { anvilFilters, anvilTabs, anvilTabTestOrder } from "./anvil-tabs";
 
 test.describe.configure({ mode: "parallel", timeout: 60 * 1000 });
-const filter_index_list = [3, 4, 5, 7, 6, 2];
-
+const filter_index_list = [3, 4, 5, 10, 6, 2];
+const filter_index_list_short = [1, 10, 3];
 test("Check that all filters exist on the Datasets tab and are clickable", async ({
   page,
 }) => {
@@ -108,32 +108,35 @@ test("Check that filter menu counts match actual counts on the Activities tab", 
   );
 });
 
+test.setTimeout(120000);
 test("Check that the blue filter bubbles match the selected filter for an arbitrary filter on the Files tab", async ({
   page,
 }) => {
   await testFilterBubbles(
     page,
     anvilTabs.files,
-    filter_index_list.map((x) => anvilFilters[x])
+    filter_index_list_short.map((x) => anvilFilters[x])
   );
 });
 
+test.setTimeout(120000);
 test("Check that the blue filter bubbles match the selected filter for an arbitrary filter on the BioSamples tab", async ({
   page,
 }) => {
   await testFilterBubbles(
     page,
     anvilTabs.biosamples,
-    filter_index_list.map((x) => anvilFilters[x])
+    filter_index_list_short.map((x) => anvilFilters[x])
   );
 });
 
+test.setTimeout(120000);
 test("Check that the clear all button functions on the files tab", async ({
   page,
 }) => {
   await testClearAll(
     page,
     anvilTabs.files,
-    filter_index_list.map((x) => anvilFilters[x])
+    filter_index_list_short.map((x) => anvilFilters[x])
   );
 });

--- a/explorer/e2e/anvil/anvil-filters.spec.ts
+++ b/explorer/e2e/anvil/anvil-filters.spec.ts
@@ -9,7 +9,7 @@ import {
 } from "../testFunctions";
 import { anvilFilters, anvilTabs, anvilTabTestOrder } from "./anvil-tabs";
 
-test.describe.configure({ mode: "parallel" });
+test.describe.configure({ mode: "parallel", timeout: 60 * 1000 });
 const filter_index_list = [3, 4, 5, 7, 6, 2];
 
 test("Check that all filters exist on the Datasets tab and are clickable", async ({
@@ -85,12 +85,15 @@ test("Check that filter checkboxes are persistent across pages on an arbitrary f
 test("Check that filter menu counts match actual counts on the Datasets tab", async ({
   page,
 }) => {
-  await testFilterCounts(
+  const result = await testFilterCounts(
     page,
     anvilTabs.datasets,
     filter_index_list.map((x) => anvilFilters[x]),
     25
   );
+  if (!result) {
+    test.fail();
+  }
 });
 
 test("Check that filter menu counts match actual counts on the Activities tab", async ({

--- a/explorer/e2e/anvil/anvil-tabs.ts
+++ b/explorer/e2e/anvil/anvil-tabs.ts
@@ -18,10 +18,22 @@ export const anvilFilters: string[] = [
   "Phenotypic Sex",
   "Reported Ethnicity",
 ];
+export const ANATOMICAL_SITE_INDEX = 0;
+export const BIOSAMPLE_TYPE_INDEX = 1;
+export const CONSENT_GROUP_INDEX = 2;
+export const DATA_MODALITY_INDEX = 3;
+export const DATASET_INDEX = 4;
+export const DIAGNOSIS_INDEX = 5;
+export const FILE_FORMAT_INDEX = 6;
+export const IDENTIFIER_INDEX = 7;
+export const ORGANISM_TYPE_INDEX = 8;
+export const PHENOTYPIC_SEX_INDEX = 9;
+export const REPORTED_ETHNICITY_INDEX = 10;
 
 export const anvilTabs: AnvilCMGTabCollection = {
   activities: {
     emptyFirstColumn: false,
+    maxPages: 25,
     preselectedColumns: [
       { name: "Document Id", sortable: true },
       { name: "Activity Type", sortable: true },
@@ -40,6 +52,7 @@ export const anvilTabs: AnvilCMGTabCollection = {
   },
   biosamples: {
     emptyFirstColumn: false,
+    maxPages: 25,
     preselectedColumns: [
       { name: "BioSample Id", sortable: true },
       { name: "Anatomical Site", sortable: true },
@@ -57,6 +70,7 @@ export const anvilTabs: AnvilCMGTabCollection = {
   },
   datasets: {
     emptyFirstColumn: false,
+    maxPages: 25,
     preselectedColumns: [
       { name: "Dataset", sortable: true },
       { name: "Access", sortable: false },
@@ -75,6 +89,7 @@ export const anvilTabs: AnvilCMGTabCollection = {
   },
   donors: {
     emptyFirstColumn: false,
+    maxPages: 25,
     preselectedColumns: [
       { name: "Donor Id", sortable: true },
       { name: "Organism Type", sortable: true },
@@ -89,6 +104,7 @@ export const anvilTabs: AnvilCMGTabCollection = {
   },
   files: {
     emptyFirstColumn: true,
+    maxPages: 25,
     preselectedColumns: [
       { name: "Name", sortable: true },
       { name: "File Format", sortable: true },

--- a/explorer/e2e/anvil/anvil-tabs.ts
+++ b/explorer/e2e/anvil/anvil-tabs.ts
@@ -5,7 +5,7 @@ import {
   TabDescription,
 } from "../testInterfaces";
 
-export const filters: string[] = [
+export const anvilFilters: string[] = [
   "Anatomical Site",
   "BioSample Type",
   "Consent Group",

--- a/explorer/e2e/anvil/anvil-tabs.ts
+++ b/explorer/e2e/anvil/anvil-tabs.ts
@@ -5,7 +5,7 @@ import {
   TabDescription,
 } from "../testInterfaces";
 
-export const anvilFilters: string[] = [
+export const anvilFilterNames: string[] = [
   "Anatomical Site",
   "BioSample Type",
   "Consent Group",

--- a/explorer/e2e/testFunctions.ts
+++ b/explorer/e2e/testFunctions.ts
@@ -1,5 +1,4 @@
 import { expect, Locator, Page } from "@playwright/test";
-import { anvilFilters } from "./anvil/anvil-tabs";
 import { TabDescription } from "./testInterfaces";
 
 /* eslint-disable sonarjs/no-duplicate-string  -- ignoring duplicate strings here */
@@ -216,20 +215,22 @@ export async function testPreSelectedColumns(
   }
 }
 
-export const filter_regex = (filter: string): RegExp =>
+export const filterRegex = (filter: string): RegExp =>
   new RegExp(filter + "\\s+\\([0-9]+\\)\\s*");
 
 export async function testFilterPresence(
   page: Page,
-  tab: TabDescription
+  tab: TabDescription,
+  filters: string[]
 ): Promise<void> {
   // Goto the selected tab
   await page.goto(tab.url);
   await expect(page.getByRole("tab").getByText(tab.tabName)).toBeVisible();
-  for (const filter of anvilFilters) {
+  for (const filter of filters) {
     // Check that each filter is visible and clickable
-    await expect(page.getByText(filter_regex(filter))).toBeVisible();
-    await page.getByText(filter_regex(filter)).click();
+    await expect(page.getByText(filterRegex(filter))).toBeVisible();
+    await page.getByText(filterRegex(filter)).click();
+    await expect(page.getByRole("checkbox").first()).toBeVisible();
     await expect(page.getByRole("checkbox").first()).not.toBeChecked();
     // Check that clicking out of the filter menu causes it to disappear
     await page.locator("body").click();
@@ -237,4 +238,105 @@ export async function testFilterPresence(
   }
 }
 
+export const getNamedFilterButton = (
+  page: Page,
+  filterName: string
+): Locator => {
+  return page
+    .getByRole("button")
+    .filter({ has: page.getByRole("checkbox"), hasText: filterName });
+};
+export const getFirstFilterButton = (page: Page): Locator => {
+  return page
+    .getByRole("button")
+    .filter({ has: page.getByRole("checkbox") })
+    .first();
+};
+
+export async function testFilterPersistence(
+  page: Page,
+  testFilter: string,
+  tabOrder: TabDescription[]
+): Promise<void> {
+  // Start on the first tab in the test order (should be files)
+  await page.goto(tabOrder[0].url);
+  // Select the first checkbox on the test filter
+  await page.getByText(filterRegex(testFilter)).click();
+  const to_select = await getFirstFilterButton(page);
+  await expect(to_select.getByRole("checkbox")).not.toBeChecked();
+  await to_select.getByRole("checkbox").setChecked(true);
+  const filterName = (await to_select.innerText()).split("\n")[0]; //MAY NEED TO ADD SOME CHECKING MECHANISM HERE
+  await expect(to_select.getByRole("checkbox")).toBeChecked();
+  await page.locator("body").click();
+  // Expect at least some text to still be visible
+  await expect(getFirstElementTextLocator(page, 0)).toBeVisible();
+  // For each tab, check that the selected filter is still checked
+  for (const tab of tabOrder.slice(1)) {
+    await page.getByRole("tab").getByText(tab.tabName).click();
+    await expect(page.getByText(filterRegex(testFilter))).toBeVisible();
+    await page.getByText(filterRegex(testFilter)).click();
+    const previously_selected = getNamedFilterButton(page, filterName);
+    await expect(previously_selected.getByRole("checkbox")).toBeChecked();
+    await page.locator("body").click();
+  }
+  // Return to the start tab and confirm that the filter stays checked and that some content is visible
+  await page.getByRole("tab").getByText(tabOrder[0].tabName).click();
+  await expect(getFirstElementTextLocator(page, 0)).toBeVisible();
+  await page.getByText(filterRegex(testFilter)).click();
+  const previously_selected = getFirstFilterButton(page);
+  await expect(previously_selected).toContainText(filterName, {
+    useInnerText: true,
+  });
+  await expect(previously_selected.getByRole("checkbox").first()).toBeChecked();
+}
+
+export async function testFilterCounts(
+  page: Page,
+  tab: TabDescription,
+  filters: string[],
+  elements_per_page: number
+): Promise<void> {
+  await page.goto(tab.url);
+  // For each arbitrarily selected filter
+  for (const filter of filters) {
+    // Select the filter
+    await page.getByText(filterRegex(filter)).click();
+    // Get the number associated with the first filter button, and select it
+    const filter_button = getFirstFilterButton(page);
+    const filterNumber = Number(
+      (await filter_button.innerText()).split("\n")[1]
+    );
+    await filter_button.getByRole("checkbox").setChecked(true);
+    //
+    await page.locator("body").click();
+    const firstNumber =
+      filterNumber <= elements_per_page ? filterNumber : elements_per_page;
+    await expect(
+      page.getByText("Results 1 - " + firstNumber + " of " + filterNumber)
+    ).toBeVisible();
+  }
+}
+
+export async function testFilterBubbles(
+  page: Page,
+  tab: TabDescription,
+  filters: string[]
+): Promise<void> {
+  page.goto(tab.url);
+  for (const filter of filters) {
+    await page.getByText(filterRegex(filter)).click();
+    const firstFilterButton = getFirstFilterButton(page);
+    const firstFilterName = (await firstFilterButton.innerText()).split(
+      "\n"
+    )[0];
+    await firstFilterButton.getByRole("checkbox").setChecked(true);
+    await page.locator("body").click();
+    const filterBlueButton = page
+      .getByRole("button")
+      .getByText(firstFilterName);
+    await expect(filterBlueButton).toBeVisible();
+    await filterBlueButton.click();
+    await expect(filterBlueButton).toHaveCount(0);
+  }
+}
 /* eslint-enable sonarjs/no-duplicate-string -- Checking duplicate strings again*/

--- a/explorer/e2e/testFunctions.ts
+++ b/explorer/e2e/testFunctions.ts
@@ -373,9 +373,9 @@ export async function testFilterPersistence(
   await page
     .getByRole("tab")
     .getByText(tabOrder[0].tabName, { exact: true })
-    .click();
+    .dispatchEvent("click");
   await expect(getFirstRowNthColumnCellLocator(page, 0)).toBeVisible();
-  await page.getByText(filterRegex(testFilterName)).click();
+  await page.getByText(filterRegex(testFilterName)).dispatchEvent("click");
   const previouslySelected = getFirstFilterButtonLocator(page);
   await expect(previouslySelected).toContainText(filterName, {
     useInnerText: true,

--- a/explorer/e2e/testFunctions.ts
+++ b/explorer/e2e/testFunctions.ts
@@ -1,11 +1,11 @@
 import { expect, Locator, Page } from "@playwright/test";
-import { anvilFilters, anvilTabs, anvilTabTestOrder } from "./anvil/anvil-tabs";
+import { anvilFilters } from "./anvil/anvil-tabs";
 import { TabDescription } from "./testInterfaces";
 
 /* eslint-disable sonarjs/no-duplicate-string  -- ignoring duplicate strings here */
 // Run the "Expect each tab to appear as selected when the corresponding url is accessed" test
 
-const getFirstElementTextLocator = (
+export const getFirstElementTextLocator = (
   page: Page,
   workColumnPosition: number
 ): Locator => {
@@ -82,13 +82,10 @@ export async function testSortAzul(
         ? columnPosition + 1
         : columnPosition;
       // Locators for the first and last cells in a particular column position on the page
-      const firstElementTextLocator = page
-        .getByRole("rowgroup")
-        .nth(1)
-        .getByRole("row")
-        .nth(0)
-        .getByRole("cell")
-        .nth(workColumnPosition);
+      const firstElementTextLocator = getFirstElementTextLocator(
+        page,
+        workColumnPosition
+      );
       const lastElementTextLocator = page
         .getByRole("rowgroup")
         .nth(1)
@@ -141,13 +138,10 @@ export async function testSortCatalog(
         ? columnPosition + 1
         : columnPosition;
       // Locators for the first and last cells in a particular column position on the page
-      const firstElementTextLocator = page
-        .getByRole("rowgroup")
-        .nth(1)
-        .getByRole("row")
-        .nth(0)
-        .getByRole("cell")
-        .nth(workColumnPosition);
+      const firstElementTextLocator = getFirstElementTextLocator(
+        page,
+        workColumnPosition
+      );
       // Locator for the sort button
       const columnSortLocator = page
         .getByRole("columnheader", {
@@ -222,7 +216,7 @@ export async function testPreSelectedColumns(
   }
 }
 
-const filter_regex = (filter: string): RegExp =>
+export const filter_regex = (filter: string): RegExp =>
   new RegExp(filter + "\\s+\\([0-9]+\\)\\s*");
 
 export async function testFilterPresence(
@@ -231,18 +225,9 @@ export async function testFilterPresence(
 ): Promise<void> {
   await page.goto(tab.url);
   await expect(page.getByRole("tab").getByText(tab.tabName)).toBeVisible();
-  await page.getByText(filter_regex(anvilFilters[3])).click(); // maybe should select a random one instead;
-  await expect(page.getByRole("checkbox").first()).not.toBeChecked();
-  await page.getByRole("checkbox").first().click();
-  await expect(page.getByRole("checkbox").first()).toBeChecked();
-  await page.locator("body").click();
-  for (const blah of anvilTabTestOrder) {
-    console.log(blah);
-    await page.getByRole("tab").getByText(anvilTabs[blah].tabName).click();
-    await expect(getFirstElementTextLocator(page, 0)).toBeVisible();
-    await expect(page.getByText(filter_regex(anvilFilters[3]))).toBeVisible();
-    await page.getByText(filter_regex(anvilFilters[3])).click();
-    await expect(page.getByRole("checkbox").first()).toBeChecked();
+  for (const filter of anvilFilters) {
+    await page.getByText(filter_regex(filter)).click(); // maybe should select a random one instead;
+    await expect(page.getByRole("checkbox").first()).not.toBeChecked();
     await page.locator("body").click();
   }
 }

--- a/explorer/e2e/testFunctions.ts
+++ b/explorer/e2e/testFunctions.ts
@@ -264,7 +264,7 @@ export async function testFilterPersistence(
   await page.getByText(filterRegex(testFilter)).click();
   const to_select = await getFirstFilterButton(page);
   await expect(to_select.getByRole("checkbox")).not.toBeChecked();
-  await to_select.getByRole("checkbox").setChecked(true);
+  await to_select.getByRole("checkbox").click;
   const filterName = (await to_select.innerText()).split("\n")[0]; //MAY NEED TO ADD SOME CHECKING MECHANISM HERE
   await expect(to_select.getByRole("checkbox")).toBeChecked();
   await page.locator("body").click();

--- a/explorer/e2e/testFunctions.ts
+++ b/explorer/e2e/testFunctions.ts
@@ -262,11 +262,11 @@ export async function testFilterPersistence(
   await page.goto(tabOrder[0].url);
   // Select the first checkbox on the test filter
   await page.getByText(filterRegex(testFilter)).click();
-  const to_select = await getFirstFilterButton(page);
-  await expect(to_select.getByRole("checkbox")).not.toBeChecked();
-  await to_select.getByRole("checkbox").click();
-  const filterName = (await to_select.innerText()).split("\n")[0]; //MAY NEED TO ADD SOME CHECKING MECHANISM HERE
-  await expect(to_select.getByRole("checkbox")).toBeChecked();
+  const toSelect = await getFirstFilterButton(page);
+  await expect(toSelect.getByRole("checkbox")).not.toBeChecked();
+  await toSelect.getByRole("checkbox").click();
+  const filterName = (await toSelect.innerText()).split("\n")[0]; //MAY NEED TO ADD SOME CHECKING MECHANISM HERE
+  await expect(toSelect.getByRole("checkbox")).toBeChecked();
   await page.locator("body").click();
   // Expect at least some text to still be visible
   await expect(getFirstElementTextLocator(page, 0)).toBeVisible();
@@ -279,8 +279,8 @@ export async function testFilterPersistence(
     await expect(page.getByText(filterRegex(testFilter))).toBeVisible();
     await page.getByText(filterRegex(testFilter)).dispatchEvent("click");
     await page.waitForLoadState("load");
-    const previously_selected = getNamedFilterButton(page, filterName);
-    await expect(previously_selected.getByRole("checkbox")).toBeChecked();
+    const previouslySelected = getNamedFilterButton(page, filterName);
+    await expect(previouslySelected.getByRole("checkbox")).toBeChecked();
     await page.waitForLoadState("load");
     await page.locator("body").click();
   }
@@ -291,18 +291,18 @@ export async function testFilterPersistence(
     .click();
   await expect(getFirstElementTextLocator(page, 0)).toBeVisible();
   await page.getByText(filterRegex(testFilter)).click();
-  const previously_selected = getFirstFilterButton(page);
-  await expect(previously_selected).toContainText(filterName, {
+  const previouslySelected = getFirstFilterButton(page);
+  await expect(previouslySelected).toContainText(filterName, {
     useInnerText: true,
   });
-  await expect(previously_selected.getByRole("checkbox").first()).toBeChecked();
+  await expect(previouslySelected.getByRole("checkbox").first()).toBeChecked();
 }
 
 export async function testFilterCounts(
   page: Page,
   tab: TabDescription,
   filters: string[],
-  elements_per_page: number
+  elementsPerPage: number
 ): Promise<boolean> {
   await page.goto(tab.url);
   // For each arbitrarily selected filter
@@ -311,26 +311,26 @@ export async function testFilterCounts(
     await page.getByText(filterRegex(filter)).dispatchEvent("click");
     // Get the number associated with the first filter button, and select it
     await page.waitForLoadState("load");
-    const filter_button = getFirstFilterButton(page);
-    const filter_numbers = (await filter_button.innerText()).split("\n");
-    const filter_number =
-      filter_numbers.map((x) => Number(x)).find((x) => !isNaN(x) && x !== 0) ??
+    const filterButton = getFirstFilterButton(page);
+    const filterNumbers = (await filterButton.innerText()).split("\n");
+    const filterNumber =
+      filterNumbers.map((x) => Number(x)).find((x) => !isNaN(x) && x !== 0) ??
       -1;
-    if (filter_number < 0) {
-      console.log(filter_numbers.map((x) => Number(x)));
+    if (filterNumber < 0) {
+      console.log(filterNumbers.map((x) => Number(x)));
       return false;
     }
     // Check the filter
-    await filter_button.getByRole("checkbox").dispatchEvent("click");
+    await filterButton.getByRole("checkbox").dispatchEvent("click");
     await page.waitForLoadState("load");
     // Exit the filter menu
     await page.locator("body").click();
     await expect(page.getByRole("checkbox")).toHaveCount(0);
     // Expect the displayed count of elements to be 0
     const firstNumber =
-      filter_number <= elements_per_page ? filter_number : elements_per_page;
+      filterNumber <= elementsPerPage ? filterNumber : elementsPerPage;
     await expect(
-      page.getByText("Results 1 - " + firstNumber + " of " + filter_number)
+      page.getByText("Results 1 - " + firstNumber + " of " + filterNumber)
     ).toBeVisible();
   }
   return true;
@@ -379,14 +379,14 @@ export async function testClearAll(
   filters: string[]
 ): Promise<void> {
   await page.goto(tab.url);
-  const selected_filter_list = [];
+  const selectedFilterList = [];
   for (const filter of filters) {
     await page.getByText(filterRegex(filter)).dispatchEvent("click");
     await getFirstFilterButton(page).getByRole("checkbox").click();
     await expect(
       getFirstFilterButton(page).getByRole("checkbox")
     ).toBeChecked();
-    selected_filter_list.push(
+    selectedFilterList.push(
       (await getFirstFilterButton(page).innerText())
         .split("\n")
         .find((x) => x.length > 0) ?? ""
@@ -394,7 +394,7 @@ export async function testClearAll(
     await page.locator("body").click();
   }
   await page.getByText("Clear All").dispatchEvent("click");
-  for (const filter of selected_filter_list) {
+  for (const filter of selectedFilterList) {
     await expect(
       page.locator("#sidebar-positioner").getByText(filter)
     ).toHaveCount(0);
@@ -402,7 +402,7 @@ export async function testClearAll(
   for (let i = 0; i < filters.length; i++) {
     await page.getByText(filterRegex(filters[i])).dispatchEvent("click");
     await expect(
-      getNamedFilterButton(page, selected_filter_list[i]).getByRole("checkbox")
+      getNamedFilterButton(page, selectedFilterList[i]).getByRole("checkbox")
     ).not.toBeChecked();
     await page.locator("body").click();
   }

--- a/explorer/e2e/testFunctions.ts
+++ b/explorer/e2e/testFunctions.ts
@@ -223,12 +223,17 @@ export async function testFilterPresence(
   page: Page,
   tab: TabDescription
 ): Promise<void> {
+  // Goto the selected tab
   await page.goto(tab.url);
   await expect(page.getByRole("tab").getByText(tab.tabName)).toBeVisible();
   for (const filter of anvilFilters) {
-    await page.getByText(filter_regex(filter)).click(); // maybe should select a random one instead;
+    // Check that each filter is visible and clickable
+    await expect(page.getByText(filter_regex(filter))).toBeVisible();
+    await page.getByText(filter_regex(filter)).click();
     await expect(page.getByRole("checkbox").first()).not.toBeChecked();
+    // Check that clicking out of the filter menu causes it to disappear
     await page.locator("body").click();
+    await expect(page.getByRole("checkbox")).toHaveCount(0);
   }
 }
 

--- a/explorer/e2e/testInterfaces.ts
+++ b/explorer/e2e/testInterfaces.ts
@@ -1,5 +1,6 @@
 export interface TabDescription {
   emptyFirstColumn: boolean;
+  maxPages?: number;
   preselectedColumns: columnDescription[];
   selectableColumns: columnDescription[];
   tabName: string;

--- a/explorer/playwright_anvil.config.ts
+++ b/explorer/playwright_anvil.config.ts
@@ -33,6 +33,6 @@ const config: PlaywrightTestConfig = {
     timeout: 240 * 1000,
     url: "http://localhost:3000/",
   },
-  workers: "75%",
+  workers: 1,
 };
 export default config;

--- a/explorer/playwright_anvil.config.ts
+++ b/explorer/playwright_anvil.config.ts
@@ -33,6 +33,6 @@ const config: PlaywrightTestConfig = {
     timeout: 240 * 1000,
     url: "http://localhost:3000/",
   },
-  workers: 1,
+  workers: "75%",
 };
 export default config;


### PR DESCRIPTION
### Ticket
Closes #4068 .

### Reviewers
@NoopDog .

### Changes
Added the following tests for AnVIL-CMG
- Check that all filters defined in `explorer/e2e/anvilTabs.js` display on each tab, are clickable, and cause a checkbox to be displayed
- Check that selecting the first 5 checkboxes on one arbitrary filter on the datasets tab does not remove any elements from the table
- Check that selecting the first checkbox on an one arbitrary filter on the datasets causes that box to remain checked when each of the other tabs is selected
- Check that the stated number of entries visible matches the number displayed next to the entry on the filter menu for an arbitrary but constant set of filters
- Check that the blue filter bubbles match the filter settings and that clicking them deselects the filter for an arbitrary but constant set of filters
- Check that the "Clear All" button functions correctly for an arbitrary but constant set of filters