### PR TITLE
feat: add anvil data dictionary (#4416)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "2.13.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "22.0.0",
+        "@databiosphere/findable-ui": "^23.0.0",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@mdx-js/loader": "^3.0.1",
@@ -2480,9 +2480,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-22.0.0.tgz",
-      "integrity": "sha512-4LoEekBvQhh46RJWBVJtsuGmnVfLNaIxQ5OEDVq894gy/nDrQZK/3KHF8JmOTBI5+PeYUf34mme3Su58KaH6NQ==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-23.0.0.tgz",
+      "integrity": "sha512-QgVUgJVwFDOlhVOu+R77LP1vMC4wPJrUU4t9mOU//TWUU8kihLg+hzKOX5AjEbYFS5HGuCI7EGF5ZSCORSrDmg==",
       "engines": {
         "node": "20.10.0"
       },
@@ -26563,9 +26563,9 @@
       "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw=="
     },
     "@databiosphere/findable-ui": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-22.0.0.tgz",
-      "integrity": "sha512-4LoEekBvQhh46RJWBVJtsuGmnVfLNaIxQ5OEDVq894gy/nDrQZK/3KHF8JmOTBI5+PeYUf34mme3Su58KaH6NQ==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-23.0.0.tgz",
+      "integrity": "sha512-QgVUgJVwFDOlhVOu+R77LP1vMC4wPJrUU4t9mOU//TWUU8kihLg+hzKOX5AjEbYFS5HGuCI7EGF5ZSCORSrDmg==",
       "requires": {}
     },
     "@digitak/esrun": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "check-system-status:anvil-cmg": "esrun e2e/anvil/anvil-check-system-status.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "22.0.0",
+    "@databiosphere/findable-ui": "^23.0.0",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@mdx-js/loader": "^3.0.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -30,6 +30,7 @@ import type { AppProps } from "next/app";
 import { useEffect } from "react";
 import TagManager from "react-gtm-module";
 import { BREAKPOINTS } from "../site-config/common/constants";
+import { LayoutDimensionsProvider } from "@databiosphere/findable-ui/lib/providers/layoutDimensions/provider";
 
 const FEATURE_FLAGS = Object.values(FEATURES);
 const SESSION_TIMEOUT = 15 * 60 * 1000; // 15 minutes
@@ -77,47 +78,49 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
               timeout={SESSION_TIMEOUT}
             >
               <LoginGuardProvider>
-                <LayoutStateProvider>
-                  <AppLayout>
-                    <ThemeProvider
-                      theme={(theme: Theme): Theme =>
-                        createTheme(
-                          deepmerge(theme, {
-                            breakpoints: createBreakpoints(BREAKPOINTS),
-                          })
-                        )
-                      }
-                    >
-                      <Header {...header} />
-                    </ThemeProvider>
-                    <ExploreStateProvider entityListType={entityListType}>
-                      <FileManifestStateProvider>
-                        <Main>
-                          <ErrorBoundary
-                            fallbackRender={({
-                              error,
-                              reset,
-                            }: {
-                              error: DataExplorerError;
-                              reset: () => void;
-                            }): JSX.Element => (
-                              <Error
-                                errorMessage={error.message}
-                                requestUrlMessage={error.requestUrlMessage}
-                                rootPath={redirectRootToPath}
-                                onReset={reset}
-                              />
-                            )}
-                          >
-                            <Component {...pageProps} />
-                            <Floating {...floating} />
-                          </ErrorBoundary>
-                        </Main>
-                      </FileManifestStateProvider>
-                    </ExploreStateProvider>
-                    <Footer {...footer} />
-                  </AppLayout>
-                </LayoutStateProvider>
+                <LayoutDimensionsProvider>
+                  <LayoutStateProvider>
+                    <AppLayout>
+                      <ThemeProvider
+                        theme={(theme: Theme): Theme =>
+                          createTheme(
+                            deepmerge(theme, {
+                              breakpoints: createBreakpoints(BREAKPOINTS),
+                            })
+                          )
+                        }
+                      >
+                        <Header {...header} />
+                      </ThemeProvider>
+                      <ExploreStateProvider entityListType={entityListType}>
+                        <FileManifestStateProvider>
+                          <Main>
+                            <ErrorBoundary
+                              fallbackRender={({
+                                error,
+                                reset,
+                              }: {
+                                error: DataExplorerError;
+                                reset: () => void;
+                              }): JSX.Element => (
+                                <Error
+                                  errorMessage={error.message}
+                                  requestUrlMessage={error.requestUrlMessage}
+                                  rootPath={redirectRootToPath}
+                                  onReset={reset}
+                                />
+                              )}
+                            >
+                              <Component {...pageProps} />
+                              <Floating {...floating} />
+                            </ErrorBoundary>
+                          </Main>
+                        </FileManifestStateProvider>
+                      </ExploreStateProvider>
+                      <Footer {...footer} />
+                    </AppLayout>
+                  </LayoutStateProvider>
+                </LayoutDimensionsProvider>
               </LoginGuardProvider>
             </GoogleSignInAuthenticationProvider>
           </SystemStatusProvider>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,7 +14,6 @@ import { ConfigProvider as DXConfigProvider } from "@databiosphere/findable-ui/l
 import { ExploreStateProvider } from "@databiosphere/findable-ui/lib/providers/exploreState";
 import { FileManifestStateProvider } from "@databiosphere/findable-ui/lib/providers/fileManifestState";
 import { GoogleSignInAuthenticationProvider } from "@databiosphere/findable-ui/lib/providers/googleSignInAuthentication/provider";
-import { LayoutStateProvider } from "@databiosphere/findable-ui/lib/providers/layoutState";
 import { LoginGuardProvider } from "@databiosphere/findable-ui/lib/providers/loginGuard/provider";
 import { SystemStatusProvider } from "@databiosphere/findable-ui/lib/providers/systemStatus";
 import { createAppTheme } from "@databiosphere/findable-ui/lib/theme/theme";
@@ -79,47 +78,45 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
             >
               <LoginGuardProvider>
                 <LayoutDimensionsProvider>
-                  <LayoutStateProvider>
-                    <AppLayout>
-                      <ThemeProvider
-                        theme={(theme: Theme): Theme =>
-                          createTheme(
-                            deepmerge(theme, {
-                              breakpoints: createBreakpoints(BREAKPOINTS),
-                            })
-                          )
-                        }
-                      >
-                        <Header {...header} />
-                      </ThemeProvider>
-                      <ExploreStateProvider entityListType={entityListType}>
-                        <FileManifestStateProvider>
-                          <Main>
-                            <ErrorBoundary
-                              fallbackRender={({
-                                error,
-                                reset,
-                              }: {
-                                error: DataExplorerError;
-                                reset: () => void;
-                              }): JSX.Element => (
-                                <Error
-                                  errorMessage={error.message}
-                                  requestUrlMessage={error.requestUrlMessage}
-                                  rootPath={redirectRootToPath}
-                                  onReset={reset}
-                                />
-                              )}
-                            >
-                              <Component {...pageProps} />
-                              <Floating {...floating} />
-                            </ErrorBoundary>
-                          </Main>
-                        </FileManifestStateProvider>
-                      </ExploreStateProvider>
-                      <Footer {...footer} />
-                    </AppLayout>
-                  </LayoutStateProvider>
+                  <AppLayout>
+                    <ThemeProvider
+                      theme={(theme: Theme): Theme =>
+                        createTheme(
+                          deepmerge(theme, {
+                            breakpoints: createBreakpoints(BREAKPOINTS),
+                          })
+                        )
+                      }
+                    >
+                      <Header {...header} />
+                    </ThemeProvider>
+                    <ExploreStateProvider entityListType={entityListType}>
+                      <FileManifestStateProvider>
+                        <Main>
+                          <ErrorBoundary
+                            fallbackRender={({
+                              error,
+                              reset,
+                            }: {
+                              error: DataExplorerError;
+                              reset: () => void;
+                            }): JSX.Element => (
+                              <Error
+                                errorMessage={error.message}
+                                requestUrlMessage={error.requestUrlMessage}
+                                rootPath={redirectRootToPath}
+                                onReset={reset}
+                              />
+                            )}
+                          >
+                            <Component {...pageProps} />
+                            <Floating {...floating} />
+                          </ErrorBoundary>
+                        </Main>
+                      </FileManifestStateProvider>
+                    </ExploreStateProvider>
+                    <Footer {...footer} />
+                  </AppLayout>
                 </LayoutDimensionsProvider>
               </LoginGuardProvider>
             </GoogleSignInAuthenticationProvider>

--- a/pages/data-dictionary/index.tsx
+++ b/pages/data-dictionary/index.tsx
@@ -1,0 +1,10 @@
+import { DataDictionaryView } from "@databiosphere/findable-ui/lib/views/DataDictionaryView/dataDictionaryView";
+import { Main } from "@databiosphere/findable-ui/lib/components/Layout/components/ContentLayout/components/Main/main";
+
+const Page = (): JSX.Element => {
+  return <DataDictionaryView />;
+};
+
+Page.Main = Main;
+
+export default Page;

--- a/site-config/anvil-cmg/dev/config.ts
+++ b/site-config/anvil-cmg/dev/config.ts
@@ -185,6 +185,10 @@ export function makeConfig(
                   url: "/guides",
                 },
                 {
+                  label: "Data Dictionary",
+                  url: "/data-dictionary",
+                },
+                {
                   label: "Terms of service",
                   url: "/terms-of-service",
                 },


### PR DESCRIPTION
### Ticket

Closes #4416.

### Reviewers

@NoopDog.

### Changes

- Added AnVIL data dictionary page (requires findable-ui package with `<DataDictionaryView/>` component. See [PR](https://github.com/DataBiosphere/findable-ui/pull/338) and branch `fran/337-dictionary-navigation`.

<img width="1252" alt="image" src="https://github.com/user-attachments/assets/3e2e1580-97cd-4524-bf8f-77fdaddbbd1c" />

<img width="2455" alt="image" src="https://github.com/user-attachments/assets/921e4a73-8721-434c-bc68-52a1fcfd78c6" />


<img width="2456" alt="image" src="https://github.com/user-attachments/assets/89b6f448-acfb-4483-a6ce-b2515bae8c04" />
