### PR TITLE
fix: use up-to-date column names for formatting call in analytics reports (#4421)

### DIFF
--- a/analytics/anvil-catalog-sheets/generate_sheets_report.ipynb
+++ b/analytics/anvil-catalog-sheets/generate_sheets_report.ipynb
@@ -2,9 +2,17 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: ANVIL_ANALYTICS_REPORTING_CLIENT_SECRET_PATH=../../../do_not_commit_ga4_credentials.json\n"
+     ]
+    }
+   ],
    "source": [
     "# Update this line to the path of your ga4 credentials. Make sure these are never stored in a version controlled folder.\n",
     "%env ANVIL_ANALYTICS_REPORTING_CLIENT_SECRET_PATH=../../../do_not_commit_ga4_credentials.json"
@@ -12,12 +20,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
     "from analytics import sheets_api as sheets\n",
     "from analytics import sheets_elements as elements\n",
+    "from analytics import entities as e\n",
     "from analytics import api as ga\n",
     "import pandas as pd\n",
     "from constants import *\n",
@@ -26,9 +35,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Please visit this URL to authorize this application: https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=274560362763-p5netdrssq6r02lcfan6s157m6d65rqe.apps.googleusercontent.com&redirect_uri=http%3A%2F%2Flocalhost%3A8082%2F&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fspreadsheets+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fanalytics.readonly&state=cvpeqoNGBve6K3fVhpWzKJZ2IBswWk&access_type=offline\n"
+     ]
+    }
+   ],
    "source": [
     "ga_authentication, drive_authentication, sheets_authentication = ga.authenticate(\n",
     "    SECRET_NAME,\n",
@@ -59,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,9 +87,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'spreadsheetId': '1e-m11cXlbdbYwGpdu_InyYQkTiWR2KkYigmvtN2qKGM',\n",
+       " 'replies': [{'addChart': {'chart': {'chartId': 929691188,\n",
+       "     'spec': {'title': 'Pageviews and Users Over Time',\n",
+       "      'basicChart': {'chartType': 'LINE',\n",
+       "       'axis': [{'position': 'BOTTOM_AXIS', 'viewWindowOptions': {}},\n",
+       "        {'position': 'LEFT_AXIS', 'viewWindowOptions': {}}],\n",
+       "       'domains': [{'domain': {'sourceRange': {'sources': [{'sheetId': 726663797,\n",
+       "             'startRowIndex': 0,\n",
+       "             'endRowIndex': 48,\n",
+       "             'startColumnIndex': 0,\n",
+       "             'endColumnIndex': 1}]}}}],\n",
+       "       'series': [{'series': {'sourceRange': {'sources': [{'sheetId': 726663797,\n",
+       "             'startRowIndex': 0,\n",
+       "             'endRowIndex': 48,\n",
+       "             'startColumnIndex': 1,\n",
+       "             'endColumnIndex': 2}]}},\n",
+       "         'targetAxis': 'LEFT_AXIS'},\n",
+       "        {'series': {'sourceRange': {'sources': [{'sheetId': 726663797,\n",
+       "             'startRowIndex': 0,\n",
+       "             'endRowIndex': 48,\n",
+       "             'startColumnIndex': 2,\n",
+       "             'endColumnIndex': 3}]}},\n",
+       "         'targetAxis': 'LEFT_AXIS'}],\n",
+       "       'headerCount': 1},\n",
+       "      'hiddenDimensionStrategy': 'SKIP_HIDDEN_ROWS_AND_COLUMNS',\n",
+       "      'titleTextFormat': {'fontFamily': 'Roboto'},\n",
+       "      'fontName': 'Roboto'},\n",
+       "     'position': {'overlayPosition': {'anchorCell': {'sheetId': 726663797,\n",
+       "        'columnIndex': 5},\n",
+       "       'offsetXPixels': 75,\n",
+       "       'offsetYPixels': 75,\n",
+       "       'widthPixels': 600,\n",
+       "       'heightPixels': 371}}}}}]}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "dict_spreadsheet = {\n",
     "    \"Monthly Traffic Summary\": df_monthly_pageviews,\n",
@@ -91,17 +151,17 @@
     "    sheets.FILE_OVERRIDE_BEHAVIORS.OVERRIDE_IF_IN_SAME_PLACE,\n",
     "    column_formatting_options={\n",
     "        \"Monthly Traffic Summary\": {\n",
-    "            \"Month\": sheets.COLUMN_FORMAT_OPTIONS.YEAR_MONTH_DATE,\n",
-    "            \"Users Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
-    "            \"Total Pageviews Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.DIMENSION_YEAR_MONTH[\"alias\"]: sheets.COLUMN_FORMAT_OPTIONS.YEAR_MONTH_DATE,\n",
+    "            e.METRIC_ACTIVE_USERS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.METRIC_PAGE_VIEWS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
     "        },\n",
     "        \"Outbound Links\": {\n",
-    "            \"Total Clicks Percent Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
-    "            \"Total Users Percent Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.SYNTHETIC_METRIC_CLICKS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.METRIC_TOTAL_USERS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
     "        },\n",
     "        \"Pageviews\": {\n",
-    "            \"Total Views Percent Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
-    "            \"Total Users Percent Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.METRIC_PAGE_VIEWS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.METRIC_TOTAL_USERS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
     "        },\n",
     "\n",
     "    },\n",
@@ -159,7 +219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/analytics/anvil-explorer-sheets/generate_sheets_report.ipynb
+++ b/analytics/anvil-explorer-sheets/generate_sheets_report.ipynb
@@ -2,13 +2,14 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
     "import analytics.api as ga\n",
     "import analytics.sheets_api as sheets\n",
     "import analytics.sheets_elements as elements\n",
+    "import analytics.entities as e\n",
     "import pandas as pd\n",
     "import gspread\n",
     "from constants import *"
@@ -16,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -33,14 +34,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Please visit this URL to authorize this application: https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=425030666072-vun85q7nt3038skng8gs0f03juh97e17.apps.googleusercontent.com&redirect_uri=http%3A%2F%2Flocalhost%3A8082%2F&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fspreadsheets+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fanalytics.readonly&state=o8oUzUca8ESjd1GImvQPjxAcKhIkdb&access_type=offline\n"
+      "Please visit this URL to authorize this application: https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=274560362763-p5netdrssq6r02lcfan6s157m6d65rqe.apps.googleusercontent.com&redirect_uri=http%3A%2F%2Flocalhost%3A8082%2F&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fanalytics.readonly+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fspreadsheets&state=3TOrvrS8EuGJvNWqEnjqNIlknGfZW7&access_type=offline\n"
      ]
     }
    ],
@@ -75,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,32 +87,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'spreadsheetId': '1Wm8jbfdBKu7Gd0ld40r8AwT4ffPg6xP4nV-jdY1FsE4',\n",
-       " 'replies': [{'addChart': {'chart': {'chartId': 918233154,\n",
+       "{'spreadsheetId': '1ueSQdU9pTa1qPptkNc4vk4xoHuJgP6gNcQ7exRxN9y0',\n",
+       " 'replies': [{'addChart': {'chart': {'chartId': 113619751,\n",
        "     'spec': {'title': 'Pageviews and Users Over Time',\n",
        "      'basicChart': {'chartType': 'LINE',\n",
        "       'axis': [{'position': 'BOTTOM_AXIS', 'viewWindowOptions': {}},\n",
        "        {'position': 'LEFT_AXIS', 'viewWindowOptions': {}}],\n",
-       "       'domains': [{'domain': {'sourceRange': {'sources': [{'sheetId': 1792760679,\n",
+       "       'domains': [{'domain': {'sourceRange': {'sources': [{'sheetId': 388329788,\n",
        "             'startRowIndex': 0,\n",
-       "             'endRowIndex': 12,\n",
+       "             'endRowIndex': 13,\n",
        "             'startColumnIndex': 0,\n",
        "             'endColumnIndex': 1}]}}}],\n",
-       "       'series': [{'series': {'sourceRange': {'sources': [{'sheetId': 1792760679,\n",
+       "       'series': [{'series': {'sourceRange': {'sources': [{'sheetId': 388329788,\n",
        "             'startRowIndex': 0,\n",
-       "             'endRowIndex': 12,\n",
+       "             'endRowIndex': 13,\n",
        "             'startColumnIndex': 1,\n",
        "             'endColumnIndex': 2}]}},\n",
        "         'targetAxis': 'LEFT_AXIS'},\n",
-       "        {'series': {'sourceRange': {'sources': [{'sheetId': 1792760679,\n",
+       "        {'series': {'sourceRange': {'sources': [{'sheetId': 388329788,\n",
        "             'startRowIndex': 0,\n",
-       "             'endRowIndex': 12,\n",
+       "             'endRowIndex': 13,\n",
        "             'startColumnIndex': 2,\n",
        "             'endColumnIndex': 3}]}},\n",
        "         'targetAxis': 'LEFT_AXIS'}],\n",
@@ -119,7 +120,7 @@
        "      'hiddenDimensionStrategy': 'SKIP_HIDDEN_ROWS_AND_COLUMNS',\n",
        "      'titleTextFormat': {'fontFamily': 'Roboto'},\n",
        "      'fontName': 'Roboto'},\n",
-       "     'position': {'overlayPosition': {'anchorCell': {'sheetId': 1792760679,\n",
+       "     'position': {'overlayPosition': {'anchorCell': {'sheetId': 388329788,\n",
        "        'columnIndex': 5},\n",
        "       'offsetXPixels': 75,\n",
        "       'offsetYPixels': 25,\n",
@@ -127,7 +128,7 @@
        "       'heightPixels': 371}}}}}]}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -150,17 +151,17 @@
     "    sheets.FILE_OVERRIDE_BEHAVIORS.OVERRIDE_IF_IN_SAME_PLACE,\n",
     "    column_formatting_options={\n",
     "        \"Explorer Summary\": {\n",
-    "            \"Month\": sheets.COLUMN_FORMAT_OPTIONS.YEAR_MONTH_DATE,\n",
-    "            \"Users Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
-    "            \"Total Pageviews Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.DIMENSION_YEAR_MONTH[\"alias\"]: sheets.COLUMN_FORMAT_OPTIONS.YEAR_MONTH_DATE,\n",
+    "            e.METRIC_ACTIVE_USERS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.METRIC_PAGE_VIEWS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
     "        },\n",
     "        \"Outbound Links\": {\n",
-    "            \"Total Clicks Percent Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
-    "            \"Total Users Percent Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.SYNTHETIC_METRIC_CLICKS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.METRIC_TOTAL_USERS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
     "        },\n",
     "        \"Pageviews\": {\n",
-    "            \"Total Views Percent Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
-    "            \"Total Users Percent Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.METRIC_PAGE_VIEWS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.METRIC_TOTAL_USERS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
     "        },\n",
     "\n",
     "    },\n",
@@ -218,7 +219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/analytics/hca-explorer-sheets/generate_sheets_report.ipynb
+++ b/analytics/hca-explorer-sheets/generate_sheets_report.ipynb
@@ -2,9 +2,17 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: HCA_ANALYTICS_REPORTING_CLIENT_SECRET_PATH=../../../do_not_commit_ga4_credentials.json\n"
+     ]
+    }
+   ],
    "source": [
     "# Update this line to the path of your ga4 credentials. Make sure these are never stored in a version controlled folder.\n",
     "%env HCA_ANALYTICS_REPORTING_CLIENT_SECRET_PATH=../../../do_not_commit_ga4_credentials.json"
@@ -12,12 +20,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
     "from analytics import sheets_api as sheets\n",
     "from analytics import sheets_elements as elements\n",
+    "from analytics import entities as e\n",
     "from analytics import api as ga\n",
     "import pandas as pd\n",
     "from constants import *\n",
@@ -26,9 +35,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "HCA_ANALYTICS_REPORTING_CLIENT_SECRET_PATH ../../../do_not_commit_ga4_credentials.json\n",
+      "Please visit this URL to authorize this application: https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=274560362763-p5netdrssq6r02lcfan6s157m6d65rqe.apps.googleusercontent.com&redirect_uri=http%3A%2F%2Flocalhost%3A8082%2F&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fspreadsheets+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fanalytics.readonly&state=FT0CijRvMp0UqcOaNAl7R8Bi6Zo2I7&access_type=offline\n"
+     ]
+    }
+   ],
    "source": [
     "ga_authentication, drive_authentication, sheets_authentication = ga.authenticate(\n",
     "    SECRET_NAME,\n",
@@ -60,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,9 +89,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'spreadsheetId': '1ayEkLcxd22Mf7wXKXjwGn-a6cunMCw2lbzuIPtuIL7g',\n",
+       " 'replies': [{'addChart': {'chart': {'chartId': 88883080,\n",
+       "     'spec': {'title': 'Pageviews and Users Over Time',\n",
+       "      'basicChart': {'chartType': 'LINE',\n",
+       "       'axis': [{'position': 'BOTTOM_AXIS', 'viewWindowOptions': {}},\n",
+       "        {'position': 'LEFT_AXIS', 'viewWindowOptions': {}}],\n",
+       "       'domains': [{'domain': {'sourceRange': {'sources': [{'sheetId': 139493651,\n",
+       "             'startRowIndex': 0,\n",
+       "             'endRowIndex': 13,\n",
+       "             'startColumnIndex': 0,\n",
+       "             'endColumnIndex': 1}]}}}],\n",
+       "       'series': [{'series': {'sourceRange': {'sources': [{'sheetId': 139493651,\n",
+       "             'startRowIndex': 0,\n",
+       "             'endRowIndex': 13,\n",
+       "             'startColumnIndex': 1,\n",
+       "             'endColumnIndex': 2}]}},\n",
+       "         'targetAxis': 'LEFT_AXIS'},\n",
+       "        {'series': {'sourceRange': {'sources': [{'sheetId': 139493651,\n",
+       "             'startRowIndex': 0,\n",
+       "             'endRowIndex': 13,\n",
+       "             'startColumnIndex': 2,\n",
+       "             'endColumnIndex': 3}]}},\n",
+       "         'targetAxis': 'LEFT_AXIS'}],\n",
+       "       'headerCount': 1},\n",
+       "      'hiddenDimensionStrategy': 'SKIP_HIDDEN_ROWS_AND_COLUMNS',\n",
+       "      'titleTextFormat': {'fontFamily': 'Roboto'},\n",
+       "      'fontName': 'Roboto'},\n",
+       "     'position': {'overlayPosition': {'anchorCell': {'sheetId': 139493651,\n",
+       "        'columnIndex': 5},\n",
+       "       'offsetXPixels': 75,\n",
+       "       'offsetYPixels': 25,\n",
+       "       'widthPixels': 600,\n",
+       "       'heightPixels': 371}}}}}]}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "dict_spreadsheet = {\n",
     "    \"Explorer Summary\": df_monthly_pageviews,\n",
@@ -94,17 +155,17 @@
     "    sheets.FILE_OVERRIDE_BEHAVIORS.OVERRIDE_IF_IN_SAME_PLACE,\n",
     "    column_formatting_options={\n",
     "        \"Explorer Summary\": {\n",
-    "            \"Month\": sheets.COLUMN_FORMAT_OPTIONS.YEAR_MONTH_DATE,\n",
-    "            \"Users Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
-    "            \"Total Pageviews Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.DIMENSION_YEAR_MONTH[\"alias\"]: sheets.COLUMN_FORMAT_OPTIONS.YEAR_MONTH_DATE,\n",
+    "            e.METRIC_ACTIVE_USERS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.METRIC_PAGE_VIEWS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
     "        },\n",
     "        \"Outbound Links\": {\n",
-    "            \"Total Clicks Percent Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
-    "            \"Total Users Percent Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.SYNTHETIC_METRIC_CLICKS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.METRIC_TOTAL_USERS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
     "        },\n",
     "        \"Page Views\": {\n",
-    "            \"Total Views Percent Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
-    "            \"Total Users Percent Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.METRIC_PAGE_VIEWS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.METRIC_TOTAL_USERS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
     "        }\n",
     "    },\n",
     "    sheet_formatting_options={\n",
@@ -162,7 +223,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/analytics/lungmap-analytics/sheets/generate_sheets_report.ipynb
+++ b/analytics/lungmap-analytics/sheets/generate_sheets_report.ipynb
@@ -2,13 +2,14 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
     "import analytics.api as ga\n",
     "import analytics.sheets_api as sheets\n",
     "import analytics.sheets_elements as elements\n",
+    "import analytics.entities as e\n",
     "import pandas as pd\n",
     "import gspread\n",
     "from constants import *"
@@ -16,18 +17,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: ANALYTICS_REPORTING_CLIENT_SECRET_PATH=../../../../do_not_commit_ga4_credentials.json\n"
+     ]
+    }
+   ],
    "source": [
     "%env ANALYTICS_REPORTING_CLIENT_SECRET_PATH=../../../../do_not_commit_ga4_credentials.json"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Please visit this URL to authorize this application: https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=274560362763-p5netdrssq6r02lcfan6s157m6d65rqe.apps.googleusercontent.com&redirect_uri=http%3A%2F%2Flocalhost%3A8082%2F&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fspreadsheets+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fanalytics.readonly&state=u1KGZe2fXcNGFQvdEn0yUQvCbU4IHu&access_type=offline\n"
+     ]
+    }
+   ],
    "source": [
     "ga_authentication, drive_authentication, sheets_authentication = ga.authenticate(\n",
     "    SECRET_NAME,\n",
@@ -59,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,9 +87,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'spreadsheetId': '1LC6lrC3ZhGuJFtPFIgvNWcFeoGyQnQtIkFAckEliVG0',\n",
+       " 'replies': [{'addChart': {'chart': {'chartId': 678937881,\n",
+       "     'spec': {'title': 'Pageviews and Users Over Time',\n",
+       "      'basicChart': {'chartType': 'LINE',\n",
+       "       'axis': [{'position': 'BOTTOM_AXIS', 'viewWindowOptions': {}},\n",
+       "        {'position': 'LEFT_AXIS', 'viewWindowOptions': {}}],\n",
+       "       'domains': [{'domain': {'sourceRange': {'sources': [{'sheetId': 286312932,\n",
+       "             'startRowIndex': 0,\n",
+       "             'endRowIndex': 41,\n",
+       "             'startColumnIndex': 0,\n",
+       "             'endColumnIndex': 1}]}}}],\n",
+       "       'series': [{'series': {'sourceRange': {'sources': [{'sheetId': 286312932,\n",
+       "             'startRowIndex': 0,\n",
+       "             'endRowIndex': 41,\n",
+       "             'startColumnIndex': 1,\n",
+       "             'endColumnIndex': 2}]}},\n",
+       "         'targetAxis': 'LEFT_AXIS'},\n",
+       "        {'series': {'sourceRange': {'sources': [{'sheetId': 286312932,\n",
+       "             'startRowIndex': 0,\n",
+       "             'endRowIndex': 41,\n",
+       "             'startColumnIndex': 2,\n",
+       "             'endColumnIndex': 3}]}},\n",
+       "         'targetAxis': 'LEFT_AXIS'}],\n",
+       "       'headerCount': 1},\n",
+       "      'hiddenDimensionStrategy': 'SKIP_HIDDEN_ROWS_AND_COLUMNS',\n",
+       "      'titleTextFormat': {'fontFamily': 'Roboto'},\n",
+       "      'fontName': 'Roboto'},\n",
+       "     'position': {'overlayPosition': {'anchorCell': {'sheetId': 286312932,\n",
+       "        'columnIndex': 5},\n",
+       "       'offsetXPixels': 75,\n",
+       "       'offsetYPixels': 75,\n",
+       "       'widthPixels': 600,\n",
+       "       'heightPixels': 371}}}}}]}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "dict_spreadsheet = {\n",
     "    \"Monthly Traffic Summary\": df_monthly_pageviews,\n",
@@ -91,17 +151,17 @@
     "    sheets.FILE_OVERRIDE_BEHAVIORS.OVERRIDE_IF_IN_SAME_PLACE,\n",
     "    column_formatting_options={\n",
     "        \"Monthly Traffic Summary\": {\n",
-    "            \"Month\": sheets.COLUMN_FORMAT_OPTIONS.YEAR_MONTH_DATE,\n",
-    "            \"Users Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
-    "            \"Total Pageviews Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.DIMENSION_YEAR_MONTH[\"alias\"]: sheets.COLUMN_FORMAT_OPTIONS.YEAR_MONTH_DATE,\n",
+    "            e.METRIC_ACTIVE_USERS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.METRIC_PAGE_VIEWS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
     "        },\n",
     "        \"Outbound Links\": {\n",
-    "            \"Total Clicks Percent Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
-    "            \"Total Users Percent Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.SYNTHETIC_METRIC_CLICKS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.METRIC_TOTAL_USERS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
     "        },\n",
     "        \"Pageviews\": {\n",
-    "            \"Total Views Percent Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
-    "            \"Total Users Percent Change\": sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.METRIC_PAGE_VIEWS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
+    "            e.METRIC_TOTAL_USERS[\"change_alias\"]: sheets.COLUMN_FORMAT_OPTIONS.PERCENT_COLORED,\n",
     "        },\n",
     "\n",
     "    },\n",
@@ -166,7 +226,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Closes #4421