### PR TITLE
feat: add version info to footer for HCA Data Explorer (#4261)

### DIFF
--- a/site-config/hca-dcp/cc-ma-dev/config.ts
+++ b/site-config/hca-dcp/cc-ma-dev/config.ts
@@ -12,11 +12,12 @@ const BROWSER_URL =
   "https://ma-pilot.explore.data.humancellatlas.dev.clevercanary.com";
 const CATALOG = "dcp3";
 const DATA_URL = "https://service.dev.singlecell.gi.ucsc.edu";
+const GIT_HUB_REPO_URL = "https://github.com/DataBiosphere/data-browser";
 const PORTAL_URL = "https://data.humancellatlas.dev.clevercanary.com";
 
 const config: SiteConfig = {
   ...makeManagedAccessConfig(
-    makeConfig(BROWSER_URL, PORTAL_URL, DATA_URL, undefined, CATALOG)
+    makeConfig(BROWSER_URL, PORTAL_URL, DATA_URL, GIT_HUB_REPO_URL, CATALOG)
   ),
 };
 

--- a/site-config/hca-dcp/cc-ma-dev/config.ts
+++ b/site-config/hca-dcp/cc-ma-dev/config.ts
@@ -16,7 +16,7 @@ const PORTAL_URL = "https://data.humancellatlas.dev.clevercanary.com";
 
 const config: SiteConfig = {
   ...makeManagedAccessConfig(
-    makeConfig(BROWSER_URL, PORTAL_URL, DATA_URL, CATALOG)
+    makeConfig(BROWSER_URL, PORTAL_URL, DATA_URL, undefined, CATALOG)
   ),
 };
 

--- a/site-config/hca-dcp/dev/config.ts
+++ b/site-config/hca-dcp/dev/config.ts
@@ -26,9 +26,10 @@ import { floating } from "./layout/floating";
 const APP_TITLE = "HCA Data Explorer";
 const CATALOG = "dcp43";
 const BROWSER_URL = "https://explore.data.humancellatlas.dev.clevercanary.com";
-export const DATA_URL = "https://service.azul.data.humancellatlas.org";
-export const EXPORT_TO_TERRA_URL = "https://app.terra.bio";
+const DATA_URL = "https://service.azul.data.humancellatlas.org";
+const EXPORT_TO_TERRA_URL = "https://app.terra.bio";
 const FONT_FAMILY_DIN = "'din-2014', sans-serif";
+const GIT_HUB_REPO_URL = "https://github.com/DataBiosphere/data-browser";
 const HOME_PAGE_PATH = "/projects";
 const ORG_URL = "https://www.humancellatlas.org";
 const PAGINATION_PAGE_SIZE = "25";
@@ -38,6 +39,7 @@ export function makeConfig(
   browserUrl: string,
   portalUrl: string,
   dataUrl: string,
+  gitHubUrl: string = GIT_HUB_REPO_URL,
   catalog: string = CATALOG
 ): SiteConfig {
   return {
@@ -66,6 +68,7 @@ export function makeConfig(
     explorerTitle: "Explore Data",
     export: exportConfig,
     exportToTerraUrl: EXPORT_TO_TERRA_URL,
+    gitHubUrl,
     layout: {
       floating,
       footer: {
@@ -95,6 +98,7 @@ export function makeConfig(
             url: `${portalUrl}/contact`,
           },
         ],
+        versionInfo: true,
       },
       header: {
         announcements,

--- a/site-config/hca-dcp/ma-dev/config.ts
+++ b/site-config/hca-dcp/ma-dev/config.ts
@@ -10,7 +10,7 @@ export const PORTAL_URL = "https://dev.singlecell.gi.ucsc.edu";
 
 const config: SiteConfig = {
   ...makeManagedAccessConfig(
-    makeConfig(BROWSER_URL, PORTAL_URL, DATA_URL, CATALOG)
+    makeConfig(BROWSER_URL, PORTAL_URL, DATA_URL, undefined, CATALOG)
   ),
 };
 

--- a/site-config/hca-dcp/ma-dev/config.ts
+++ b/site-config/hca-dcp/ma-dev/config.ts
@@ -6,11 +6,12 @@ import { makeConfig } from "../dev/config";
 const BROWSER_URL = "https://explore.dev.singlecell.gi.ucsc.edu";
 const CATALOG = "dcp3";
 export const DATA_URL = "https://service.dev.singlecell.gi.ucsc.edu";
+const GIT_HUB_REPO_URL = "https://github.com/DataBiosphere/data-browser";
 export const PORTAL_URL = "https://dev.singlecell.gi.ucsc.edu";
 
 const config: SiteConfig = {
   ...makeManagedAccessConfig(
-    makeConfig(BROWSER_URL, PORTAL_URL, DATA_URL, undefined, CATALOG)
+    makeConfig(BROWSER_URL, PORTAL_URL, DATA_URL, GIT_HUB_REPO_URL, CATALOG)
   ),
 };
 

--- a/site-config/hca-dcp/ma-prod/config.ts
+++ b/site-config/hca-dcp/ma-prod/config.ts
@@ -7,11 +7,12 @@ import { getAuthenticationConfig } from "./authentication/authentication";
 const BROWSER_URL = "https://explore.data.humancellatlas.org";
 const CATALOG = "dcp43";
 const DATA_URL = "https://service.azul.data.humancellatlas.org";
+const GIT_HUB_REPO_URL = "https://github.com/DataBiosphere/data-browser";
 const PORTAL_URL = "https://data.humancellatlas.org";
 
 const config: SiteConfig = {
   ...makeManagedAccessConfig(
-    makeConfig(BROWSER_URL, PORTAL_URL, DATA_URL, undefined, CATALOG)
+    makeConfig(BROWSER_URL, PORTAL_URL, DATA_URL, GIT_HUB_REPO_URL, CATALOG)
   ),
 };
 

--- a/site-config/hca-dcp/ma-prod/config.ts
+++ b/site-config/hca-dcp/ma-prod/config.ts
@@ -11,7 +11,7 @@ const PORTAL_URL = "https://data.humancellatlas.org";
 
 const config: SiteConfig = {
   ...makeManagedAccessConfig(
-    makeConfig(BROWSER_URL, PORTAL_URL, DATA_URL, CATALOG)
+    makeConfig(BROWSER_URL, PORTAL_URL, DATA_URL, undefined, CATALOG)
   ),
 };
 


### PR DESCRIPTION
### Ticket

Closes #4261.

### Reviewers

@NoopDog.

### Changes

- Added version info to HCA DCP footer.

<img width="1109" alt="image" src="https://github.com/user-attachments/assets/0c8b749a-8a2c-47f8-ba75-13488d30af47">
