### PR TITLE
chore: added system status check to anvil-cmg tests (#4108)

### DIFF
--- a/.github/workflows/run-playwright-tests-anvil-cmg.yml
+++ b/.github/workflows/run-playwright-tests-anvil-cmg.yml
@@ -17,6 +17,10 @@ jobs:
         run: |
             cd explorer
             npm ci
+      - name: Check Backend System Status
+        run: |
+            cd explorer
+            npm run check-system-status:anvil-cmg
       - name: Install Playwright Browsers
         run: |
             cd explorer

--- a/.github/workflows/run-playwright-tests-anvil-cmg.yml
+++ b/.github/workflows/run-playwright-tests-anvil-cmg.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
             cd explorer
             npm ci
-      - name: Check Backend System Status
+      - name: Check Backend System Status - TEST RESULTS ARE NOT VALID IF THIS FAILS
         run: |
             cd explorer
             npm run check-system-status:anvil-cmg
@@ -29,6 +29,10 @@ jobs:
         run: |
           cd explorer
           npm run test:anvil-cmg
+      - name: Check backend status again - TEST RESULTS ARE NOT VALID IF THIS FAILS
+        run: |
+          cd explorer
+          npm run check-system-status:anvil-cmg
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/explorer/e2e/anvil/anvil-check-system-status.ts
+++ b/explorer/e2e/anvil/anvil-check-system-status.ts
@@ -1,0 +1,12 @@
+import { checkIsIndexing } from "../checkIsIndexing";
+const ANVIL_CMG_SYSTEM_STATUS_URL =
+  "https://service.anvil.gi.ucsc.edu/health/progress";
+
+/**
+ * Check system status for Anvil-CMG
+ */
+async function anvilCheckIsIndexing(): Promise<void> {
+  await checkIsIndexing(ANVIL_CMG_SYSTEM_STATUS_URL);
+}
+
+anvilCheckIsIndexing();

--- a/explorer/e2e/checkIsIndexing.ts
+++ b/explorer/e2e/checkIsIndexing.ts
@@ -11,7 +11,7 @@ export async function checkIsIndexing(systemStatusUrl: string): Promise<void> {
     process.exit(1);
   }
   const systemStatusJson = await systemStatusResponse.json();
-  const isUp = systemStatusJson.up && systemStatusJson.progress.up;
+  const isUp = false; // systemStatusJson.up && systemStatusJson.progress.up;
   const isIndexing =
     systemStatusJson.progress.unindexed_bundles > 0 ||
     systemStatusJson.progress.unindexed_documents > 0;

--- a/explorer/e2e/checkIsIndexing.ts
+++ b/explorer/e2e/checkIsIndexing.ts
@@ -6,12 +6,12 @@ export async function checkIsIndexing(systemStatusUrl: string): Promise<void> {
   const systemStatusResponse = await fetch(systemStatusUrl);
   if (systemStatusResponse.status != 200) {
     console.log(
-      "WARNING: The System Status API is currently unavailable, or an incorrect url was passed. Tests may fail for unexpected reasons."
+      "ERROR: The System Status API is currently unavailable, or an incorrect url was passed. Please rerun tests when this is resolved."
     );
     process.exit(1);
   }
   const systemStatusJson = await systemStatusResponse.json();
-  const isUp = false; // systemStatusJson.up && systemStatusJson.progress.up;
+  const isUp = systemStatusJson.up && systemStatusJson.progress.up;
   const isIndexing =
     systemStatusJson.progress.unindexed_bundles > 0 ||
     systemStatusJson.progress.unindexed_documents > 0;

--- a/explorer/e2e/checkIsIndexing.ts
+++ b/explorer/e2e/checkIsIndexing.ts
@@ -1,0 +1,32 @@
+/**
+ * Check the system status, including whether the backend is currently indexing
+ * @param systemStatusUrl - a url to the system status api
+ */
+export async function checkIsIndexing(systemStatusUrl: string): Promise<void> {
+  const systemStatusResponse = await fetch(systemStatusUrl);
+  if (systemStatusResponse.status != 200) {
+    console.log(
+      "WARNING: The System Status API is currently unavailable, or an incorrect url was passed. Tests may fail for unexpected reasons."
+    );
+    process.exit(1);
+  }
+  const systemStatusJson = await systemStatusResponse.json();
+  const isUp = systemStatusJson.up && systemStatusJson.progress.up;
+  const isIndexing =
+    systemStatusJson.progress.unindexed_bundles > 0 ||
+    systemStatusJson.progress.unindexed_documents > 0;
+  if (!isUp) {
+    console.log(
+      "There is an issue with the backend server. Please rerun tests once this issue has been resolved. If tests have already been run, please ignore the results and try again later."
+    );
+    process.exit(1);
+  } else if (isIndexing) {
+    console.log(
+      "ERROR: The database is currently indexing, which means that tests cannot run reliably. Please rerun tests later once indexing has stopped. If tests have already been run, please ignore the results and try again after indexing has stopped."
+    );
+    process.exit(1);
+  } else {
+    console.log("The System Status is currently good!");
+    process.exit(0);
+  }
+}

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -33,7 +33,8 @@
     "test:e2e": "playwright test",
     "get-cellxgene-projects-hca": "esrun ./site-config/hca-dcp/dev/scripts/get-cellxgene-projects.ts ",
     "test:anvil-cmg": "playwright test -c playwright_anvil.config.ts --trace retain-on-failure",
-    "test:anvil-catalog": "playwright test -c playwright_anvil-catalog.config.ts --trace retain-on-failure"
+    "test:anvil-catalog": "playwright test -c playwright_anvil-catalog.config.ts --trace retain-on-failure",
+    "check-system-status:anvil-cmg": "esrun e2e/anvil/anvil-check-system-status.ts"
   },
   "dependencies": {
     "@databiosphere/findable-ui": "9.1.0",


### PR DESCRIPTION
### Ticket
Closes #4108 .

### Reviewers
@NoopDog .

### Changes
- Added a script to check the indexing status
- Added this script to the anvil-cmg tests

### Known Issues
- This check relies on the Azul `/health/progress` api, which according to the documentation "should not be requested frequently or by automated monitoring facilities that would be better served by the [/health/fast](https://service.anvil.gi.ucsc.edu/#operations-Auxiliary-get_health_fast) or [/health/cached](https://service.anvil.gi.ucsc.edu/#operations-Auxiliary-get_health_cached) endpoints." However, this api is already used to generate the indexing status alert, so I assume this isn't an issue?
