### PR TITLE
feat: remove archive preview (#4134)

### DIFF
--- a/explorer/app/components/Detail/components/GeneratedMatricesTables/components/FileNameCell/fileNameCell.tsx
+++ b/explorer/app/components/Detail/components/GeneratedMatricesTables/components/FileNameCell/fileNameCell.tsx
@@ -7,13 +7,13 @@ export interface FileNameCellProps {
 }
 
 export const FileNameCell = ({
-  archivePreview,
+  // archivePreview,
   fileName,
 }: FileNameCellProps): JSX.Element => {
   return (
     <Cell>
       {fileName}
-      {archivePreview}
+      {/*{archivePreview}*/}
     </Cell>
   );
 };


### PR DESCRIPTION
### Ticket
Closes #4134.

### Reviewers
@NoopDog.

### Changes
- Removed archive preview from matrices.

<img width="2365" alt="image" src="https://github.com/user-attachments/assets/fd11ef54-94fb-4c49-90f9-a2d51e7cecf7">

See [The Tabula Sapiens: A multiple-organ, single-cell transcriptomic atlas of humans](https://explore.data.humancellatlas.org/projects/10201832-7c73-4033-9b65-3ef13d81656a/project-matrices)

<img width="2365" alt="image" src="https://github.com/user-attachments/assets/dada3440-fe34-44ba-9240-023e2ca82bc6">
