### PR TITLE
test: allowed empty filter options on testFilterPersistence (#4211)

### DIFF
--- a/explorer/e2e/anvil/anvil-filters.spec.ts
+++ b/explorer/e2e/anvil/anvil-filters.spec.ts
@@ -104,14 +104,11 @@ test("Check that filter checkboxes are persistent across pages on an arbitrary f
   page,
 }) => {
   test.setTimeout(120000);
-  const result = await testFilterPersistence(
+  await testFilterPersistence(
     page,
     ANVIL_FILTER_NAMES[FILE_FORMAT_INDEX],
     ANVIL_TAB_TEST_ORDER.map((x) => ANVIL_TABS[x])
   );
-  if (!result) {
-    test.fail();
-  }
 });
 
 test("Check that filter menu counts match actual counts on the Datasets tab", async ({


### PR DESCRIPTION
### Ticket
Closes #4211 .

### Reviewers
@MillenniumFalconMechanic .

### Changes
- Replaced assertion in `testFilterPersistence` that filter options should not be blank with a loop to check other filter options if the first one is blank