### PR TITLE
chore: updated default order in hca-dcp "Projects" tab (#4081)

### DIFF
--- a/explorer/site-config/hca-dcp/category.ts
+++ b/explorer/site-config/hca-dcp/category.ts
@@ -46,8 +46,8 @@ export const HCA_DCP_CATEGORY_KEY = {
 
 export const HCA_DCP_CATEGORY_LABEL = {
   ACCESSIBLE: "Access",
-  AGGREGATE_LAST_MODIFIED_DATE: "Update Date",
-  AGGREGATE_SUBMISSION_DATE: "Submission Date",
+  AGGREGATE_LAST_MODIFIED_DATE: "Updated",
+  AGGREGATE_SUBMISSION_DATE: "Submitted",
   ANALYSIS_PROTOCOL: "Analysis Protocol",
   ANATOMICAL_ENTITY: "Anatomical Entity",
   AZUL_FILE_DOWNLOAD: " ",

--- a/explorer/site-config/hca-dcp/dev/index/projectsEntityConfig.ts
+++ b/explorer/site-config/hca-dcp/dev/index/projectsEntityConfig.ts
@@ -246,7 +246,7 @@ export const projectsEntityConfig: EntityConfig = {
         width: { max: "1fr", min: "224px" },
       },
       {
-        columnVisible: false,
+        columnVisible: true,
         componentConfig: {
           component: C.Cell,
           viewBuilder: V.buildAggregateLastModifiedDate,
@@ -257,8 +257,8 @@ export const projectsEntityConfig: EntityConfig = {
       },
     ],
     defaultSort: {
-      desc: SORT_DIRECTION.ASCENDING,
-      id: HCA_DCP_CATEGORY_KEY.PROJECT_TITLE,
+      desc: SORT_DIRECTION.DESCENDING,
+      id: HCA_DCP_CATEGORY_KEY.AGGREGATE_LAST_MODIFIED_DATE,
     },
   } as ListConfig<ProjectsResponse>,
   listView: {


### PR DESCRIPTION
### Ticket
Closes #4081 .

### Reviewers
@NoopDog .

### Changes
- Changed the "Update Date" header to "Updated"
- Changed "Submission Date" to "Submitted"
- Made the "Updated" column display by default
- Set the default order by on the Project Column to "Updated", and to be in descending order

