### PR TITLE
feat: add biological network to project detail page rhs (#4145)

### DIFF
--- a/explorer/app/apis/azul/hca-dcp/common/entities.ts
+++ b/explorer/app/apis/azul/hca-dcp/common/entities.ts
@@ -96,6 +96,7 @@ export interface ProjectResponse {
   projectTitle: string;
   publications: PublicationResponse[];
   supplementaryLinks: (string | null)[];
+  tissueAtlas: TissueAtlasResponse[];
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO - revisit nested Azul structure.
@@ -152,4 +153,12 @@ export interface SampleResponse {
  */
 export interface SamplesEntityResponse {
   samples: SampleResponse[];
+}
+
+/**
+ * Model of tissueAtlas value in the response from index/projects API endpoint.
+ */
+export interface TissueAtlasResponse {
+  atlas: string | null;
+  version: string;
 }

--- a/explorer/app/components/Detail/components/Section/components/AtlasSection/atlasSection.styles.ts
+++ b/explorer/app/components/Detail/components/Section/components/AtlasSection/atlasSection.styles.ts
@@ -1,0 +1,9 @@
+import { GridPaperSection } from "@databiosphere/findable-ui/lib/components/common/Section/section.styles";
+import styled from "@emotion/styled";
+
+export const StyledSection = styled(GridPaperSection)`
+  img {
+    box-sizing: content-box;
+    padding: 4px;
+  }
+`;

--- a/explorer/app/components/Detail/components/Section/components/AtlasSection/atlasSection.tsx
+++ b/explorer/app/components/Detail/components/Section/components/AtlasSection/atlasSection.tsx
@@ -1,0 +1,33 @@
+import { SectionTitle } from "@databiosphere/findable-ui/lib/components/common/Section/components/SectionTitle/sectionTitle";
+import { TEXT_BODY_400 } from "@databiosphere/findable-ui/lib/theme/common/typography";
+import { Grid2, Typography } from "@mui/material";
+import { NetworkIcon } from "../../../../../common/NetworkIcon/networkIcon";
+import { StyledSection } from "./atlasSection.styles";
+import { GRID_PROPS } from "./constants";
+import { Atlas } from "./types";
+
+interface AtlasProps {
+  atlases: Atlas[];
+}
+
+export const AtlasSection = ({ atlases }: AtlasProps): JSX.Element => {
+  return (
+    <StyledSection>
+      <Grid2 {...GRID_PROPS.COLUMN} spacing={4}>
+        <SectionTitle title="Atlas" />
+        <Grid2 {...GRID_PROPS.COLUMN} spacing={2}>
+          {atlases.length > 0 ? (
+            atlases.map(({ atlasName, networkKey }, i) => (
+              <Grid2 key={i} alignItems="center" container spacing={2}>
+                <NetworkIcon networkKey={networkKey} />
+                <Typography variant={TEXT_BODY_400}>{atlasName}</Typography>
+              </Grid2>
+            ))
+          ) : (
+            <Typography variant={TEXT_BODY_400}>None</Typography>
+          )}
+        </Grid2>
+      </Grid2>
+    </StyledSection>
+  );
+};

--- a/explorer/app/components/Detail/components/Section/components/AtlasSection/constants.ts
+++ b/explorer/app/components/Detail/components/Section/components/AtlasSection/constants.ts
@@ -1,0 +1,8 @@
+import { Grid2Props } from "@mui/material";
+
+export const GRID_PROPS: Record<
+  string,
+  Partial<Omit<Grid2Props, "component">>
+> = {
+  COLUMN: { container: true, direction: "column" },
+};

--- a/explorer/app/components/Detail/components/Section/components/AtlasSection/types.ts
+++ b/explorer/app/components/Detail/components/Section/components/AtlasSection/types.ts
@@ -1,0 +1,6 @@
+import { NetworkKey } from "../../../../../Index/common/entities";
+
+export interface Atlas {
+  atlasName: string;
+  networkKey: NetworkKey;
+}

--- a/explorer/app/components/Index/common/utils.ts
+++ b/explorer/app/components/Index/common/utils.ts
@@ -1,6 +1,8 @@
 import { AzulSummaryResponse } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
 import { FileFormat } from "../../../apis/azul/anvil-cmg/common/entities";
 import { ProjectSummary } from "../../../apis/azul/hca-dcp/common/entities";
+import { NETWORK_KEYS } from "./constants";
+import { NetworkKey } from "./entities";
 
 /**
  * Calculates the summary file format count using count values returned for each file format in the summary response.
@@ -58,4 +60,14 @@ export function getSummaryCount(
   summaryKey: keyof AzulSummaryResponse
 ): number {
   return summaryResponse[summaryKey] as number;
+}
+
+/**
+ * Type guard for NetworkKey.
+ * @param value - Value.
+ * @returns true if value is a NetworkKey.
+ */
+export function isNetworkKey(value: unknown): value is NetworkKey {
+  if (typeof value !== "string") return false;
+  return (NETWORK_KEYS as readonly string[]).includes(value);
 }

--- a/explorer/app/components/index.tsx
+++ b/explorer/app/components/index.tsx
@@ -92,6 +92,7 @@ export { FileLocationCopy } from "./Detail/components/GeneratedMatricesTables/co
 export { FileLocationDownload } from "./Detail/components/GeneratedMatricesTables/components/FileLocationDownload/fileLocationDownload";
 export { FileNameCell } from "./Detail/components/GeneratedMatricesTables/components/FileNameCell/fileNameCell";
 export { GeneratedMatricesTables } from "./Detail/components/GeneratedMatricesTables/generatedMatricesTables";
+export { AtlasSection } from "./Detail/components/Section/components/AtlasSection/atlasSection";
 export { ManifestDownloadEntity as AnVILManifestDownloadEntity } from "./Export/components/AnVILExplorer/components/ManifestDownload/components/ManifestDownloadEntity/manifestDownloadEntity";
 export { BioNetworkCell } from "./Index/components/BioNetworkCell/bioNetworkCell";
 export { ConsentCodesCell } from "./Index/components/ConsentCodesCell/consentCodesCell";

--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/projectMapper/projectMapper.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/projectMapper/projectMapper.ts
@@ -11,6 +11,8 @@ import {
   ProjectResponse,
   PublicationResponse,
 } from "../../../../../apis/azul/hca-dcp/common/entities";
+import { Atlas } from "../../../../../components/Detail/components/Section/components/AtlasSection/types";
+import { isNetworkKey } from "../../../../../components/Index/common/utils";
 import { CONTRIBUTOR_ROLE } from "./constants";
 import { AnalysisPortal, ProjectEdit } from "./projectEdits/entities";
 import { projectEdits } from "./projectEdits/projectEdits";
@@ -28,6 +30,23 @@ export function mapProjectAnalysisPortals(
   }
   const { analysisPortals } = getProjectEdit(projectResponse.projectId) || {};
   return analysisPortals;
+}
+
+/**
+ * Maps project tissue atlases from the project response to network key and corresponding atlas name.
+ * @param projectResponse - Response model return from project API.
+ * @returns list of atlas with network key and atlas name.
+ */
+export function mapProjectAtlas(projectResponse?: ProjectResponse): Atlas[] {
+  if (!projectResponse) return [];
+  return projectResponse.tissueAtlas.reduce((acc, { atlas, version }, i) => {
+    if (!atlas) return acc;
+    const networkKey = projectResponse.bionetworkName[i];
+    if (isNetworkKey(networkKey)) {
+      acc.push({ atlasName: `${atlas} ${version}`, networkKey });
+    }
+    return acc;
+  }, [] as Atlas[]);
 }
 
 /**

--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
@@ -95,6 +95,7 @@ import { mapProjectDataSummary } from "./dataSummaryMapper/dataSummaryMapper";
 import { AnalysisPortal } from "./projectMapper/projectEdits/entities";
 import {
   mapProjectAnalysisPortals,
+  mapProjectAtlas,
   mapProjectCollaboratingOrganizations,
   mapProjectContacts,
   mapProjectContributors,
@@ -524,6 +525,20 @@ export const buildAnalysisPortals = (
         ...props,
       }),
     keyValuePairs,
+  };
+};
+
+/**
+ * Build props for atlas section from the given projects response.
+ * @param projectsResponse - Response model return from projects API.
+ * @returns model to be used as props for the AtlasSection component.
+ */
+export const buildAtlasSection = (
+  projectsResponse: ProjectsResponse
+): React.ComponentProps<typeof C.AtlasSection> => {
+  const project = getProjectResponse(projectsResponse);
+  return {
+    atlases: mapProjectAtlas(project),
   };
 };
 

--- a/explorer/site-config/hca-dcp/dev/detail/project/overviewSideColumn.ts
+++ b/explorer/site-config/hca-dcp/dev/detail/project/overviewSideColumn.ts
@@ -5,6 +5,10 @@ import * as V from "../../../../../app/viewModelBuilders/azul/hca-dcp/common/vie
 
 export const sideColumn = [
   {
+    component: C.AtlasSection,
+    viewBuilder: V.buildAtlasSection,
+  } as ComponentConfig<typeof C.AtlasSection, ProjectsResponse>,
+  {
     children: [
       {
         children: [


### PR DESCRIPTION
### Ticket
Closes #4145.

### Reviewers
@NoopDog.

### Changes
- Added Atlas (with corresponding biological network icon) to project detail page.

### Notes
- Note, assumed the order of biological network `bionetworkName` corresponds with tissueAtlas `atlas` order.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/2b945831-d02d-4cc7-8d5b-cda88b1c5a38">
