### PR TITLE
feat: remove help link in footer (#4405)

### DIFF
--- a/site-config/anvil-cmg/dev/config.ts
+++ b/site-config/anvil-cmg/dev/config.ts
@@ -158,10 +158,6 @@ export function makeConfig(
         Branding: C.ANVILBranding({ portalURL: portalUrl }),
         navLinks: [
           {
-            label: "Help",
-            url: `${browserUrl}/help`,
-          },
-          {
             label: "Privacy",
             url: `${browserUrl}/privacy`,
           },


### PR DESCRIPTION
### Ticket

Closes #4405.

### Reviewers

@MillenniumFalconMechanic.

### Changes

- Removed `Help` link in AnVIL DX footer (not AnVIL catalog).

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/22f9980b-897e-451b-879f-ec0f106a4cf9" />
