### PR TITLE
test: create tests for index export button (#4117)

### DIFF
--- a/explorer/e2e/anvil/anvil-backpages.spec.ts
+++ b/explorer/e2e/anvil/anvil-backpages.spec.ts
@@ -11,14 +11,24 @@ test.skip("Smoke test `Export to Terra` button on the first available dataset", 
   page,
 }) => {
   test.setTimeout(120000);
-  await testExportBackpage(context, page, ANVIL_TABS.DATASETS);
+  const testResult = await testExportBackpage(
+    context,
+    page,
+    ANVIL_TABS.DATASETS
+  );
+  if (!testResult) {
+    test.fail();
+  }
 });
 
 test.skip("Check access controls on the datasets backpages work for the first two tabs", async ({
   page,
 }) => {
   test.setTimeout(120000);
-  await testBackpageAccess(page, ANVIL_TABS.DATASETS);
+  const testResult = await testBackpageAccess(page, ANVIL_TABS.DATASETS);
+  if (!testResult) {
+    test.fail();
+  }
 });
 
 test("Check that information on the backpages matches information in the data tables", async ({

--- a/explorer/e2e/anvil/anvil-index-export-button.spec.ts
+++ b/explorer/e2e/anvil/anvil-index-export-button.spec.ts
@@ -1,18 +1,27 @@
 import test from "@playwright/test";
 import {
+  testBulkDownloadIndexExportWorkflow,
   testIndexExportSummary,
-  testIndexExportWorkflow,
 } from "../testFunctions";
 import { ANVIL_TABS } from "./anvil-tabs";
 
 test("Smoke test File Manifest Request index export workflow on the Files tab", async ({
   page,
 }) => {
-  await testIndexExportWorkflow(page, ANVIL_TABS.FILES);
+  const testResult = await testBulkDownloadIndexExportWorkflow(
+    page,
+    ANVIL_TABS.FILES
+  );
+  if (!testResult) {
+    test.fail();
+  }
 });
 
 test("Check that figures in the Selected Data Summary tab on the index export page matches figures on the index page on the BioSamples tab", async ({
   page,
 }) => {
-  await testIndexExportSummary(page, ANVIL_TABS.BIOSAMPLES);
+  const testResult = await testIndexExportSummary(page, ANVIL_TABS.BIOSAMPLES);
+  if (!testResult) {
+    test.fail();
+  }
 });

--- a/explorer/e2e/anvil/anvil-index-export-button.spec.ts
+++ b/explorer/e2e/anvil/anvil-index-export-button.spec.ts
@@ -5,13 +5,13 @@ import {
 } from "../testFunctions";
 import { ANVIL_TABS } from "./anvil-tabs";
 
-test("Check that the export button on the index page functions as expected, on the Files tab", async ({
+test("Smoke test File Manifest Request index export workflow on the Diles tab", async ({
   page,
 }) => {
   await testIndexExportWorkflow(page, ANVIL_TABS.FILES);
 });
 
-test("Check that figures in the details tab on the index export page matches figures on the index page, on the BioSamples tab", async ({
+test("Check that figures in the details tab on the index export page matches figures on the index page on the BioSamples tab", async ({
   page,
 }) => {
   await testIndexExportDetails(page, ANVIL_TABS.BIOSAMPLES);

--- a/explorer/e2e/anvil/anvil-index-export-button.spec.ts
+++ b/explorer/e2e/anvil/anvil-index-export-button.spec.ts
@@ -8,6 +8,7 @@ import { ANVIL_TABS } from "./anvil-tabs";
 test("Smoke test File Manifest Request index export workflow on the Files tab", async ({
   page,
 }) => {
+  test.setTimeout(120000);
   const testResult = await testBulkDownloadIndexExportWorkflow(
     page,
     ANVIL_TABS.FILES

--- a/explorer/e2e/anvil/anvil-index-export-button.spec.ts
+++ b/explorer/e2e/anvil/anvil-index-export-button.spec.ts
@@ -5,7 +5,7 @@ import {
 } from "../testFunctions";
 import { ANVIL_TABS } from "./anvil-tabs";
 
-test("Smoke test File Manifest Request index export workflow on the Diles tab", async ({
+test("Smoke test File Manifest Request index export workflow on the Files tab", async ({
   page,
 }) => {
   await testIndexExportWorkflow(page, ANVIL_TABS.FILES);

--- a/explorer/e2e/anvil/anvil-index-export-button.spec.ts
+++ b/explorer/e2e/anvil/anvil-index-export-button.spec.ts
@@ -1,6 +1,6 @@
 import test from "@playwright/test";
 import {
-  testIndexExportDetails,
+  testIndexExportSummary,
   testIndexExportWorkflow,
 } from "../testFunctions";
 import { ANVIL_TABS } from "./anvil-tabs";
@@ -11,8 +11,8 @@ test("Smoke test File Manifest Request index export workflow on the Diles tab", 
   await testIndexExportWorkflow(page, ANVIL_TABS.FILES);
 });
 
-test("Check that figures in the details tab on the index export page matches figures on the index page on the BioSamples tab", async ({
+test("Check that figures in the Selected Data Summary tab on the index export page matches figures on the index page on the BioSamples tab", async ({
   page,
 }) => {
-  await testIndexExportDetails(page, ANVIL_TABS.BIOSAMPLES);
+  await testIndexExportSummary(page, ANVIL_TABS.BIOSAMPLES);
 });

--- a/explorer/e2e/anvil/anvil-main-export-button.spec.ts
+++ b/explorer/e2e/anvil/anvil-main-export-button.spec.ts
@@ -1,0 +1,18 @@
+import test from "@playwright/test";
+import {
+  testIndexExportDetails,
+  testIndexExportWorkflow,
+} from "../testFunctions";
+import { ANVIL_TABS } from "./anvil-tabs";
+
+test("Check that the export button on the index page functions as expected, on the Files tab", async ({
+  page,
+}) => {
+  await testIndexExportWorkflow(page, ANVIL_TABS.FILES);
+});
+
+test("Check that figures in the details tab on the index export page matches figures on the index page, on the BioSamples tab", async ({
+  page,
+}) => {
+  await testIndexExportDetails(page, ANVIL_TABS.BIOSAMPLES);
+});

--- a/explorer/e2e/anvil/anvil-tabs.ts
+++ b/explorer/e2e/anvil/anvil-tabs.ts
@@ -46,23 +46,22 @@ export const REPORTED_ETHNICITY_INDEX = 10;
 
 const ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT = "Search all filters...";
 
-export const anvilIndexExportButtons: IndexExportButtons = {
+export const ANVIL_INDEX_EXPORT_BUTTONS: IndexExportButtons = {
+  actionLandingMessage: "Confirm Organism Type and Manifest File Formats",
   detailsName: "Selected Data Summary",
   detailsToCheck: ["BioSamples", "Donors", "Files"],
   exportActionButtonText: "Download Manifest",
   exportOptionButtonText: "Request File Manifest",
   exportRequestButtonText: "Prepare Manifest",
-  firstLandingMessage:
-    "Download a File Manifest with Metadata for the Selected Data",
   indexExportButtonText: "Export",
-  secondLandingMessage: "Confirm Organism Type and Manifest File Formats",
-  secondLoadingMessage: "Your manifest will be ready shortly...",
+  requestLandingMessage:
+    "Download a File Manifest with Metadata for the Selected Data",
 };
 
 export const ANVIL_TABS: AnvilCMGTabCollection = {
   ACTIVITIES: {
     emptyFirstColumn: false,
-    indexExportPage: anvilIndexExportButtons,
+    indexExportPage: ANVIL_INDEX_EXPORT_BUTTONS,
     maxPages: 25,
     preselectedColumns: ANVIL_ACTIVITIES_PRESELECTED_COLUMNS_BY_NAME,
     searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
@@ -72,7 +71,7 @@ export const ANVIL_TABS: AnvilCMGTabCollection = {
   },
   BIOSAMPLES: {
     emptyFirstColumn: false,
-    indexExportPage: anvilIndexExportButtons,
+    indexExportPage: ANVIL_INDEX_EXPORT_BUTTONS,
     maxPages: 25,
     preselectedColumns: ANVIL_BIOSAMPLES_PRESELECTED_COLUMNS_BY_NAME,
     searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
@@ -90,15 +89,16 @@ export const ANVIL_TABS: AnvilCMGTabCollection = {
     backpageExportButtons: {
       accessNotGrantedMessage:
         "To export this dataset, please sign in and, if necessary, request access.",
+      actionLandingMessage: "Your Terra Workspace Link is Ready",
       detailsName: "Dataset Details",
       exportActionButtonText: "Open Terra",
       exportRequestButtonText: "Request Link",
       exportTabName: "Export",
       exportUrlRegExp: /\.*\/export-to-terra/,
-      firstLoadingMessage: "Your link will be ready shortly...",
       newTabMessage:
         "If you are a new user or returning user, click sign in to continue.",
-      secondLandingMessage: "Your Terra Workspace Link is Ready",
+      requestLandingMessage:
+        "Terra is a biomedical research platform to analyze data using workflows, Jupyter Notebooks, RStudio, and Galaxy.",
     },
     backpageHeaders: [
       {
@@ -148,7 +148,7 @@ export const ANVIL_TABS: AnvilCMGTabCollection = {
       },
     ],
     emptyFirstColumn: false,
-    indexExportPage: anvilIndexExportButtons,
+    indexExportPage: ANVIL_INDEX_EXPORT_BUTTONS,
     maxPages: 25,
     preselectedColumns: ANVIL_DATASETS_PRESELECTED_COLUMNS_BY_NAME,
     searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
@@ -158,7 +158,7 @@ export const ANVIL_TABS: AnvilCMGTabCollection = {
   },
   DONORS: {
     emptyFirstColumn: false,
-    indexExportPage: anvilIndexExportButtons,
+    indexExportPage: ANVIL_INDEX_EXPORT_BUTTONS,
     maxPages: 25,
     preselectedColumns: ANVIL_DONORS_PRESELECTED_COLUMNS_BY_NAME,
     searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
@@ -168,7 +168,7 @@ export const ANVIL_TABS: AnvilCMGTabCollection = {
   },
   FILES: {
     emptyFirstColumn: true,
-    indexExportPage: anvilIndexExportButtons,
+    indexExportPage: ANVIL_INDEX_EXPORT_BUTTONS,
     maxPages: 25,
     preselectedColumns: ANVIL_FILES_PRESELECTED_COLUMNS_BY_NAME,
     searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,

--- a/explorer/e2e/anvil/anvil-tabs.ts
+++ b/explorer/e2e/anvil/anvil-tabs.ts
@@ -1,6 +1,7 @@
 /* eslint-disable sonarjs/no-duplicate-string  -- ignoring duplicate strings here */
 import {
   AnvilCMGTabCollection,
+  IndexExportButtons,
   TabCollectionKeys,
   TabDescription,
 } from "../testInterfaces";
@@ -45,9 +46,23 @@ export const REPORTED_ETHNICITY_INDEX = 10;
 
 const ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT = "Search all filters...";
 
+export const anvilIndexExportButtons: IndexExportButtons = {
+  detailsName: "Selected Data Summary",
+  detailsToCheck: ["BioSamples", "Donors", "Files"],
+  exportActionButtonText: "Download Manifest",
+  exportOptionButtonText: "Request File Manifest",
+  exportRequestButtonText: "Prepare Manifest",
+  firstLandingMessage:
+    "Download a File Manifest with Metadata for the Selected Data",
+  indexExportButtonText: "Export",
+  secondLandingMessage: "Confirm Organism Type and Manifest File Formats",
+  secondLoadingMessage: "Your manifest will be ready shortly...",
+};
+
 export const ANVIL_TABS: AnvilCMGTabCollection = {
   ACTIVITIES: {
     emptyFirstColumn: false,
+    indexExportPage: anvilIndexExportButtons,
     maxPages: 25,
     preselectedColumns: ANVIL_ACTIVITIES_PRESELECTED_COLUMNS_BY_NAME,
     searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
@@ -57,6 +72,7 @@ export const ANVIL_TABS: AnvilCMGTabCollection = {
   },
   BIOSAMPLES: {
     emptyFirstColumn: false,
+    indexExportPage: anvilIndexExportButtons,
     maxPages: 25,
     preselectedColumns: ANVIL_BIOSAMPLES_PRESELECTED_COLUMNS_BY_NAME,
     searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
@@ -132,6 +148,7 @@ export const ANVIL_TABS: AnvilCMGTabCollection = {
       },
     ],
     emptyFirstColumn: false,
+    indexExportPage: anvilIndexExportButtons,
     maxPages: 25,
     preselectedColumns: ANVIL_DATASETS_PRESELECTED_COLUMNS_BY_NAME,
     searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
@@ -141,6 +158,7 @@ export const ANVIL_TABS: AnvilCMGTabCollection = {
   },
   DONORS: {
     emptyFirstColumn: false,
+    indexExportPage: anvilIndexExportButtons,
     maxPages: 25,
     preselectedColumns: ANVIL_DONORS_PRESELECTED_COLUMNS_BY_NAME,
     searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
@@ -150,6 +168,7 @@ export const ANVIL_TABS: AnvilCMGTabCollection = {
   },
   FILES: {
     emptyFirstColumn: true,
+    indexExportPage: anvilIndexExportButtons,
     maxPages: 25,
     preselectedColumns: ANVIL_FILES_PRESELECTED_COLUMNS_BY_NAME,
     searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,

--- a/explorer/e2e/testFunctions.ts
+++ b/explorer/e2e/testFunctions.ts
@@ -1142,7 +1142,7 @@ export async function testIndexExportWorkflow(
   //TODO: validate the results from the downnload
 }
 
-export async function testIndexExportDetails(
+export async function testIndexExportSummary(
   page: Page,
   tab: TabDescription
 ): Promise<boolean> {

--- a/explorer/e2e/testFunctions.ts
+++ b/explorer/e2e/testFunctions.ts
@@ -1088,7 +1088,7 @@ export async function testBulkDownloadIndexExportWorkflow(
   await expect(exportButtonLocator).toBeVisible();
   await exportButtonLocator.click();
   await expect(
-    page.getByText(tab.indexExportPage.requestLandingMessage ?? "")
+    page.getByText(tab.indexExportPage.requestLandingMessage)
   ).toBeVisible();
   await expect(
     page.getByRole("link", {
@@ -1107,7 +1107,7 @@ export async function testBulkDownloadIndexExportWorkflow(
   const exportActionButtonLocator = page.getByRole("link", {
     name: tab.indexExportPage?.exportActionButtonText,
   });
-  await expect(exportActionButtonLocator).toBeEnabled();
+  await expect(exportActionButtonLocator).toBeEnabled({ timeout: 60000 });
   const downloadPromise = page.waitForEvent("download", { timeout: 10000 }); // This timeout is necessary, as otherwise the test will wait for the global test timeout
   await exportActionButtonLocator.click();
   const download = await downloadPromise;

--- a/explorer/e2e/testInterfaces.ts
+++ b/explorer/e2e/testInterfaces.ts
@@ -51,13 +51,11 @@ export interface BackpageAccessTags {
 }
 
 export interface ExportButtonInfo {
+  actionLandingMessage: string;
   detailsName: string;
   exportActionButtonText: string;
   exportRequestButtonText: string;
-  firstLandingMessage?: string; //TODO: rename to requestLoadingMessage
-  firstLoadingMessage?: string;
-  secondLandingMessage?: string; //TODO: rename to actionLaodingMessage
-  secondLoadingMessage?: string;
+  requestLandingMessage: string;
 }
 
 export interface BackpageExportButtons extends ExportButtonInfo {

--- a/explorer/e2e/testInterfaces.ts
+++ b/explorer/e2e/testInterfaces.ts
@@ -7,6 +7,7 @@ export interface TabDescription {
   backpageExportButtons?: BackpageExportButtons;
   backpageHeaders?: BackpageHeader[];
   emptyFirstColumn: boolean;
+  indexExportPage?: IndexExportButtons;
   maxPages?: number;
   preselectedColumns: StringToColumnDescription;
   searchFiltersPlaceholderText: string;
@@ -49,14 +50,27 @@ export interface BackpageAccessTags {
   grantedShortName: string;
 }
 
-export interface BackpageExportButtons {
-  accessNotGrantedMessage: string;
+export interface ExportButtonInfo {
   detailsName: string;
   exportActionButtonText: string;
   exportRequestButtonText: string;
+  firstLandingMessage?: string; //TODO: rename to requestLoadingMessage
+  firstLoadingMessage?: string;
+  secondLandingMessage?: string; //TODO: rename to actionLaodingMessage
+  secondLoadingMessage?: string;
+}
+
+export interface BackpageExportButtons extends ExportButtonInfo {
+  accessNotGrantedMessage: string;
   exportTabName: string;
   exportUrlRegExp: RegExp;
-  firstLoadingMessage: string;
   newTabMessage: string;
-  secondLandingMessage: string;
+}
+
+//TODO: might need to make it so that there's an interface with indexExportButtonText
+// and a list of other objects that go to different export pages for this to work with HCA
+export interface IndexExportButtons extends ExportButtonInfo {
+  detailsToCheck: string[];
+  exportOptionButtonText: string;
+  indexExportButtonText: string;
 }

--- a/explorer/e2e/testReadme.md
+++ b/explorer/e2e/testReadme.md
@@ -85,7 +85,7 @@ through the actions taken as part of the test and view the impact on the web pag
     - Requires a list of the values in the sidebar to be present in `anvil-tabs.ts` and that plural labels are defined there for any columns that include n-tag cells
 - Index Export (`anvil-index-export-button.spec.ts`)
   - Test the "File Manifest Request" workflow works
-    - Runs through the export workfl.ow for "File Manifest Request" Workflow, checking that loading screens and text appear correctly on each page
+    - Runs through the export workflow for "File Manifest Request" workflow, checking that loading screens and text appear correctly on each page
     - Checks that a download occurs when the "Download Manifest" is clicked
     - Runs only on the Files tab
   - Tests that the counts in the "Selected Data Summary" box match the counts on the index page

--- a/explorer/e2e/testReadme.md
+++ b/explorer/e2e/testReadme.md
@@ -83,6 +83,14 @@ through the actions taken as part of the test and view the impact on the web pag
   - Test that data in the sidebar of the "Datasets" tab is the same as the text displayed in the main table
     - Enables all non-preselected columns and read values from all columns in the first row, including n-tag cells. Then selects the backpage for the first row and checks that all matching columns are reflected
     - Requires a list of the values in the sidebar to be present in `anvil-tabs.ts` and that plural labels are defined there for any columns that include n-tag cells
+- Index Export (`anvil-index-export-button.spec.ts`)
+  - Test the "File Manifest Request" workflow works
+    - Runs through the export workfl.ow for "File Manifest Request" Workflow, checking that loading screens and text appear correctly on each page
+    - Checks that a download occurs when the "Download Manifest" is clicked
+    - Runs only on the Files tab
+  - Tests that the counts in the "Selected Data Summary" box match the counts on the index page
+    - Does not apply filters
+    - Runs only on the BioSamples tab
 
 #### AnVIL-Catalog
 


### PR DESCRIPTION
### Ticket
Closes #4117.

### Reviewers
@NoopDog .

### Changes
- Added the following tests for the "index" export page:
- Workflow smoke test
  - Click the "Export" button
  - Click the "Request File Manifest" button
  - Select one checkbox from the File Format table and all possible Organism Type checkboxes
  - Click the "Prepare Manifest" button
  - Click the "Download Manifest" Button
  - Check that a file downloads
- Selected Data Summary test
  - Read the counts next to the Index Export Button (see screenshot)
  - Click the "Export" button
  - Check that the counts on the index page match the counts under "Selected Data Summary"
 
<img width="1440" alt="Screenshot 2024-10-30 at 2 25 16 PM" src="https://github.com/user-attachments/assets/0c0e5a0c-4434-463c-bb45-70690c31b7d2">

### Questions
 - Should we attempt to capture the download from the "Download Manifest" button, and if so, should we make any checks about it? Right now the download is made but we do not check the file name or size
