### PR TITLE
feat: remove download buttons from files tab (#4429)

### DIFF
--- a/e2e/anvil/anvil-tabs.ts
+++ b/e2e/anvil/anvil-tabs.ts
@@ -167,7 +167,7 @@ export const ANVIL_TABS: AnvilCMGTabCollection = {
     url: "/donors",
   },
   FILES: {
-    emptyFirstColumn: true,
+    emptyFirstColumn: false,
     indexExportPage: ANVIL_INDEX_EXPORT_BUTTONS,
     maxPages: 25,
     preselectedColumns: ANVIL_FILES_PRESELECTED_COLUMNS_BY_NAME,

--- a/site-config/anvil-cmg/dev/index/filesEntityConfig.ts
+++ b/site-config/anvil-cmg/dev/index/filesEntityConfig.ts
@@ -141,6 +141,7 @@ export const filesEntityConfig: EntityConfig<FilesResponse> = {
     tableOptions: {
       initialState: {
         columnVisibility: {
+          [ANVIL_CMG_CATEGORY_KEY.AZUL_FILE_DOWNLOAD]: false,
           [ANVIL_CMG_CATEGORY_KEY.DONOR_PHENOTYPIC_SEX]: false,
           [ANVIL_CMG_CATEGORY_KEY.DONOR_REPORTED_ETHNICITY]: false,
           [ANVIL_CMG_CATEGORY_KEY.DIAGNOSE_DISEASE]: false,


### PR DESCRIPTION
### Ticket

Closes #4429.

### Reviewers

@NoopDog 

### Changes

- Removed download file buttons from files tab.

<img width="1872" alt="image" src="https://github.com/user-attachments/assets/7f4fce24-31fb-47c2-8c13-56ed99428091" />
