### PR TITLE
fix: get_change_df_over_time uses an inclusive range (#4365)

### DIFF
--- a/analytics/analytics_package/analytics/sheets_elements.py
+++ b/analytics/analytics_package/analytics/sheets_elements.py
@@ -270,7 +270,7 @@ def get_change_over_time_df(
         metrics,
 		time_dimension,
 		sort_results=[time_dimension],
-		df_processor=(lambda df: df.set_index(df.index + "01")[-2::-1]),
+		df_processor=(lambda df: df.set_index(df.index + "01").sort_index(ascending=False)),
 		format_table=False,
 		**other_params
 	)

--- a/analytics/analytics_package/setup.py
+++ b/analytics/analytics_package/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
 	name="analytics",
-	version="3.4.0",
+	version="3.4.1",
 	packages=["analytics"],
 	install_requires=["matplotlib", "pandas", "numpy", "google-auth-oauthlib", "google-api-python-client", "gspread", "gspread-formatting"],
 )


### PR DESCRIPTION
### Ticket

Closes #4365.

### Reviewers

@hunterckx.

### Changes

- Made the date range for `get_change_df_over_time_df` inclusive rather than half-open, to make it consistent with `get_flat_data_df`
