### PR TITLE
test: added anvil-catalog filter search test (#4125)

### DIFF
--- a/explorer/e2e/anvil-catalog/anvilcatalog-filters.spec.ts
+++ b/explorer/e2e/anvil-catalog/anvilcatalog-filters.spec.ts
@@ -1,0 +1,74 @@
+import { test } from "@playwright/test";
+import {
+  testDeselectFiltersThroughSearchBar,
+  testSelectFiltersThroughSearchBar,
+} from "../testFunctions";
+import {
+  anvilcatalogTabs,
+  ANVIL_CATALOG_FILTERS,
+  CONSENT_CODE_INDEX,
+  DBGAP_ID_INDEX,
+  TERRA_WORKSPACE_INDEX,
+} from "./anvilcatalog-tabs";
+
+const filterList = [CONSENT_CODE_INDEX, DBGAP_ID_INDEX, TERRA_WORKSPACE_INDEX];
+
+test('Check that selecting filters through the "Search all Filters" textbox works correctly on the Consortia tab', async ({
+  page,
+}) => {
+  await testSelectFiltersThroughSearchBar(
+    page,
+    anvilcatalogTabs.consortia,
+    filterList.map((i: number) => ANVIL_CATALOG_FILTERS[i])
+  );
+});
+
+test('Check that selecting filters through the "Search all Filters" textbox works correctly on the Studies tab', async ({
+  page,
+}) => {
+  await testSelectFiltersThroughSearchBar(
+    page,
+    anvilcatalogTabs.studies,
+    filterList.map((i: number) => ANVIL_CATALOG_FILTERS[i])
+  );
+});
+
+test('Check that selecting filters through the "Search all Filters" textbox works correctly on the Workspaces tab', async ({
+  page,
+}) => {
+  await testSelectFiltersThroughSearchBar(
+    page,
+    anvilcatalogTabs.workspaces,
+    filterList.map((i: number) => ANVIL_CATALOG_FILTERS[i])
+  );
+});
+
+test('Check that deselecting filters through the "Search all Filters" textbox works correctly on the Consortia tab', async ({
+  page,
+}) => {
+  await testDeselectFiltersThroughSearchBar(
+    page,
+    anvilcatalogTabs.consortia,
+    filterList.map((i: number) => ANVIL_CATALOG_FILTERS[i])
+  );
+});
+
+test('Check that deselecting filters through the "Search all Filters" textbox works correctly on the Studies tab', async ({
+  page,
+}) => {
+  await testDeselectFiltersThroughSearchBar(
+    page,
+    anvilcatalogTabs.studies,
+    filterList.map((i: number) => ANVIL_CATALOG_FILTERS[i])
+  );
+});
+
+test('Check that deselecting filters through the "Search all Filters" textbox works correctly on the Workspaces tab', async ({
+  page,
+}) => {
+  await testDeselectFiltersThroughSearchBar(
+    page,
+    anvilcatalogTabs.workspaces,
+    filterList.map((i: number) => ANVIL_CATALOG_FILTERS[i])
+  );
+});

--- a/explorer/e2e/anvil-catalog/anvilcatalog-filters.spec.ts
+++ b/explorer/e2e/anvil-catalog/anvilcatalog-filters.spec.ts
@@ -4,8 +4,8 @@ import {
   testSelectFiltersThroughSearchBar,
 } from "../testFunctions";
 import {
-  anvilcatalogTabs,
   ANVIL_CATALOG_FILTERS,
+  ANVIL_CATALOG_TABS,
   CONSENT_CODE_INDEX,
   DBGAP_ID_INDEX,
   TERRA_WORKSPACE_INDEX,
@@ -18,7 +18,7 @@ test('Check that selecting filters through the "Search all Filters" textbox work
 }) => {
   await testSelectFiltersThroughSearchBar(
     page,
-    anvilcatalogTabs.consortia,
+    ANVIL_CATALOG_TABS.CONSORTIA,
     filterList.map((i: number) => ANVIL_CATALOG_FILTERS[i])
   );
 });
@@ -28,7 +28,7 @@ test('Check that selecting filters through the "Search all Filters" textbox work
 }) => {
   await testSelectFiltersThroughSearchBar(
     page,
-    anvilcatalogTabs.studies,
+    ANVIL_CATALOG_TABS.STUDIES,
     filterList.map((i: number) => ANVIL_CATALOG_FILTERS[i])
   );
 });
@@ -38,7 +38,7 @@ test('Check that selecting filters through the "Search all Filters" textbox work
 }) => {
   await testSelectFiltersThroughSearchBar(
     page,
-    anvilcatalogTabs.workspaces,
+    ANVIL_CATALOG_TABS.WORKSPACES,
     filterList.map((i: number) => ANVIL_CATALOG_FILTERS[i])
   );
 });
@@ -48,7 +48,7 @@ test('Check that deselecting filters through the "Search all Filters" textbox wo
 }) => {
   await testDeselectFiltersThroughSearchBar(
     page,
-    anvilcatalogTabs.consortia,
+    ANVIL_CATALOG_TABS.CONSORTIA,
     filterList.map((i: number) => ANVIL_CATALOG_FILTERS[i])
   );
 });
@@ -58,7 +58,7 @@ test('Check that deselecting filters through the "Search all Filters" textbox wo
 }) => {
   await testDeselectFiltersThroughSearchBar(
     page,
-    anvilcatalogTabs.studies,
+    ANVIL_CATALOG_TABS.STUDIES,
     filterList.map((i: number) => ANVIL_CATALOG_FILTERS[i])
   );
 });
@@ -68,7 +68,7 @@ test('Check that deselecting filters through the "Search all Filters" textbox wo
 }) => {
   await testDeselectFiltersThroughSearchBar(
     page,
-    anvilcatalogTabs.workspaces,
+    ANVIL_CATALOG_TABS.WORKSPACES,
     filterList.map((i: number) => ANVIL_CATALOG_FILTERS[i])
   );
 });

--- a/explorer/e2e/anvil-catalog/anvilcatalog-tabs.ts
+++ b/explorer/e2e/anvil-catalog/anvilcatalog-tabs.ts
@@ -9,10 +9,33 @@ import {
   ANVIL_CATALOG_WORKSPACES_SELECTABLE_COLUMNS_BY_NAME,
 } from "./constants";
 
+const ANVIL_CATALOG_SEARCH_FILTERS_PLACEHOLDER_TEXT = "Search all filters...";
+export const ANVIL_CATALOG_FILTERS = [
+  "Consent Code",
+  "Consortium",
+  "Data Type",
+  "dbGap Id",
+  "Disease (indication)",
+  "Study Design",
+  "Study",
+  "Terra Workspace Name",
+];
+
+export const CONSENT_CODE_INDEX = 0;
+export const CONSORTIUM_INDEX = 1;
+export const DATA_TYPE_INDEX = 2;
+export const DBGAP_ID_INDEX = 3;
+export const DISEASE_INDICATION_INDEX = 4;
+export const STUDY_DESIGN_INDEX = 5;
+export const STUDY_INDEX = 6;
+export const TERRA_WORKSPACE_INDEX = 7;
+
+
 export const ANVIL_CATALOG_TABS: AnvilCatalogTabCollection = {
   CONSORTIA: {
     emptyFirstColumn: false,
     preselectedColumns: ANVIL_CATALOG_CONSORTIA_PRESELECTED_COLUMNS_BY_NAME,
+    searchFiltersPlaceholderText: ANVIL_CATALOG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
     selectableColumns: ANVIL_CATALOG_CONSORTIA_SELECTABLE_COLUMNS_BY_NAME,
     tabName: "Consortia",
     url: "/data/consortia",
@@ -20,6 +43,7 @@ export const ANVIL_CATALOG_TABS: AnvilCatalogTabCollection = {
   STUDIES: {
     emptyFirstColumn: false,
     preselectedColumns: ANVIL_CATALOG_STUDIES_PRESELECTED_COLUMNS_BY_NAME,
+    searchFiltersPlaceholderText: ANVIL_CATALOG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
     selectableColumns: ANVIL_CATALOG_STUDIES_SELECTABLE_COLUMNS_BY_NAME,
     tabName: "Studies",
     url: "/data/studies",
@@ -27,6 +51,7 @@ export const ANVIL_CATALOG_TABS: AnvilCatalogTabCollection = {
   WORKSPACES: {
     emptyFirstColumn: false,
     preselectedColumns: ANVIL_CATALOG_WORKSPACES_PRESELECTED_COLUMNS_BY_NAME,
+    searchFiltersPlaceholderText: ANVIL_CATALOG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
     selectableColumns: ANVIL_CATALOG_WORKSPACES_SELECTABLE_COLUMNS_BY_NAME,
     tabName: "Workspaces",
     url: "/data/workspaces",

--- a/explorer/e2e/anvil-catalog/anvilcatalog-tabs.ts
+++ b/explorer/e2e/anvil-catalog/anvilcatalog-tabs.ts
@@ -30,7 +30,6 @@ export const STUDY_DESIGN_INDEX = 5;
 export const STUDY_INDEX = 6;
 export const TERRA_WORKSPACE_INDEX = 7;
 
-
 export const ANVIL_CATALOG_TABS: AnvilCatalogTabCollection = {
   CONSORTIA: {
     emptyFirstColumn: false,

--- a/explorer/e2e/anvil/anvil-tabs.ts
+++ b/explorer/e2e/anvil/anvil-tabs.ts
@@ -43,11 +43,14 @@ export const ORGANISM_TYPE_INDEX = 8;
 export const PHENOTYPIC_SEX_INDEX = 9;
 export const REPORTED_ETHNICITY_INDEX = 10;
 
+const ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT = "Search all filters...";
+
 export const ANVIL_TABS: AnvilCMGTabCollection = {
   ACTIVITIES: {
     emptyFirstColumn: false,
     maxPages: 25,
     preselectedColumns: ANVIL_ACTIVITIES_PRESELECTED_COLUMNS_BY_NAME,
+    searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
     selectableColumns: ANVIL_ACTIVITIES_SELECTABLE_COLUMNS_BY_NAME,
     tabName: "Activities",
     url: "/activities",
@@ -56,6 +59,7 @@ export const ANVIL_TABS: AnvilCMGTabCollection = {
     emptyFirstColumn: false,
     maxPages: 25,
     preselectedColumns: ANVIL_BIOSAMPLES_PRESELECTED_COLUMNS_BY_NAME,
+    searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
     selectableColumns: ANVIL_BIOSAMPLES_SELECTABLE_COLUMNS_BY_NAME,
     tabName: "BioSamples",
     url: "/biosamples",
@@ -130,6 +134,7 @@ export const ANVIL_TABS: AnvilCMGTabCollection = {
     emptyFirstColumn: false,
     maxPages: 25,
     preselectedColumns: ANVIL_DATASETS_PRESELECTED_COLUMNS_BY_NAME,
+    searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
     selectableColumns: ANVIL_DATASETS_SELECTABLE_COLUMNS_BY_NAME,
     tabName: "Datasets",
     url: "/datasets",
@@ -138,6 +143,7 @@ export const ANVIL_TABS: AnvilCMGTabCollection = {
     emptyFirstColumn: false,
     maxPages: 25,
     preselectedColumns: ANVIL_DONORS_PRESELECTED_COLUMNS_BY_NAME,
+    searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
     selectableColumns: ANVIL_DONORS_SELECTABLE_COLUMNS_BY_NAME,
     tabName: "Donors",
     url: "/donors",
@@ -146,6 +152,7 @@ export const ANVIL_TABS: AnvilCMGTabCollection = {
     emptyFirstColumn: true,
     maxPages: 25,
     preselectedColumns: ANVIL_FILES_PRESELECTED_COLUMNS_BY_NAME,
+    searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
     selectableColumns: ANVIL_DONORS_SELECTABLE_COLUMNS_BY_NAME,
     tabName: "Files",
     url: "/files",

--- a/explorer/e2e/testFunctions.ts
+++ b/explorer/e2e/testFunctions.ts
@@ -616,7 +616,7 @@ export async function testFilterTags(
  * those filters to become deselected
  * @param page - a Playwright page object
  * @param tab - the tab object to test on
- * @param filterNames - the names of the fitlers to check
+ * @param filterNames - the names of the filters to check
  */
 export async function testClearAll(
   page: Page,
@@ -669,6 +669,7 @@ export async function testSelectFiltersThroughSearchBar(
 ): Promise<void> {
   await page.goto(tab.url);
   for (const filterName of filterNames) {
+    // Get the first filter option
     await expect(page.getByText(filterRegex(filterName))).toBeVisible();
     await page.getByText(filterRegex(filterName)).dispatchEvent("click");
     const firstFilterOptionLocator = getFirstFilterOptionLocator(page);
@@ -677,16 +678,18 @@ export async function testSelectFiltersThroughSearchBar(
       firstFilterOptionLocator
     );
     await page.locator("body").click();
-
+    // Search for the filter option
     const searchFiltersInputLocator = page.getByPlaceholder(
       tab.searchFiltersPlaceholderText,
       { exact: true }
     );
     await expect(searchFiltersInputLocator).toBeVisible();
     await searchFiltersInputLocator.fill(filterOptionName);
+    // Select a filter option with a matching name
     await getNamedFilterOptionLocator(page, filterOptionName).first().click();
     await page.locator("body").click();
     const filterTagLocator = getFilterTagLocator(page, filterOptionName);
+    // Check the filter tag is selected and click it to reset the filter
     await expect(filterTagLocator).toBeVisible();
     await filterTagLocator.dispatchEvent("click");
   }
@@ -705,8 +708,8 @@ export async function testDeselectFiltersThroughSearchBar(
   filterNames: string[]
 ): Promise<void> {
   await page.goto(tab.url);
-  const filterOptionNames: string[] = [];
   for (const filterName of filterNames) {
+    // Select each filter option
     await expect(page.getByText(filterRegex(filterName))).toBeVisible();
     await page.getByText(filterRegex(filterName)).dispatchEvent("click");
     const firstFilterOptionLocator = getFirstFilterOptionLocator(page);
@@ -714,23 +717,21 @@ export async function testDeselectFiltersThroughSearchBar(
       page,
       firstFilterOptionLocator
     );
-    filterOptionNames.push(filterOptionName);
     await firstFilterOptionLocator.click();
     await page.locator("body").click();
-  }
-  for (let i = 0; i < filterOptionNames.length; i++) {
+    // Search for and check the selected filter
     const searchFiltersInputLocator = page.getByPlaceholder(
       tab.searchFiltersPlaceholderText,
       { exact: true }
     );
     await expect(searchFiltersInputLocator).toBeVisible();
-    await searchFiltersInputLocator.fill(filterOptionNames[i]);
-    await getNamedFilterOptionLocator(page, filterOptionNames[i])
+    await searchFiltersInputLocator.fill(filterOptionName);
+    await getNamedFilterOptionLocator(page, filterOptionName)
       .locator("input[type='checkbox']:checked")
       .first()
       .click();
     await page.locator("body").click();
-    const filterTagLocator = getFilterTagLocator(page, filterOptionNames[i]);
+    const filterTagLocator = getFilterTagLocator(page, filterOptionName);
     await expect(filterTagLocator).not.toBeVisible();
   }
 }

--- a/explorer/e2e/testInterfaces.ts
+++ b/explorer/e2e/testInterfaces.ts
@@ -9,6 +9,7 @@ export interface TabDescription {
   emptyFirstColumn: boolean;
   maxPages?: number;
   preselectedColumns: StringToColumnDescription;
+  searchFiltersPlaceholderText: string;
   selectableColumns: StringToColumnDescription;
   tabName: string;
   url: string;

--- a/explorer/e2e/testReadme.md
+++ b/explorer/e2e/testReadme.md
@@ -99,6 +99,11 @@ through the actions taken as part of the test and view the impact on the web pag
     - Runs on all tabs
   - Check that selecting all checkboxes in the Edit Columns menu adds the correct headers to the table
     - Only runs on the "Consortia" tab (other tabs do not have editable columns)
+- Filters (`anvilcatalog-filters.spec.ts`)
+  - Search filters bar
+    - Check that filters can be selected through the search bar
+    - Check that filters can be deselected through the search bar
+    - Both tests run on all tabs
 - All tests rely on correct lists of tabs, columns, and filters in `anvilcatalog-tabs.ts`
 
 ### Candidate Additional Tests (anvil-cmg):


### PR DESCRIPTION
Added "Search all filters" tests to AnVIL-Catalog

### Ticket
Closes #4125 .

### Reviewers
@MillenniumFalconMechanic .

### Changes
- Added filter related constants to `anvilcatalog-tabs.ts`
- Added a test to
  - Select an arbitrary filter
  - Read the first filter option
  - Exit the filter menu
  - Search for that filter, and select it
  - Ensure filter label appears and that filter appears checked in the filter menu
  - Repeat for 3 filters
- Added another test to
  - Select an arbitrary filter
  - Check the first filter option
  - Exit the filter menu
  - Search for that filter, and deselect it
  - Ensure that the filter label appears unchecked
  - Repeat for 3 filters

