### PR TITLE
feat: hide the dataset and filter export functionality on filter results level without the ff 'verbatim' (#4097)

### DIFF
--- a/explorer/app/components/Export/components/AnVILExplorer/ExportMethod/exportMethod.tsx
+++ b/explorer/app/components/Export/components/AnVILExplorer/ExportMethod/exportMethod.tsx
@@ -1,0 +1,22 @@
+import {
+  ExportMethod as DXExportMethod,
+  ExportMethodProps,
+} from "@databiosphere/findable-ui/lib/components/Export/components/ExportMethod/exportMethod";
+import { useExploreState } from "@databiosphere/findable-ui/lib/hooks/useExploreState";
+import React, { Fragment, useEffect, useState } from "react";
+import { FEATURE_FLAGS } from "../../../../../viewModelBuilders/common/contants";
+
+export const ExportMethod = ({ ...props }: ExportMethodProps): JSX.Element => {
+  const {
+    exploreState: { featureFlagState },
+  } = useExploreState();
+  const [showMethod, setShowMethod] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (featureFlagState) {
+      setShowMethod(featureFlagState === FEATURE_FLAGS.VERBATIM);
+    }
+  }, [featureFlagState]);
+
+  return showMethod ? <DXExportMethod {...props} /> : <Fragment />;
+};

--- a/explorer/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
@@ -104,6 +104,7 @@ import * as MDX from "../../../../components/common/MDXContent/anvil-cmg";
 import { ExportMethod } from "../../../../components/Export/components/AnVILExplorer/ExportMethod/exportMethod";
 import { METADATA_KEY } from "../../../../components/Index/common/entities";
 import { getPluralizedMetadataLabel } from "../../../../components/Index/common/indexTransformer";
+import { FEATURE_FLAGS } from "../../../common/contants";
 import { Unused } from "../../../common/entities";
 import { SUMMARY_DISPLAY_TEXT } from "./summaryMapper/constants";
 import { mapExportSummary } from "./summaryMapper/summaryMapper";
@@ -451,10 +452,13 @@ export const buildExportEntityWarning = (
 ): React.ComponentProps<typeof C.FluidAlert> => {
   const {
     authState: { isAuthenticated },
+    exploreState: { featureFlagState },
   } = viewContext;
-  const title = isAuthenticated
-    ? "To export this dataset, please request access."
-    : "To export this dataset, please sign in and, if necessary, request access.";
+  const title = featureFlagState?.includes(FEATURE_FLAGS.VERBATIM)
+    ? isAuthenticated
+      ? "To export this dataset, please request access."
+      : "To export this dataset, please sign in and, if necessary, request access."
+    : "Export functionality is currently under development. Check back soon for updates.";
   return {
     severity: "warning",
     title,
@@ -1240,26 +1244,41 @@ export const renderWhenUnAuthorized = (
 /**
  * Renders entity related export when the given datasests response is accessible.
  * @param datasetsResponse - Response model return from datasets API.
+ * @param viewContext - View context.
  * @returns model to be used as props for the ConditionalComponent component.
  */
 export const renderExportEntity = (
-  datasetsResponse: DatasetsResponse
+  datasetsResponse: DatasetsResponse,
+  viewContext: ViewContext
 ): React.ComponentProps<typeof C.ConditionalComponent> => {
+  const {
+    exploreState: { featureFlagState },
+  } = viewContext;
   return {
-    isIn: isDatasetAccessible(datasetsResponse),
+    isIn:
+      isDatasetAccessible(datasetsResponse) &&
+      Boolean(featureFlagState?.includes(FEATURE_FLAGS.VERBATIM)),
   };
 };
 
 /**
  * Renders entity related export warning when the given datasests response is not accessible.
  * @param datasetsResponse - Response model return from datasets API.
+ * @param viewContext - View context.
  * @returns model to be used as props for the ConditionalComponent component.
  */
 export const renderExportEntityWarning = (
-  datasetsResponse: DatasetsResponse
+  datasetsResponse: DatasetsResponse,
+  viewContext: ViewContext
 ): React.ComponentProps<typeof C.ConditionalComponent> => {
+  const {
+    exploreState: { featureFlagState },
+  } = viewContext;
   return {
-    isIn: !isDatasetAccessible(datasetsResponse),
+    isIn: !(
+      isDatasetAccessible(datasetsResponse) &&
+      Boolean(featureFlagState?.includes(FEATURE_FLAGS.VERBATIM))
+    ),
   };
 };
 

--- a/explorer/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
@@ -101,6 +101,7 @@ import {
 } from "../../../../apis/azul/common/utils";
 import * as C from "../../../../components";
 import * as MDX from "../../../../components/common/MDXContent/anvil-cmg";
+import { ExportMethod } from "../../../../components/Export/components/AnVILExplorer/ExportMethod/exportMethod";
 import { METADATA_KEY } from "../../../../components/Index/common/entities";
 import { getPluralizedMetadataLabel } from "../../../../components/Index/common/indexTransformer";
 import { Unused } from "../../../common/entities";
@@ -545,7 +546,7 @@ export const buildExportMethodManifestDownload = (
 export const buildExportMethodTerra = (
   _: Unused,
   viewContext: ViewContext
-): React.ComponentProps<typeof C.ExportMethod> => {
+): React.ComponentProps<typeof ExportMethod> => {
   return {
     ...getExportMethodAccessibility(viewContext),
     buttonLabel: "Analyze in Terra",

--- a/explorer/app/viewModelBuilders/common/contants.ts
+++ b/explorer/app/viewModelBuilders/common/contants.ts
@@ -5,3 +5,6 @@ export const DATE_TIME_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
   year: "numeric",
 };
 export const DATE_TIME_LOCALES = "en-US";
+export const FEATURE_FLAGS = {
+  VERBATIM: "verbatim",
+};

--- a/explorer/site-config/anvil-cmg/dev/export/export.ts
+++ b/explorer/site-config/anvil-cmg/dev/export/export.ts
@@ -3,6 +3,7 @@ import {
   ExportConfig,
 } from "@databiosphere/findable-ui/lib/config/entities";
 import * as C from "../../../../app/components";
+import { ExportMethod } from "../../../../app/components/Export/components/AnVILExplorer/ExportMethod/exportMethod";
 import * as V from "../../../../app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders";
 import { ROUTE_EXPORT_TO_TERRA, ROUTE_MANIFEST_DOWNLOAD } from "./constants";
 import { mainColumn as exportMainColumn } from "./exportMainColumn";
@@ -72,9 +73,9 @@ export const exportConfig: ExportConfig = {
         {
           children: [
             {
-              component: C.ExportMethod,
+              component: ExportMethod,
               viewBuilder: V.buildExportMethodTerra,
-            } as ComponentConfig<typeof C.ExportMethod>,
+            } as ComponentConfig<typeof ExportMethod>,
             {
               component: C.ExportMethod,
               viewBuilder: V.buildExportMethodManifestDownload,


### PR DESCRIPTION
### Ticket
Closes #4097

### Reviewers
@NoopDog 

### Changes
- Updated filter export and dataset export to only show, with the feature flag 'verbatim'.
