### PR TITLE
test: rationalized test timeouts (#4213)

### DIFF
--- a/e2e/anvil/anvil-backpages.spec.ts
+++ b/e2e/anvil/anvil-backpages.spec.ts
@@ -10,7 +10,6 @@ test.skip("Smoke test `Export to Terra` button on the first available dataset", 
   context,
   page,
 }) => {
-  test.setTimeout(120000);
   const testResult = await testExportBackpage(
     context,
     page,
@@ -24,7 +23,6 @@ test.skip("Smoke test `Export to Terra` button on the first available dataset", 
 test.skip("Check access controls on the datasets backpages work for the first two tabs", async ({
   page,
 }) => {
-  test.setTimeout(120000);
   const testResult = await testBackpageAccess(page, ANVIL_TABS.DATASETS);
   if (!testResult) {
     test.fail();
@@ -34,7 +32,6 @@ test.skip("Check access controls on the datasets backpages work for the first tw
 test("Check that information on the backpages matches information in the data tables", async ({
   page,
 }) => {
-  test.setTimeout(120000);
   const testResult = await testBackpageDetails(page, ANVIL_TABS.DATASETS);
   if (!testResult) {
     test.fail();

--- a/e2e/anvil/anvil-filters.spec.ts
+++ b/e2e/anvil/anvil-filters.spec.ts
@@ -68,7 +68,6 @@ test("Check that all filters exist on the Files tab and are clickable", async ({
 test("Check that the first filter on the Datasets tab creates at least one checkbox, and that checking up to the first five does not cause an error and does not cause there to be no entries in the table", async ({
   page,
 }) => {
-  test.setTimeout(120000);
   // Goto the datasets tab
   await page.goto(ANVIL_TABS.DATASETS.url);
   await expect(
@@ -103,7 +102,6 @@ test("Check that the first filter on the Datasets tab creates at least one check
 test("Check that filter checkboxes are persistent across pages on an arbitrary filter", async ({
   page,
 }) => {
-  test.setTimeout(120000);
   await testFilterPersistence(
     page,
     ANVIL_FILTER_NAMES[FILE_FORMAT_INDEX],
@@ -114,7 +112,6 @@ test("Check that filter checkboxes are persistent across pages on an arbitrary f
 test("Check that filter menu counts match actual counts on the Datasets tab", async ({
   page,
 }) => {
-  test.setTimeout(120000);
   const result = await testFilterCounts(
     page,
     ANVIL_TABS.DATASETS,
@@ -129,7 +126,6 @@ test("Check that filter menu counts match actual counts on the Datasets tab", as
 test("Check that filter menu counts match actual counts on the Activities tab", async ({
   page,
 }) => {
-  test.setTimeout(120000);
   await testFilterCounts(
     page,
     ANVIL_TABS.ACTIVITIES,
@@ -141,7 +137,6 @@ test("Check that filter menu counts match actual counts on the Activities tab", 
 test("Check that the filter tags match the selected filter for an arbitrary filter on the Files tab", async ({
   page,
 }) => {
-  test.setTimeout(120000);
   await testFilterTags(
     page,
     ANVIL_TABS.FILES,
@@ -152,7 +147,6 @@ test("Check that the filter tags match the selected filter for an arbitrary filt
 test("Check that the filter tags match the selected filter for an arbitrary filter on the BioSamples tab", async ({
   page,
 }) => {
-  test.setTimeout(120000);
   await testFilterTags(
     page,
     ANVIL_TABS.BIOSAMPLES,
@@ -163,7 +157,6 @@ test("Check that the filter tags match the selected filter for an arbitrary filt
 test("Check that the clear all button functions on the files tab", async ({
   page,
 }) => {
-  test.setTimeout(120000);
   await testClearAll(
     page,
     ANVIL_TABS.FILES,

--- a/e2e/anvil/anvil-pagination.spec.ts
+++ b/e2e/anvil/anvil-pagination.spec.ts
@@ -19,7 +19,6 @@ test("Check first page has disabled back and enabled forward pagination buttons 
 test("Paginate through the entire Files tab to confirm that the page number stays consistent and that paginating forwards is disabled on the last page. Uses filters to reduce the amount of calls necessary", async ({
   page,
 }) => {
-  test.setTimeout(500000);
   const result = await filterAndTestLastPagePagination(
     page,
     ANVIL_TABS.FILES,
@@ -33,6 +32,5 @@ test("Paginate through the entire Files tab to confirm that the page number stay
 test("Check forward and backwards pagination causes the page content to change on the Biosamples page", async ({
   page,
 }) => {
-  test.setTimeout(90000);
   await testPaginationContent(page, ANVIL_TABS.BIOSAMPLES);
 });

--- a/e2e/anvil/anvil-sort.spec.ts
+++ b/e2e/anvil/anvil-sort.spec.ts
@@ -5,7 +5,6 @@ import { ANVIL_TABS } from "./anvil-tabs";
 test("Expect clicking each column header three times to keep the first text element visible on the Datasets tab", async ({
   page,
 }) => {
-  test.setTimeout(180000);
   const testResult = await testSortAzul(page, ANVIL_TABS.DATASETS);
   if (!testResult) {
     test.fail();
@@ -15,7 +14,6 @@ test("Expect clicking each column header three times to keep the first text elem
 test("Expect clicking each column header three times to keep the first text element visible on the Donors tab", async ({
   page,
 }) => {
-  test.setTimeout(180000);
   const testResult = await testSortAzul(page, ANVIL_TABS.DONORS);
   if (!testResult) {
     test.fail();
@@ -25,7 +23,6 @@ test("Expect clicking each column header three times to keep the first text elem
 test("Expect clicking each column header of each tab three times to keep the first text element visible on the BioSamples tab", async ({
   page,
 }) => {
-  test.setTimeout(180000);
   const testResult = await testSortAzul(page, ANVIL_TABS.BIOSAMPLES);
   if (!testResult) {
     test.fail();
@@ -35,7 +32,6 @@ test("Expect clicking each column header of each tab three times to keep the fir
 test("Expect clicking each column header three times to keep the first text element visible on the Activities tab", async ({
   page,
 }) => {
-  test.setTimeout(180000);
   const testResult = await testSortAzul(page, ANVIL_TABS.ACTIVITIES);
   if (!testResult) {
     test.fail();
@@ -45,7 +41,6 @@ test("Expect clicking each column header three times to keep the first text elem
 test("Expect clicking each column header three times to keep the first text element visible on the Files tab", async ({
   page,
 }) => {
-  test.setTimeout(180000);
   const testResult = await testSortAzul(page, ANVIL_TABS.FILES);
   if (!testResult) {
     test.fail();

--- a/e2e/testFunctions.ts
+++ b/e2e/testFunctions.ts
@@ -7,6 +7,10 @@ import {
 
 /* eslint-disable sonarjs/no-duplicate-string  -- ignoring duplicate strings here */
 
+// Timeout constants
+const EXPORT_REQUEST_TIMEOUT = 60000;
+const DOWNLOAD_TIMEOUT = 10000;
+
 /**
  * Get an array of all visible column header names
  * @param page - a Playwright page object
@@ -777,8 +781,6 @@ export async function testDeselectFiltersThroughSearchBar(
   }
 }
 
-const EXPORT_REQUEST_TIMEOUT = 60000;
-
 /**
  * Get the first link to a backpage with specified backpage access
  * @param page - a Playright page locator
@@ -1147,8 +1149,12 @@ export async function testBulkDownloadIndexExportWorkflow(
   const exportActionButtonLocator = page.getByRole("link", {
     name: tab.indexExportPage?.exportActionButtonText,
   });
-  await expect(exportActionButtonLocator).toBeEnabled({ timeout: 60000 });
-  const downloadPromise = page.waitForEvent("download", { timeout: 10000 }); // This timeout is necessary, as otherwise the test will wait for the global test timeout
+  await expect(exportActionButtonLocator).toBeEnabled({
+    timeout: EXPORT_REQUEST_TIMEOUT,
+  });
+  const downloadPromise = page.waitForEvent("download", {
+    timeout: DOWNLOAD_TIMEOUT,
+  }); // This timeout is necessary, as otherwise the test will wait for the global test timeout
   await exportActionButtonLocator.click();
   const download = await downloadPromise;
   // Cancel the download when it occurs, since there's no need to let it fully download

--- a/e2e/testFunctions.ts
+++ b/e2e/testFunctions.ts
@@ -88,7 +88,7 @@ export async function testUrl(
   // Check that the selected tab appears selected and the other tabs appear deselected
   await expect(
     page.getByRole("tab").getByText(tab.tabName, { exact: true })
-  ).toHaveAttribute("aria-selected", "true", { timeout: 25000 });
+  ).toHaveAttribute("aria-selected", "true");
   for (const otherTab of otherTabs) {
     if (otherTab.tabName !== tab.tabName) {
       await expect(
@@ -116,7 +116,7 @@ export async function testTab(
     .getByRole("tab")
     .getByText(endTab.tabName, { exact: true })
     .click();
-  await expect(page).toHaveURL(endTab.url, { timeout: 25000 }); // Long timeout because some tabs take a long time to load
+  await expect(page).toHaveURL(endTab.url);
   await expect(page.getByRole("tab").getByText(endTab.tabName)).toHaveAttribute(
     "aria-selected",
     "true"
@@ -777,6 +777,8 @@ export async function testDeselectFiltersThroughSearchBar(
   }
 }
 
+const EXPORT_REQUEST_TIMEOUT = 60000;
+
 /**
  * Get the first link to a backpage with specified backpage access
  * @param page - a Playright page locator
@@ -811,7 +813,7 @@ const makeMinimalExportRequest = async (
   for (const checkboxLocator of allNonTableCheckboxLocators) {
     await checkboxLocator.click();
     await expect(checkboxLocator).toBeChecked();
-    await expect(checkboxLocator).toBeEnabled({ timeout: 10000 });
+    await expect(checkboxLocator).toBeEnabled();
   }
 
   // Check the second checkbox in the table (this should be the checkbox after the "select all checkbox")
@@ -822,7 +824,7 @@ const makeMinimalExportRequest = async (
   const secondCheckboxInTableLocator = allInTableCheckboxLocators[1];
   await secondCheckboxInTableLocator.click();
   await expect(secondCheckboxInTableLocator).toBeChecked();
-  await expect(secondCheckboxInTableLocator).toBeEnabled({ timeout: 10000 });
+  await expect(secondCheckboxInTableLocator).toBeEnabled();
   // Make sure that no other checkboxes are selected
   const otherInTableCheckboxLocators = [
     allInTableCheckboxLocators[0],
@@ -833,7 +835,7 @@ const makeMinimalExportRequest = async (
     await expect(otherCheckboxLocator).toBeEnabled();
   }
   // Click the Export Request button
-  await expect(exportRequestButtonLocator).toBeEnabled({ timeout: 10000 });
+  await expect(exportRequestButtonLocator).toBeEnabled();
   await exportRequestButtonLocator.click();
 };
 
@@ -889,7 +891,7 @@ export async function testExportBackpage(
     page.getByText(tab.backpageExportButtons.actionLandingMessage, {
       exact: true,
     })
-  ).toBeVisible({ timeout: 60000 });
+  ).toBeVisible({ timeout: EXPORT_REQUEST_TIMEOUT });
   const exportActionButtonLocator = page.getByRole("button", {
     name: tab.backpageExportButtons?.exportActionButtonText,
   });
@@ -1354,7 +1356,7 @@ export async function testPaginationContent(
   await page.goto(tab.url);
   await expect(
     page.getByRole("tab").getByText(tab.tabName, { exact: true })
-  ).toHaveAttribute("aria-selected", "true", { timeout: 25000 });
+  ).toHaveAttribute("aria-selected", "true");
 
   const firstElementTextLocator = getFirstRowNthColumnCellLocator(page, 0);
 

--- a/e2e/testFunctions.ts
+++ b/e2e/testFunctions.ts
@@ -8,8 +8,8 @@ import {
 /* eslint-disable sonarjs/no-duplicate-string  -- ignoring duplicate strings here */
 
 // Timeout constants
-const EXPORT_REQUEST_TIMEOUT = 60000;
-const DOWNLOAD_TIMEOUT = 10000;
+const TIMEOUT_EXPORT_REQUEST = 60000;
+const TIMEOUT_DOWNLOAD = 10000;
 
 /**
  * Get an array of all visible column header names
@@ -893,7 +893,7 @@ export async function testExportBackpage(
     page.getByText(tab.backpageExportButtons.actionLandingMessage, {
       exact: true,
     })
-  ).toBeVisible({ timeout: EXPORT_REQUEST_TIMEOUT });
+  ).toBeVisible({ timeout: TIMEOUT_EXPORT_REQUEST });
   const exportActionButtonLocator = page.getByRole("button", {
     name: tab.backpageExportButtons?.exportActionButtonText,
   });
@@ -1150,10 +1150,10 @@ export async function testBulkDownloadIndexExportWorkflow(
     name: tab.indexExportPage?.exportActionButtonText,
   });
   await expect(exportActionButtonLocator).toBeEnabled({
-    timeout: EXPORT_REQUEST_TIMEOUT,
+    timeout: TIMEOUT_EXPORT_REQUEST,
   });
   const downloadPromise = page.waitForEvent("download", {
-    timeout: DOWNLOAD_TIMEOUT,
+    timeout: TIMEOUT_DOWNLOAD,
   }); // This timeout is necessary, as otherwise the test will wait for the global test timeout
   await exportActionButtonLocator.click();
   const download = await downloadPromise;

--- a/playwright_anvil.config.ts
+++ b/playwright_anvil.config.ts
@@ -22,7 +22,7 @@ const config: PlaywrightTestConfig = {
   ],
   testDir: "e2e",
   testMatch: /.*\/(anvil)\/.*\.spec\.ts/,
-  timeout: 60 * 1000,
+  timeout: 3 * 60 * 1000,
   use: {
     baseURL: "http://localhost:3000/",
     screenshot: "only-on-failure",


### PR DESCRIPTION
### Ticket

Closes #4213 .

### Reviewers

@NoopDog .

### Changes

- Removed all timeout calls, except where necessary for reliability
- Set a global test timeout of 3 minutes, and removed all `test.setTimeout` calls
