### PR TITLE
fix: removed hca specific config from lungmap (#4287)

### DIFF
--- a/site-config/lungmap/dev/config.ts
+++ b/site-config/lungmap/dev/config.ts
@@ -1,15 +1,15 @@
-import { CategoryGroupConfig } from "@databiosphere/findable-ui/lib/config/entities";
-import hcaConfig, {
+import {
   DATA_URL as HCA_DATA_URL,
   PORTAL_URL as HCA_PORTAL_URL,
 } from "site-config/hca-dcp/ma-dev/config";
 import * as C from "../../../app/components/index";
 import { FLATTEN, GIT_HUB_REPO_URL } from "../../common/constants";
 import { SiteConfig } from "../../common/entities";
-import { filesEntityConfig as hcaFilesEntityConfig } from "../../hca-dcp/dev/index/filesEntityConfig";
-import { samplesEntityConfig as hcaSamplesEntityConfig } from "../../hca-dcp/dev/index/samplesEntityConfig";
 import { exportConfig } from "./export/exportConfig";
+import { CATEGORY_GROUPS } from "./index/common/category";
+import { filesEntityConfig } from "./index/filesEntityConfig";
 import { projectsEntityConfig } from "./index/projectsEntityConfig";
+import { samplesEntityConfig } from "./index/samplesEntityConfig";
 import { summary } from "./index/summary";
 import { socialMedia } from "./socialMedia";
 
@@ -40,7 +40,7 @@ export function makeConfig(
     authentication: undefined,
     browserURL: browserUrl,
     categoryGroupConfig: {
-      ...(hcaConfig.categoryGroupConfig as CategoryGroupConfig),
+      categoryGroups: CATEGORY_GROUPS,
       key: "lungmap",
     },
     contentDir: "lungmap",
@@ -53,11 +53,7 @@ export function makeConfig(
       },
       url: `${dataUrl}/`,
     },
-    entities: [
-      projectsEntityConfig,
-      hcaSamplesEntityConfig,
-      hcaFilesEntityConfig,
-    ],
+    entities: [projectsEntityConfig, samplesEntityConfig, filesEntityConfig],
     explorerTitle: "Explore Data",
     export: exportConfig,
     exportToTerraUrl: EXPORT_TO_TERRA_URL,

--- a/site-config/lungmap/dev/detail/project/exportMainColumn.ts
+++ b/site-config/lungmap/dev/detail/project/exportMainColumn.ts
@@ -1,9 +1,10 @@
 import { ALERT_PROPS } from "@databiosphere/findable-ui/lib/components/common/Alert/constants";
 import { ComponentConfig } from "@databiosphere/findable-ui/lib/config/entities";
 import { SIZE } from "@databiosphere/findable-ui/lib/styles/common/constants/size";
+import { ProjectsResponse } from "app/apis/azul/hca-dcp/common/responses";
 import * as C from "../../../../../app/components";
 import * as MDX from "../../../../../app/components/common/MDXContent/lungmap";
-import { mainColumn as hcaExportMainColumn } from "../../../../hca-dcp/dev/detail/project/exportMainColumn";
+import * as V from "../../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
 
 export const mainColumn: ComponentConfig[] = [
   {
@@ -14,5 +15,8 @@ export const mainColumn: ComponentConfig[] = [
       size: SIZE.LARGE,
     },
   } as ComponentConfig<typeof MDX.AlertBatchCorrectionWarning>,
-  hcaExportMainColumn[1],
+  {
+    component: C.ExportToTerra,
+    viewBuilder: V.buildExportEntityToTerra,
+  } as ComponentConfig<typeof C.ExportToTerra, ProjectsResponse>,
 ];

--- a/site-config/lungmap/dev/detail/project/mainColumn.ts
+++ b/site-config/lungmap/dev/detail/project/mainColumn.ts
@@ -2,30 +2,79 @@ import {
   ComponentConfig,
   ComponentsConfig,
 } from "@databiosphere/findable-ui/lib/config/entities";
+import { ProjectsResponse } from "app/apis/azul/hca-dcp/common/responses";
 import * as C from "../../../../../app/components";
 import * as MDX from "../../../../../app/components/common/MDXContent/lungmap";
-import { mainColumn as hcaOverviewMainColumn } from "../../../../hca-dcp/dev/detail/project/overviewMainColumn";
+import * as V from "../../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
 
-// Data Release Policy
-const DATA_RELEASE_POLICY: ComponentConfig = {
-  children: [
-    {
-      component: MDX.DataReleasePolicy,
-    } as ComponentConfig<typeof MDX.DataReleasePolicy>,
-  ],
-  component: C.CollapsableSection,
-  props: {
-    collapsable: false,
-    title: "Data Access Policy",
-  },
-};
-
-/**
- * Returns overview main column components.
- * @returns overview main column components.
- */
-export function getOverviewMainColumn(): ComponentsConfig {
-  const mainColumn = [...hcaOverviewMainColumn];
-  mainColumn.pop(); // Remove the last element (HCA Data Release Policy).
-  return [...mainColumn, DATA_RELEASE_POLICY];
-}
+export const mainColumn: ComponentsConfig = [
+  {
+    component: C.Description,
+    viewBuilder: V.buildDescription,
+  } as ComponentConfig<typeof C.Description, ProjectsResponse>,
+  {
+    component: C.Contacts,
+    viewBuilder: V.buildContacts,
+  } as ComponentConfig<typeof C.Contacts, ProjectsResponse>,
+  {
+    component: C.Publications,
+    viewBuilder: V.buildPublications,
+  } as ComponentConfig<typeof C.Publications, ProjectsResponse>,
+  {
+    component: C.Contributors,
+    viewBuilder: V.buildContributors,
+  } as ComponentConfig<typeof C.Contributors, ProjectsResponse>,
+  {
+    component: C.CollaboratingOrganizations,
+    viewBuilder: V.buildCollaboratingOrganizations,
+  } as ComponentConfig<typeof C.CollaboratingOrganizations, ProjectsResponse>,
+  {
+    component: C.DataCurators,
+    viewBuilder: V.buildDataCurators,
+  } as ComponentConfig<typeof C.DataCurators, ProjectsResponse>,
+  {
+    component: C.Citation,
+    viewBuilder: V.buildCitation,
+  } as ComponentConfig<typeof C.Citation, ProjectsResponse>,
+  {
+    component: C.SupplementaryLinks,
+    viewBuilder: V.buildSupplementaryLinks,
+  } as ComponentConfig<typeof C.SupplementaryLinks>,
+  {
+    children: [
+      {
+        component: C.KeyValuePairs,
+        viewBuilder: V.buildAccessions,
+      } as ComponentConfig<typeof C.KeyValuePairs, ProjectsResponse>,
+    ],
+    component: C.CollapsableSection,
+    props: {
+      collapsable: true,
+      title: "Accessions",
+    },
+  } as ComponentConfig<typeof C.CollapsableSection>,
+  {
+    children: [
+      {
+        component: MDX.DataReleasePolicy,
+      } as ComponentConfig<typeof MDX.DataReleasePolicy>,
+    ],
+    component: C.CollapsableSection,
+    props: {
+      collapsable: false,
+      title: "Data Access Policy",
+    },
+  } as ComponentConfig<typeof C.CollapsableSection>,
+  {
+    children: [
+      {
+        component: MDX.DataReleasePolicy,
+      } as ComponentConfig<typeof MDX.DataReleasePolicy>,
+    ],
+    component: C.CollapsableSection,
+    props: {
+      collapsable: false,
+      title: "Data Access Policy",
+    },
+  } as ComponentConfig<typeof C.CollapsableSection>,
+];

--- a/site-config/lungmap/dev/detail/project/mainColumn.ts
+++ b/site-config/lungmap/dev/detail/project/mainColumn.ts
@@ -65,16 +65,4 @@ export const mainColumn: ComponentsConfig = [
       title: "Data Access Policy",
     },
   } as ComponentConfig<typeof C.CollapsableSection>,
-  {
-    children: [
-      {
-        component: MDX.DataReleasePolicy,
-      } as ComponentConfig<typeof MDX.DataReleasePolicy>,
-    ],
-    component: C.CollapsableSection,
-    props: {
-      collapsable: false,
-      title: "Data Access Policy",
-    },
-  } as ComponentConfig<typeof C.CollapsableSection>,
 ];

--- a/site-config/lungmap/dev/detail/project/metadataMainColumn.ts
+++ b/site-config/lungmap/dev/detail/project/metadataMainColumn.ts
@@ -1,0 +1,11 @@
+import { ComponentConfig } from "@databiosphere/findable-ui/lib/config/entities";
+import { ProjectsResponse } from "../../../../../app/apis/azul/hca-dcp/common/responses";
+import * as C from "../../../../../app/components";
+import * as V from "../../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
+
+export const mainColumn: ComponentConfig[] = [
+  {
+    component: C.ManifestDownloadEntity,
+    viewBuilder: V.buildManifestDownloadEntity,
+  } as ComponentConfig<typeof C.ManifestDownloadEntity, ProjectsResponse>,
+];

--- a/site-config/lungmap/dev/detail/project/overviewSideColumn.ts
+++ b/site-config/lungmap/dev/detail/project/overviewSideColumn.ts
@@ -1,0 +1,4 @@
+import { ComponentConfig } from "@databiosphere/findable-ui/lib/config/entities";
+import { sideColumn as hcaOverviewSideColumn } from "../../../../hca-dcp/dev/detail/project/overviewSideColumn";
+
+export const sideColumn: ComponentConfig[] = hcaOverviewSideColumn.slice(1);

--- a/site-config/lungmap/dev/detail/project/overviewSideColumn.ts
+++ b/site-config/lungmap/dev/detail/project/overviewSideColumn.ts
@@ -1,4 +1,47 @@
 import { ComponentConfig } from "@databiosphere/findable-ui/lib/config/entities";
-import { sideColumn as hcaOverviewSideColumn } from "../../../../hca-dcp/dev/detail/project/overviewSideColumn";
+import { ProjectsResponse } from "../../../../../app/apis/azul/hca-dcp/common/responses";
+import * as C from "../../../../../app/components";
+import * as V from "../../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
 
-export const sideColumn: ComponentConfig[] = hcaOverviewSideColumn.slice(1);
+export const sideColumn: ComponentConfig[] = [
+  {
+    children: [
+      {
+        children: [
+          {
+            component: C.SectionTitle,
+            props: {
+              title: "Analysis Portals",
+            },
+          } as ComponentConfig<typeof C.SectionTitle>,
+          {
+            component: C.KeyValuePairs,
+            viewBuilder: V.buildAnalysisPortals,
+          } as ComponentConfig<typeof C.KeyValuePairs, ProjectsResponse>,
+        ],
+        component: C.Grid,
+        props: {
+          gridSx: { gap: 4 },
+        },
+      } as ComponentConfig<typeof C.Grid>,
+    ],
+    component: C.GridPaperSection,
+  } as ComponentConfig<typeof C.GridPaperSection>,
+  {
+    component: C.Details,
+    viewBuilder: V.buildDetails,
+  } as ComponentConfig<typeof C.Details>,
+  {
+    children: [
+      {
+        component: C.KeyValuePairs,
+        viewBuilder: V.buildFileCounts,
+      } as ComponentConfig<typeof C.KeyValuePairs, ProjectsResponse>,
+    ],
+    component: C.CollapsableSection,
+    props: {
+      collapsable: true,
+      title: "File Counts",
+    },
+  } as ComponentConfig<typeof C.CollapsableSection>,
+];

--- a/site-config/lungmap/dev/export/exportConfig.ts
+++ b/site-config/lungmap/dev/export/exportConfig.ts
@@ -3,6 +3,8 @@ import {
   ExportConfig,
   ExportMethodConfig,
 } from "@databiosphere/findable-ui/lib/config/entities";
+import * as C from "../../../../app/components";
+import * as HCAViewModelBuilders from "../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
 import * as V from "../../../../app/viewModelBuilders/azul/lungmap/common/viewModelBuilders";
 import {
   ROUTE_BULK_DOWNLOAD,
@@ -17,7 +19,22 @@ export const exportConfig: ExportConfig = {
   ...getExportConfig(hcaExportConfig),
   tabs: [
     {
-      ...hcaExportConfig.tabs[0],
+      label: "Choose Export Method",
+      mainColumn: [
+        {
+          component: C.ExportMethod,
+          viewBuilder: HCAViewModelBuilders.buildExportMethodBulkDownload,
+        } as ComponentConfig<typeof C.ExportMethod>,
+        {
+          component: C.ExportMethod,
+          viewBuilder: HCAViewModelBuilders.buildExportMethodManifestDownload,
+        } as ComponentConfig<typeof C.ExportMethod>,
+        {
+          component: C.ExportMethod,
+          viewBuilder: HCAViewModelBuilders.buildExportMethodTerra,
+        } as ComponentConfig<typeof C.ExportMethod>,
+      ],
+      route: "/export",
       sideColumn: [
         ...getExportCurrentQueryAndDataSummary(),
         ...getExportDataReleasePolicy(),

--- a/site-config/lungmap/dev/index/common/category.ts
+++ b/site-config/lungmap/dev/index/common/category.ts
@@ -1,0 +1,37 @@
+import {
+  CategoryConfig,
+  CategoryGroup,
+} from "@databiosphere/findable-ui/lib/config/entities";
+import {
+  ACCESSIBLE,
+  MA_CATEGORY_GROUP,
+} from "site-config/hca-dcp/cc-ma-dev/index/common/category";
+import {
+  BIONETWORK_NAME,
+  CATEGORY_GROUP,
+} from "site-config/hca-dcp/dev/index/common/category";
+
+export const PROJECTS_CATEGORY_KEYS_EXCLUDE = [
+  ACCESSIBLE.key,
+  BIONETWORK_NAME.key,
+];
+
+export const LUNGMAP_CATEGORY_GROUP: Record<string, CategoryGroup> = {
+  PROJECT: {
+    ...MA_CATEGORY_GROUP.PROJECT,
+    categoryConfigs: [
+      ...MA_CATEGORY_GROUP.PROJECT.categoryConfigs.filter(
+        (categoryGroup: CategoryConfig) =>
+          !PROJECTS_CATEGORY_KEYS_EXCLUDE.includes(categoryGroup.key)
+      ),
+    ],
+  },
+};
+
+export const CATEGORY_GROUPS: CategoryGroup[] = [
+  LUNGMAP_CATEGORY_GROUP.PROJECT,
+  CATEGORY_GROUP.DONOR,
+  CATEGORY_GROUP.SAMPLE,
+  CATEGORY_GROUP.PROTOCOL,
+  CATEGORY_GROUP.FILE,
+];

--- a/site-config/lungmap/dev/index/common/category.ts
+++ b/site-config/lungmap/dev/index/common/category.ts
@@ -1,35 +1,73 @@
+import { CategoryGroup } from "@databiosphere/findable-ui/lib/config/entities";
 import {
-  CategoryConfig,
-  CategoryGroup,
-} from "@databiosphere/findable-ui/lib/config/entities";
-import {
-  ACCESSIBLE,
-  MA_CATEGORY_GROUP,
-} from "site-config/hca-dcp/cc-ma-dev/index/common/category";
-import {
-  BIONETWORK_NAME,
-  CATEGORY_GROUP,
-} from "site-config/hca-dcp/dev/index/common/category";
+  ANALYSIS_PROTOCOL,
+  ANATOMICAL_ENTITY,
+  BIOLOGICAL_SEX,
+  CONTACT_NAME,
+  CONTENT_DESCRIPTION,
+  DEVELOPMENT_STAGE,
+  DONOR_DISEASE,
+  FILE_FORMAT,
+  FILE_SOURCE,
+  GENUS_SPECIES,
+  INSTITUTION,
+  INSTRUMENT_MANUFACTURER_MODEL,
+  LIBRARY_CONSTRUCTION_METHOD,
+  MODEL_ORGAN,
+  NUCLEIC_ACID_SOURCE,
+  ORGAN_PART,
+  PAIRED_END,
+  PRESERVATION_METHOD,
+  PROJECT_TITLE,
+  SAMPLE_ENTITY_TYPE,
+  SELECTED_CELL_TYPE,
+  SPECIMEN_DISEASE,
+} from "../../../../hca-dcp/dev/index/common/category";
 
-export const PROJECTS_CATEGORY_KEYS_EXCLUDE = [
-  ACCESSIBLE.key,
-  BIONETWORK_NAME.key,
-];
-
-export const LUNGMAP_CATEGORY_GROUP: Record<string, CategoryGroup> = {
-  PROJECT: {
-    ...MA_CATEGORY_GROUP.PROJECT,
+export const CATEGORY_GROUP: Record<string, CategoryGroup> = {
+  DONOR: {
     categoryConfigs: [
-      ...MA_CATEGORY_GROUP.PROJECT.categoryConfigs.filter(
-        (categoryGroup: CategoryConfig) =>
-          !PROJECTS_CATEGORY_KEYS_EXCLUDE.includes(categoryGroup.key)
-      ),
+      BIOLOGICAL_SEX,
+      DEVELOPMENT_STAGE,
+      DONOR_DISEASE,
+      GENUS_SPECIES,
     ],
+    label: "Donor",
+  },
+  FILE: {
+    categoryConfigs: [CONTENT_DESCRIPTION, FILE_FORMAT, FILE_SOURCE],
+    label: "File",
+  },
+  PROJECT: {
+    categoryConfigs: [PROJECT_TITLE, CONTACT_NAME, INSTITUTION],
+    label: "Project",
+  },
+  PROTOCOL: {
+    categoryConfigs: [
+      ANALYSIS_PROTOCOL, // workflow
+      INSTRUMENT_MANUFACTURER_MODEL,
+      LIBRARY_CONSTRUCTION_METHOD,
+      NUCLEIC_ACID_SOURCE,
+      PAIRED_END,
+    ],
+    label: "Protocol",
+  },
+  SAMPLE: {
+    categoryConfigs: [
+      ANATOMICAL_ENTITY, // specimenOrgan
+      ORGAN_PART,
+      PRESERVATION_METHOD,
+      MODEL_ORGAN,
+      SAMPLE_ENTITY_TYPE,
+      SELECTED_CELL_TYPE,
+      SPECIMEN_DISEASE,
+    ],
+    label: "Sample",
   },
 };
 
 export const CATEGORY_GROUPS: CategoryGroup[] = [
-  LUNGMAP_CATEGORY_GROUP.PROJECT,
+  CATEGORY_GROUP.PROJECT,
   CATEGORY_GROUP.DONOR,
   CATEGORY_GROUP.SAMPLE,
   CATEGORY_GROUP.PROTOCOL,

--- a/site-config/lungmap/dev/index/filesEntityConfig.ts
+++ b/site-config/lungmap/dev/index/filesEntityConfig.ts
@@ -1,0 +1,6 @@
+import { EntityConfig } from "@databiosphere/findable-ui/lib/config/entities";
+import { filesEntityConfig as hcaFilesEntityConfig } from "../../../hca-dcp/dev/index/filesEntityConfig";
+
+export const filesEntityConfig: EntityConfig = {
+  ...hcaFilesEntityConfig,
+};

--- a/site-config/lungmap/dev/index/filesEntityConfig.ts
+++ b/site-config/lungmap/dev/index/filesEntityConfig.ts
@@ -1,6 +1,275 @@
-import { EntityConfig } from "@databiosphere/findable-ui/lib/config/entities";
-import { filesEntityConfig as hcaFilesEntityConfig } from "../../../hca-dcp/dev/index/filesEntityConfig";
+import {
+  ComponentConfig,
+  EntityConfig,
+  ListConfig,
+  SORT_DIRECTION,
+} from "@databiosphere/findable-ui/lib/config/entities";
+import { EXPLORE_MODE } from "@databiosphere/findable-ui/lib/hooks/useExploreMode";
+import {
+  HCA_DCP_CATEGORY_KEY,
+  HCA_DCP_CATEGORY_LABEL,
+} from "site-config/hca-dcp/category";
+import { subTitleHero as hcaSubTitleHero } from "site-config/hca-dcp/dev/listView/subTitleHero";
+import { FilesResponse } from "../../../../app/apis/azul/hca-dcp/common/responses";
+import * as C from "../../../../app/components";
+import * as V from "../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
 
 export const filesEntityConfig: EntityConfig = {
-  ...hcaFilesEntityConfig,
+  apiPath: "index/files",
+  detail: {
+    detailOverviews: [],
+    staticLoad: false,
+    tabs: [],
+    top: [],
+  },
+  exploreMode: EXPLORE_MODE.SS_FETCH_SS_FILTERING,
+  label: "Files",
+  list: {
+    columns: [
+      {
+        componentConfig: {
+          component: C.AzulFileDownload,
+          viewBuilder: V.buildFileDownload,
+        } as ComponentConfig<typeof C.AzulFileDownload, FilesResponse>,
+        disableHiding: true,
+        disableSorting: true,
+        header: HCA_DCP_CATEGORY_LABEL.AZUL_FILE_DOWNLOAD,
+        id: HCA_DCP_CATEGORY_KEY.AZUL_FILE_DOWNLOAD,
+        width: { max: "auto", min: "76px" },
+      },
+      {
+        columnPinned: true,
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildFileName,
+        } as ComponentConfig<typeof C.BasicCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.FILE_NAME,
+        id: HCA_DCP_CATEGORY_KEY.FILE_NAME,
+        width: { max: "2fr", min: "240px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildFileFormat,
+        } as ComponentConfig<typeof C.BasicCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.FILE_FORMAT,
+        id: HCA_DCP_CATEGORY_KEY.FILE_FORMAT,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildFileSize,
+        } as ComponentConfig<typeof C.BasicCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.FILE_SIZE,
+        id: HCA_DCP_CATEGORY_KEY.FILE_SIZE,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedProtocolWorkflow,
+        } as ComponentConfig<typeof C.NTagCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.WORKFLOW,
+        id: HCA_DCP_CATEGORY_KEY.WORKFLOW,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildFileContentDescriptions,
+        } as ComponentConfig<typeof C.NTagCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.CONTENT_DESCRIPTION,
+        id: HCA_DCP_CATEGORY_KEY.CONTENT_DESCRIPTION,
+        width: { max: "1fr", min: "124px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildFileSource,
+        } as ComponentConfig<typeof C.BasicCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.FILE_SOURCE,
+        id: HCA_DCP_CATEGORY_KEY.FILE_SOURCE,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        componentConfig: {
+          component: C.Link,
+          viewBuilder: V.buildAggregatedProjectTitle,
+        } as ComponentConfig<typeof C.Link, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.PROJECT_TITLE,
+        id: HCA_DCP_CATEGORY_KEY.PROJECT_TITLE,
+        width: { max: "2fr", min: "240px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedSampleId,
+        } as ComponentConfig<typeof C.NTagCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.SAMPLE_ID,
+        id: HCA_DCP_CATEGORY_KEY.SAMPLE_ID,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedDonorGenusSpecies,
+        } as ComponentConfig<typeof C.NTagCell, FilesResponse>,
+        header: "Species",
+        id: HCA_DCP_CATEGORY_KEY.GENUS_SPECIES,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedSampleEntityType,
+        } as ComponentConfig<typeof C.NTagCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.SAMPLE_ENTITY_TYPE,
+        id: HCA_DCP_CATEGORY_KEY.SAMPLE_ENTITY_TYPE,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedSpecimenOrgan,
+        } as ComponentConfig<typeof C.NTagCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.SPECIMEN_ORGAN,
+        id: HCA_DCP_CATEGORY_KEY.SPECIMEN_ORGAN,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedSpecimenOrganPart,
+        } as ComponentConfig<typeof C.NTagCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.ORGAN_PART,
+        id: HCA_DCP_CATEGORY_KEY.ORGAN_PART,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedSampleModelOrgan,
+        } as ComponentConfig<typeof C.NTagCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.MODEL_ORGAN,
+        id: HCA_DCP_CATEGORY_KEY.MODEL_ORGAN,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedCellSuspensionSelectedCellType,
+        } as ComponentConfig<typeof C.NTagCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.SELECTED_CELL_TYPE,
+        id: HCA_DCP_CATEGORY_KEY.SELECTED_CELL_TYPE,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedProtocolLibraryConstructionApproach,
+        } as ComponentConfig<typeof C.NTagCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.LIBRARY_CONSTRUCTION_METHOD,
+        id: HCA_DCP_CATEGORY_KEY.LIBRARY_CONSTRUCTION_METHOD,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedProtocolNucleicAcidSource,
+        } as ComponentConfig<typeof C.NTagCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.NUCLEIC_ACID_SOURCE,
+        id: HCA_DCP_CATEGORY_KEY.NUCLEIC_ACID_SOURCE,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildAggregatedProtocolPairedEnd,
+        } as ComponentConfig<typeof C.BasicCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.PAIRED_END,
+        id: HCA_DCP_CATEGORY_KEY.PAIRED_END,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedDonorOrganismAge,
+        } as ComponentConfig<typeof C.NTagCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.ORGANISM_AGE,
+        id: HCA_DCP_CATEGORY_KEY.ORGANISM_AGE,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildAggregatedDonorBiologicalSex,
+        } as ComponentConfig<typeof C.BasicCell, FilesResponse>,
+        header: "Sex",
+        id: HCA_DCP_CATEGORY_KEY.BIOLOGICAL_SEX,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedSpecimenDisease,
+        } as ComponentConfig<typeof C.NTagCell, FilesResponse>,
+        header: "Disease (Specimen)",
+        id: HCA_DCP_CATEGORY_KEY.SPECIMEN_DISEASE,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedDonorDisease,
+        } as ComponentConfig<typeof C.NTagCell, FilesResponse>,
+        header: "Disease (Donor)",
+        id: HCA_DCP_CATEGORY_KEY.DONOR_DISEASE,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedDonorDevelopmentStage,
+        } as ComponentConfig<typeof C.NTagCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.DEVELOPMENT_STAGE,
+        id: HCA_DCP_CATEGORY_KEY.DEVELOPMENT_STAGE,
+        width: { max: "1fr", min: "148px" },
+      },
+      {
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildTotalCells,
+        } as ComponentConfig<typeof C.BasicCell, FilesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.CELL_COUNT,
+        id: HCA_DCP_CATEGORY_KEY.CELL_COUNT,
+        width: { max: "1fr", min: "124px" },
+      },
+    ],
+    defaultSort: {
+      desc: SORT_DIRECTION.ASCENDING,
+      id: HCA_DCP_CATEGORY_KEY.FILE_NAME,
+    },
+  } as ListConfig<FilesResponse>,
+  listView: {
+    subTitleHero: hcaSubTitleHero,
+  },
+  route: "files",
 };

--- a/site-config/lungmap/dev/index/filesEntityConfig.ts
+++ b/site-config/lungmap/dev/index/filesEntityConfig.ts
@@ -9,7 +9,6 @@ import {
   HCA_DCP_CATEGORY_KEY,
   HCA_DCP_CATEGORY_LABEL,
 } from "site-config/hca-dcp/category";
-import { subTitleHero as hcaSubTitleHero } from "site-config/hca-dcp/dev/listView/subTitleHero";
 import { FilesResponse } from "../../../../app/apis/azul/hca-dcp/common/responses";
 import * as C from "../../../../app/components";
 import * as V from "../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
@@ -268,8 +267,5 @@ export const filesEntityConfig: EntityConfig = {
       id: HCA_DCP_CATEGORY_KEY.FILE_NAME,
     },
   } as ListConfig<FilesResponse>,
-  listView: {
-    subTitleHero: hcaSubTitleHero,
-  },
   route: "files",
 };

--- a/site-config/lungmap/dev/index/projectsEntityConfig.ts
+++ b/site-config/lungmap/dev/index/projectsEntityConfig.ts
@@ -1,10 +1,27 @@
-import { EntityConfig } from "@databiosphere/findable-ui/lib/config/entities";
-import { HCA_DCP_CATEGORY_KEY } from "site-config/hca-dcp/category";
+import {
+  ComponentConfig,
+  EntityConfig,
+  SORT_DIRECTION,
+} from "@databiosphere/findable-ui/lib/config/entities";
+import { EXPLORE_MODE } from "@databiosphere/findable-ui/lib/hooks/useExploreMode";
+import {
+  HCA_DCP_CATEGORY_KEY,
+  HCA_DCP_CATEGORY_LABEL,
+} from "site-config/hca-dcp/category";
+import { ProjectsResponse } from "../../../../app/apis/azul/hca-dcp/common/responses";
+import {
+  getProjectId,
+  getTitle,
+} from "../../../../app/apis/azul/hca-dcp/common/utils";
+import * as C from "../../../../app/components";
+import { projectEdits as hcaProjectEdits } from "../../../../app/viewModelBuilders/azul/hca-dcp/common/projectMapper/projectEdits/projectEdits";
+import * as V from "../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
 import { mainColumn as hcaMetadataMainColumn } from "../../../hca-dcp/dev/detail/project/metadataMainColumn";
-import { projectsEntityConfig as hcaProjectsEntity } from "../../../hca-dcp/dev/index/projectsEntityConfig";
+import { top as hcaTop } from "../../../hca-dcp/dev/detail/project/top";
+import { subTitleHero as hcaSubTitleHero } from "../../../hca-dcp/dev/listView/subTitleHero";
 import { mainColumn as exportMainColumn } from "../detail/project/exportMainColumn";
 import { sideColumn as exportSideColumn } from "../detail/project/exportSideColumn";
-import { getOverviewMainColumn } from "../detail/project/mainColumn";
+import { mainColumn as overviewMainColumn } from "../detail/project/mainColumn";
 import { mainColumn as matricesMainColumn } from "../detail/project/matricesMainColumn";
 import { sideColumn as metadataSideColumn } from "../detail/project/metadataSideColumn";
 import { sideColumn as overviewSideColumn } from "../detail/project/overviewSideColumn";
@@ -12,21 +29,17 @@ import { mainColumn as projectFilesMainColumn } from "../detail/project/projectF
 import { sideColumn as projectFilesSideColumn } from "../detail/project/projectFilesSideColumn";
 
 /**
- * Columns from the HCA proejctsEntityConfig that should be excluded
- */
-const EXCLUDE_COLUMNS = [HCA_DCP_CATEGORY_KEY.BIONETWORK_NAME] as string[];
-
-/**
  * Entity config object responsible to config anything related to the /projects route.
  */
 export const projectsEntityConfig: EntityConfig = {
-  ...hcaProjectsEntity,
+  apiPath: "index/projects",
   detail: {
-    ...hcaProjectsEntity.detail,
+    detailOverviews: ["Overview"],
+    staticLoad: true,
     tabs: [
       {
         label: "Overview",
-        mainColumn: getOverviewMainColumn(),
+        mainColumn: overviewMainColumn,
         route: "",
         sideColumn: overviewSideColumn,
       },
@@ -54,11 +67,197 @@ export const projectsEntityConfig: EntityConfig = {
         sideColumn: exportSideColumn,
       },
     ],
+    top: hcaTop,
   },
+  exploreMode: EXPLORE_MODE.SS_FETCH_SS_FILTERING,
+  getId: getProjectId,
+  getTitle: getTitle,
+  label: "Projects",
   list: {
-    ...hcaProjectsEntity.list,
-    columns: hcaProjectsEntity.list.columns.filter(
-      (column) => !EXCLUDE_COLUMNS.includes(column.id)
-    ),
+    columns: [
+      {
+        componentConfig: {
+          component: C.Link,
+          viewBuilder: V.buildProjectTitle,
+        } as ComponentConfig<typeof C.Link, ProjectsResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.PROJECT_TITLE,
+        id: HCA_DCP_CATEGORY_KEY.PROJECT_TITLE,
+        width: { max: "2fr", min: "374px" },
+      },
+      {
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedDonorGenusSpecies,
+        } as ComponentConfig<typeof C.NTagCell, ProjectsResponse>,
+        header: "Species", // TODO confirm header
+        id: HCA_DCP_CATEGORY_KEY.GENUS_SPECIES,
+        width: { max: "1fr", min: "136px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedSampleEntityType,
+        } as ComponentConfig<typeof C.NTagCell, ProjectsResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.SAMPLE_ENTITY_TYPE,
+        id: HCA_DCP_CATEGORY_KEY.SAMPLE_ENTITY_TYPE,
+        width: { max: "1fr", min: "148px" },
+      },
+      {
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedSpecimenOrgan,
+        } as ComponentConfig<typeof C.NTagCell, ProjectsResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.ANATOMICAL_ENTITY,
+        id: HCA_DCP_CATEGORY_KEY.ANATOMICAL_ENTITY,
+        width: { max: "1fr", min: "146px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedSpecimenOrganPart,
+        } as ComponentConfig<typeof C.NTagCell, ProjectsResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.ORGAN_PART,
+        id: HCA_DCP_CATEGORY_KEY.ORGAN_PART,
+        width: { max: "1fr", min: "146px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedSampleModelOrgan,
+        } as ComponentConfig<typeof C.NTagCell, ProjectsResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.MODEL_ORGAN,
+        id: HCA_DCP_CATEGORY_KEY.MODEL_ORGAN,
+        width: { max: "1fr", min: "146px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedCellSuspensionSelectedCellType,
+        } as ComponentConfig<typeof C.NTagCell, ProjectsResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.SELECTED_CELL_TYPE,
+        id: HCA_DCP_CATEGORY_KEY.SELECTED_CELL_TYPE,
+        width: { max: "1fr", min: "146px" },
+      },
+      {
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedProtocolLibraryConstructionApproach,
+        } as ComponentConfig<typeof C.NTagCell, ProjectsResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.LIBRARY_CONSTRUCTION_METHOD,
+        id: HCA_DCP_CATEGORY_KEY.LIBRARY_CONSTRUCTION_METHOD,
+        width: { max: "1fr", min: "126px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedProtocolNucleicAcidSource,
+        } as ComponentConfig<typeof C.NTagCell, ProjectsResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.NUCLEIC_ACID_SOURCE,
+        id: HCA_DCP_CATEGORY_KEY.NUCLEIC_ACID_SOURCE,
+        width: { max: "1fr", min: "146px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildAggregatedProtocolPairedEnd,
+        } as ComponentConfig<typeof C.BasicCell, ProjectsResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.PAIRED_END,
+        id: HCA_DCP_CATEGORY_KEY.PAIRED_END,
+        width: { max: "1fr", min: "146px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedProtocolWorkflow,
+        } as ComponentConfig<typeof C.NTagCell, ProjectsResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.WORKFLOW,
+        id: HCA_DCP_CATEGORY_KEY.WORKFLOW,
+        width: { max: "1fr", min: "146px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedSpecimenDisease,
+        } as ComponentConfig<typeof C.NTagCell, ProjectsResponse>,
+        header: "Disease (Specimen)",
+        id: HCA_DCP_CATEGORY_KEY.SPECIMEN_DISEASE,
+        width: { max: "1fr", min: "146px" },
+      },
+      {
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedDonorDisease,
+        } as ComponentConfig<typeof C.NTagCell, ProjectsResponse>,
+        header: "Disease (Donor)",
+        id: HCA_DCP_CATEGORY_KEY.DONOR_DISEASE,
+        width: { max: "1fr", min: "128px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedDonorDevelopmentStage,
+        } as ComponentConfig<typeof C.NTagCell, ProjectsResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.DEVELOPMENT_STAGE,
+        id: HCA_DCP_CATEGORY_KEY.DEVELOPMENT_STAGE,
+        width: { max: "1fr", min: "148px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildAggregatedDonorCount,
+        } as ComponentConfig<typeof C.BasicCell, ProjectsResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.DONOR_COUNT,
+        id: HCA_DCP_CATEGORY_KEY.DONOR_COUNT,
+        width: { max: "1fr", min: "124px" },
+      },
+      {
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildEstimateCellCount,
+        } as ComponentConfig<typeof C.BasicCell, ProjectsResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.EFFECTIVE_CELL_COUNT,
+        id: HCA_DCP_CATEGORY_KEY.EFFECTIVE_CELL_COUNT,
+        width: { max: "1fr", min: "124px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildAggregateSubmissionDate,
+        } as ComponentConfig<typeof C.BasicCell, ProjectsResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.AGGREGATE_SUBMISSION_DATE,
+        id: HCA_DCP_CATEGORY_KEY.AGGREGATE_SUBMISSION_DATE,
+        width: { max: "1fr", min: "224px" },
+      },
+      {
+        columnVisible: true,
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildAggregateLastModifiedDate,
+        } as ComponentConfig<typeof C.BasicCell, ProjectsResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.AGGREGATE_LAST_MODIFIED_DATE,
+        id: HCA_DCP_CATEGORY_KEY.AGGREGATE_LAST_MODIFIED_DATE,
+        width: { max: "1fr", min: "224px" },
+      },
+    ],
+    defaultSort: {
+      desc: SORT_DIRECTION.DESCENDING,
+      id: HCA_DCP_CATEGORY_KEY.AGGREGATE_LAST_MODIFIED_DATE,
+    },
   },
+  listView: {
+    subTitleHero: hcaSubTitleHero,
+  },
+  overrides: hcaProjectEdits,
+  route: "projects",
 };

--- a/site-config/lungmap/dev/index/projectsEntityConfig.ts
+++ b/site-config/lungmap/dev/index/projectsEntityConfig.ts
@@ -1,14 +1,20 @@
 import { EntityConfig } from "@databiosphere/findable-ui/lib/config/entities";
+import { HCA_DCP_CATEGORY_KEY } from "site-config/hca-dcp/category";
 import { mainColumn as hcaMetadataMainColumn } from "../../../hca-dcp/dev/detail/project/metadataMainColumn";
-import { sideColumn as hcaOverviewSideColumn } from "../../../hca-dcp/dev/detail/project/overviewSideColumn";
 import { projectsEntityConfig as hcaProjectsEntity } from "../../../hca-dcp/dev/index/projectsEntityConfig";
 import { mainColumn as exportMainColumn } from "../detail/project/exportMainColumn";
 import { sideColumn as exportSideColumn } from "../detail/project/exportSideColumn";
 import { getOverviewMainColumn } from "../detail/project/mainColumn";
 import { mainColumn as matricesMainColumn } from "../detail/project/matricesMainColumn";
 import { sideColumn as metadataSideColumn } from "../detail/project/metadataSideColumn";
+import { sideColumn as overviewSideColumn } from "../detail/project/overviewSideColumn";
 import { mainColumn as projectFilesMainColumn } from "../detail/project/projectFilesMainColumn";
 import { sideColumn as projectFilesSideColumn } from "../detail/project/projectFilesSideColumn";
+
+/**
+ * Columns from the HCA proejctsEntityConfig that should be excluded
+ */
+const EXCLUDE_COLUMNS = [HCA_DCP_CATEGORY_KEY.BIONETWORK_NAME] as string[];
 
 /**
  * Entity config object responsible to config anything related to the /projects route.
@@ -22,7 +28,7 @@ export const projectsEntityConfig: EntityConfig = {
         label: "Overview",
         mainColumn: getOverviewMainColumn(),
         route: "",
-        sideColumn: hcaOverviewSideColumn,
+        sideColumn: overviewSideColumn,
       },
       {
         label: "Metadata",
@@ -48,5 +54,11 @@ export const projectsEntityConfig: EntityConfig = {
         sideColumn: exportSideColumn,
       },
     ],
+  },
+  list: {
+    ...hcaProjectsEntity.list,
+    columns: hcaProjectsEntity.list.columns.filter(
+      (column) => !EXCLUDE_COLUMNS.includes(column.id)
+    ),
   },
 };

--- a/site-config/lungmap/dev/index/projectsEntityConfig.ts
+++ b/site-config/lungmap/dev/index/projectsEntityConfig.ts
@@ -16,13 +16,12 @@ import {
 import * as C from "../../../../app/components";
 import { projectEdits as hcaProjectEdits } from "../../../../app/viewModelBuilders/azul/hca-dcp/common/projectMapper/projectEdits/projectEdits";
 import * as V from "../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
-import { mainColumn as hcaMetadataMainColumn } from "../../../hca-dcp/dev/detail/project/metadataMainColumn";
 import { top as hcaTop } from "../../../hca-dcp/dev/detail/project/top";
-import { subTitleHero as hcaSubTitleHero } from "../../../hca-dcp/dev/listView/subTitleHero";
 import { mainColumn as exportMainColumn } from "../detail/project/exportMainColumn";
 import { sideColumn as exportSideColumn } from "../detail/project/exportSideColumn";
 import { mainColumn as overviewMainColumn } from "../detail/project/mainColumn";
 import { mainColumn as matricesMainColumn } from "../detail/project/matricesMainColumn";
+import { mainColumn as metadataMainColumn } from "../detail/project/metadataMainColumn";
 import { sideColumn as metadataSideColumn } from "../detail/project/metadataSideColumn";
 import { sideColumn as overviewSideColumn } from "../detail/project/overviewSideColumn";
 import { mainColumn as projectFilesMainColumn } from "../detail/project/projectFilesMainColumn";
@@ -45,7 +44,7 @@ export const projectsEntityConfig: EntityConfig = {
       },
       {
         label: "Metadata",
-        mainColumn: hcaMetadataMainColumn,
+        mainColumn: metadataMainColumn,
         route: "project-metadata",
         sideColumn: metadataSideColumn,
       },
@@ -254,9 +253,6 @@ export const projectsEntityConfig: EntityConfig = {
       desc: SORT_DIRECTION.DESCENDING,
       id: HCA_DCP_CATEGORY_KEY.AGGREGATE_LAST_MODIFIED_DATE,
     },
-  },
-  listView: {
-    subTitleHero: hcaSubTitleHero,
   },
   overrides: hcaProjectEdits,
   route: "projects",

--- a/site-config/lungmap/dev/index/samplesEntityConfig.ts
+++ b/site-config/lungmap/dev/index/samplesEntityConfig.ts
@@ -12,7 +12,6 @@ import {
 import { SamplesResponse } from "../../../../app/apis/azul/hca-dcp/common/responses";
 import * as C from "../../../../app/components";
 import * as V from "../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
-import { subTitleHero as hcaSubTitleHero } from "../../../hca-dcp/dev/listView/subTitleHero";
 
 export const samplesEntityConfig: EntityConfig = {
   apiPath: "index/samples",
@@ -204,8 +203,5 @@ export const samplesEntityConfig: EntityConfig = {
       id: HCA_DCP_CATEGORY_KEY.SAMPLE_ID,
     },
   } as ListConfig<SamplesResponse>,
-  listView: {
-    subTitleHero: hcaSubTitleHero,
-  },
   route: "samples",
 };

--- a/site-config/lungmap/dev/index/samplesEntityConfig.ts
+++ b/site-config/lungmap/dev/index/samplesEntityConfig.ts
@@ -1,0 +1,6 @@
+import { EntityConfig } from "@databiosphere/findable-ui/lib/config/entities";
+import { samplesEntityConfig as hcaSamplesEntityConfig } from "../../../hca-dcp/dev/index/samplesEntityConfig";
+
+export const samplesEntityConfig: EntityConfig = {
+  ...hcaSamplesEntityConfig,
+};

--- a/site-config/lungmap/dev/index/samplesEntityConfig.ts
+++ b/site-config/lungmap/dev/index/samplesEntityConfig.ts
@@ -1,6 +1,211 @@
-import { EntityConfig } from "@databiosphere/findable-ui/lib/config/entities";
-import { samplesEntityConfig as hcaSamplesEntityConfig } from "../../../hca-dcp/dev/index/samplesEntityConfig";
+import {
+  ComponentConfig,
+  EntityConfig,
+  ListConfig,
+  SORT_DIRECTION,
+} from "@databiosphere/findable-ui/lib/config/entities";
+import { EXPLORE_MODE } from "@databiosphere/findable-ui/lib/hooks/useExploreMode";
+import {
+  HCA_DCP_CATEGORY_KEY,
+  HCA_DCP_CATEGORY_LABEL,
+} from "site-config/hca-dcp/category";
+import { SamplesResponse } from "../../../../app/apis/azul/hca-dcp/common/responses";
+import * as C from "../../../../app/components";
+import * as V from "../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
+import { subTitleHero as hcaSubTitleHero } from "../../../hca-dcp/dev/listView/subTitleHero";
 
 export const samplesEntityConfig: EntityConfig = {
-  ...hcaSamplesEntityConfig,
+  apiPath: "index/samples",
+  detail: {
+    detailOverviews: [],
+    staticLoad: false,
+    tabs: [],
+    top: [],
+  },
+  exploreMode: EXPLORE_MODE.SS_FETCH_SS_FILTERING,
+  label: "Samples",
+  list: {
+    columns: [
+      {
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildSampleId,
+        } as ComponentConfig<typeof C.BasicCell, SamplesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.SAMPLE_ID,
+        id: HCA_DCP_CATEGORY_KEY.SAMPLE_ID,
+        width: { max: "1fr", min: "120px" },
+      },
+      {
+        componentConfig: {
+          component: C.Link,
+          viewBuilder: V.buildAggregatedProjectTitle,
+        } as ComponentConfig<typeof C.Link, SamplesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.PROJECT_TITLE,
+        id: HCA_DCP_CATEGORY_KEY.PROJECT_TITLE,
+        width: { max: "2fr", min: "240px" },
+      },
+      {
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedDonorGenusSpecies,
+        } as ComponentConfig<typeof C.NTagCell, SamplesResponse>,
+        header: "Species", // TODO review header
+        id: HCA_DCP_CATEGORY_KEY.GENUS_SPECIES,
+        width: { max: "1fr", min: "124px" },
+      },
+      {
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildSampleEntityType,
+        } as ComponentConfig<typeof C.BasicCell, SamplesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.SAMPLE_TYPE,
+        id: HCA_DCP_CATEGORY_KEY.SAMPLE_ENTITY_TYPE,
+        width: { max: "1fr", min: "124px" },
+      },
+      {
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedSpecimenOrgan,
+        } as ComponentConfig<typeof C.NTagCell, SamplesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.ANATOMICAL_ENTITY,
+        id: HCA_DCP_CATEGORY_KEY.ANATOMICAL_ENTITY,
+        width: { max: "1fr", min: "124px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedSpecimenOrganPart,
+        } as ComponentConfig<typeof C.NTagCell, SamplesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.ORGAN_PART,
+        id: HCA_DCP_CATEGORY_KEY.ORGAN_PART,
+        width: { max: "1fr", min: "124px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildSampleModelOrgan,
+        } as ComponentConfig<typeof C.BasicCell, SamplesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.MODEL_ORGAN,
+        id: HCA_DCP_CATEGORY_KEY.MODEL_ORGAN,
+        width: { max: "1fr", min: "124px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedCellSuspensionSelectedCellType,
+        } as ComponentConfig<typeof C.NTagCell, SamplesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.SELECTED_CELL_TYPE,
+        id: HCA_DCP_CATEGORY_KEY.SELECTED_CELL_TYPE,
+        width: { max: "1fr", min: "124px" },
+      },
+      {
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedProtocolLibraryConstructionApproach,
+        } as ComponentConfig<typeof C.NTagCell, SamplesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.LIBRARY_CONSTRUCTION_METHOD,
+        id: HCA_DCP_CATEGORY_KEY.LIBRARY_CONSTRUCTION_METHOD,
+        width: { max: "1fr", min: "124px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedProtocolNucleicAcidSource,
+        } as ComponentConfig<typeof C.NTagCell, SamplesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.NUCLEIC_ACID_SOURCE,
+        id: HCA_DCP_CATEGORY_KEY.NUCLEIC_ACID_SOURCE,
+        width: { max: "1fr", min: "124px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildAggregatedProtocolPairedEnd,
+        } as ComponentConfig<typeof C.BasicCell, SamplesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.PAIRED_END,
+        id: HCA_DCP_CATEGORY_KEY.PAIRED_END,
+        width: { max: "1fr", min: "124px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedProtocolWorkflow,
+        } as ComponentConfig<typeof C.NTagCell, SamplesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.WORKFLOW,
+        id: HCA_DCP_CATEGORY_KEY.WORKFLOW,
+        width: { max: "1fr", min: "124px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedDonorOrganismAge,
+        } as ComponentConfig<typeof C.NTagCell, SamplesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.ORGANISM_AGE,
+        id: HCA_DCP_CATEGORY_KEY.ORGANISM_AGE,
+        width: { max: "1fr", min: "124px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildAggregatedDonorBiologicalSex,
+        } as ComponentConfig<typeof C.BasicCell, SamplesResponse>,
+        header: "Sex",
+        id: HCA_DCP_CATEGORY_KEY.BIOLOGICAL_SEX,
+        width: { max: "1fr", min: "124px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedSpecimenDisease,
+        } as ComponentConfig<typeof C.NTagCell, SamplesResponse>,
+        header: "Disease (Specimen)",
+        id: HCA_DCP_CATEGORY_KEY.SPECIMEN_DISEASE,
+        width: { max: "1fr", min: "124px" },
+      },
+      {
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedDonorDisease,
+        } as ComponentConfig<typeof C.NTagCell, SamplesResponse>,
+        header: "Disease (Donor)", // TODO confirm header
+        id: HCA_DCP_CATEGORY_KEY.DONOR_DISEASE,
+        width: { max: "1fr", min: "124px" },
+      },
+      {
+        columnVisible: false,
+        componentConfig: {
+          component: C.NTagCell,
+          viewBuilder: V.buildAggregatedDonorDevelopmentStage,
+        } as ComponentConfig<typeof C.NTagCell, SamplesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.DEVELOPMENT_STAGE,
+        id: HCA_DCP_CATEGORY_KEY.DEVELOPMENT_STAGE,
+        width: { max: "1fr", min: "148px" },
+      },
+      {
+        componentConfig: {
+          component: C.BasicCell,
+          viewBuilder: V.buildTotalCells,
+        } as ComponentConfig<typeof C.BasicCell, SamplesResponse>,
+        header: HCA_DCP_CATEGORY_LABEL.CELL_COUNT,
+        id: HCA_DCP_CATEGORY_KEY.CELL_COUNT,
+        width: { max: "1fr", min: "124px" },
+      },
+    ],
+    defaultSort: {
+      desc: SORT_DIRECTION.ASCENDING,
+      id: HCA_DCP_CATEGORY_KEY.SAMPLE_ID,
+    },
+  } as ListConfig<SamplesResponse>,
+  listView: {
+    subTitleHero: hcaSubTitleHero,
+  },
+  route: "samples",
 };


### PR DESCRIPTION
### Ticket

Closes #4287 .

### Reviewers

@frano-m .

### Changes

- Excluded the "Access" and "Biological Network" HCA filters from appearing on Lungmap
- Excluded the "Biological Network" HCA column from appearing on the Lungmap Project Entity List
- Excluded the "Atlas" HCA detail from appearing on the Lungmap Project Detail page
- Duplicated code from HCA for details page columns, index columns, and filters, to avoiud changes to HCA also affecting Lungmap
