### PR TITLE
feat: use dataset_id instead of title for dataset summary and file queries (#4273)

### DIFF
--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
@@ -462,20 +462,19 @@ export const buildDRSURI = (
 
 /**
  * Build props for ExportCurrentQuery component.
- * @param _ - Void.
+ * @param datasetsResponse - Response model returned from datasets API.
  * @param viewContext - View context.
  * @returns model to be used as props for the ExportCurrentQuery component.
  */
 export const buildExportCurrentQuery = (
-  _: Void,
-  viewContext: ViewContext<Void>
+  datasetsResponse: DatasetsResponse,
+  viewContext: ViewContext<DatasetsResponse>
 ): React.ComponentProps<typeof C.ExportCurrentQuery> => {
-  const {
-    fileManifestState: { filters, isFacetsLoading },
-  } = viewContext;
   return {
-    isLoading: isFacetsLoading,
-    queries: getExportCurrentQueries(filters),
+    isLoading: viewContext.fileManifestState.isFacetsLoading,
+    queries: getExportCurrentQueries(
+      getExportCurrentQuerySelectedFilters(datasetsResponse, viewContext)
+    ),
   };
 };
 
@@ -975,6 +974,19 @@ function getDatasetStatusBadge(
 }
 
 /**
+ * Returns dataset ID from the given datasets response.
+ * @param datasetsResponse - Response model return from datasets API.
+ * @returns dataset ID.
+ */
+export function getDatasetId(datasetsResponse: DatasetsResponse): string {
+  return processEntityValue(
+    datasetsResponse.datasets,
+    "dataset_id",
+    LABEL.NONE
+  );
+}
+
+/**
  * Returns dataset title from the given datasets response.
  * @param datasetsResponse - Response model return from datasets API.
  * @returns dataset title.
@@ -998,6 +1010,44 @@ export function getExportCurrentQueries(filters: Filters): CurrentQuery[] {
 }
 
 /**
+ * Returns the export current query selected filters for the given file manifest state.
+ * @param datasetsResponse - Response model return from datasets API.
+ * @param viewContext - View context.
+ * @returns export current query selected filters.
+ */
+export function getExportCurrentQuerySelectedFilters(
+  datasetsResponse: DatasetsResponse,
+  viewContext: ViewContext<DatasetsResponse>
+): Filters {
+  if ("datasets" in datasetsResponse) {
+    return getExportEntityCurrentQuerySelectedFilters(
+      datasetsResponse,
+      viewContext
+    );
+  }
+  return viewContext.fileManifestState.filters;
+}
+
+/**
+ * Returns the export entity current query selected filters for the given file manifest state.
+ * Dataset ID is filtered out from the current filters query, and dataset title is added.
+ * @param datasetsResponse - Response model return from datasets API.
+ * @param viewContext - View context.
+ * @returns export entity current query selected filters.
+ */
+export function getExportEntityCurrentQuerySelectedFilters(
+  datasetsResponse: DatasetsResponse,
+  viewContext: ViewContext<DatasetsResponse>
+): Filters {
+  const filters = viewContext.fileManifestState.filters.filter(filterDatasetId);
+  const datasetTitleFilter: SelectedFilter = {
+    categoryKey: ANVIL_CMG_CATEGORY_KEY.DATASET_TITLE,
+    value: [getDatasetTitle(datasetsResponse)],
+  };
+  return [datasetTitleFilter, ...filters];
+}
+
+/**
  * Returns the export entity filters for the given datasets response.
  * @param datasetsResponse - Response model return from datasets API.
  * @returns export entity filters.
@@ -1005,8 +1055,8 @@ export function getExportCurrentQueries(filters: Filters): CurrentQuery[] {
 function getExportEntityFilters(datasetsResponse: DatasetsResponse): Filters {
   return [
     {
-      categoryKey: ANVIL_CMG_CATEGORY_KEY.DATASET_TITLE,
-      value: [getDatasetTitle(datasetsResponse)],
+      categoryKey: ANVIL_CMG_CATEGORY_KEY.DATASET_ID,
+      value: [getDatasetId(datasetsResponse)],
     },
   ];
 }
@@ -1145,6 +1195,15 @@ function getFormFacets(fileManifestState: FileManifestState): FormFacet {
         }
       : undefined,
   };
+}
+
+/**
+ * Boolean to filter out any selected filters that have dataset ID as the category key.
+ * @param filter - Selected filter.
+ * @returns true if the filter category key is not dataset ID.
+ */
+function filterDatasetId(filter: SelectedFilter): boolean {
+  return filter.categoryKey !== ANVIL_CMG_CATEGORY_KEY.DATASET_ID;
 }
 
 /**

--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
@@ -43,6 +43,7 @@ import React from "react";
 import {
   ANVIL_CMG_CATEGORY_KEY,
   ANVIL_CMG_CATEGORY_LABEL,
+  DATASET_RESPONSE,
 } from "../../../../../site-config/anvil-cmg/category";
 import {
   ROUTE_EXPORT_TO_TERRA,
@@ -1019,7 +1020,7 @@ export function getExportCurrentQuerySelectedFilters(
   datasetsResponse: DatasetsResponse,
   viewContext: ViewContext<DatasetsResponse>
 ): Filters {
-  if ("datasets" in datasetsResponse) {
+  if (DATASET_RESPONSE.DATASETS in datasetsResponse) {
     return getExportEntityCurrentQuerySelectedFilters(
       datasetsResponse,
       viewContext

--- a/site-config/anvil-cmg/category.ts
+++ b/site-config/anvil-cmg/category.ts
@@ -55,3 +55,7 @@ export const ANVIL_CMG_CATEGORY_LABEL = {
   LIBRARY_ID: "Library Id",
   PREP_MATERIAL_NAME: "Library Preparation",
 };
+
+export const DATASET_RESPONSE = {
+  DATASETS: "datasets",
+};

--- a/site-config/anvil-cmg/category.ts
+++ b/site-config/anvil-cmg/category.ts
@@ -10,7 +10,7 @@ export const ANVIL_CMG_CATEGORY_KEY = {
   BIOSAMPLE_TYPE: "biosample_type",
   DATASET_ACCESSIBLE: "datasets.accessible",
   DATASET_CONSENT_GROUP: "datasets.consent_group",
-  DATASET_ID: "dataset_id",
+  DATASET_ID: "datasets.dataset_id",
   DATASET_REGISTERED_ID: "datasets.registered_identifier",
   DATASET_TITLE: "datasets.title",
   DIAGNOSE_DISEASE: "diagnoses.disease",


### PR DESCRIPTION
### Ticket

Closes #4273.

### Reviewers

@NoopDog.

### Changes

- Updated export "selected filters" for entity related exports to use `datasets.dataset_id` instead of `datasets.title`.
- Current queries panel code is updated to only show the title, and not the selected id.

##### Example download request:

```https://service.anvil.gi.ucsc.edu/fetch/manifest/files?catalog=anvil&filters=%7B%22datasets.dataset_id%22%3A%7B%22is%22%3A%5B%22385290c3-dff5-fb6d-2501-fa0ba3ad1c35%22%5D%7D%2C%22donors.organism_type%22%3A%7B%22is%22%3A%5Bnull%5D%7D%2C%22files.file_format%22%3A%7B%22is%22%3A%5B%22.crai%22%5D%7D%7D&format=verbatim.pfb```

##### Example download payload:


```
catalog: anvil
filters: {"datasets.dataset_id":{"is":["385290c3-dff5-fb6d-2501-fa0ba3ad1c35"]},"donors.organism_type":{"is":[null]},"files.file_format":{"is":[".crai"]}}
format: verbatim.pfb
```

<img width="1468" alt="image" src="https://github.com/user-attachments/assets/11d20138-d130-4e8b-bd8a-a0a8abdedbf2">
