### PR TITLE
chore: set default catalog to dcp48 for HCA #4478

### DIFF
--- a/site-config/hca-dcp/dev/config.ts
+++ b/site-config/hca-dcp/dev/config.ts
@@ -24,7 +24,7 @@ import { floating } from "./layout/floating";
 
 // Template constants
 const APP_TITLE = "HCA Data Explorer";
-const CATALOG = "dcp47";
+const CATALOG = "dcp48";
 const BROWSER_URL = "https://explore.data.humancellatlas.dev.clevercanary.com";
 const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const EXPORT_TO_TERRA_URL = "https://app.terra.bio";

--- a/site-config/hca-dcp/ma-prod/config.ts
+++ b/site-config/hca-dcp/ma-prod/config.ts
@@ -6,7 +6,7 @@ import { getAuthenticationConfig } from "./authentication/authentication";
 
 // Template constants
 const BROWSER_URL = "https://explore.data.humancellatlas.org";
-const CATALOG = "dcp47";
+const CATALOG = "dcp48";
 const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const PORTAL_URL = "https://data.humancellatlas.org";
 


### PR DESCRIPTION
This pull request updates the catalog version used in the configuration files for different environments. Specifically, it changes the catalog from `dcp47` to `dcp48`.

Configuration updates:

* [`site-config/hca-dcp/dev/config.ts`](diffhunk://#diff-8a7e038c1d886524377b9df40ea8f8561697eeefc809745d656c1f99a0e4dc21L27-R27): Updated the `CATALOG` constant from `dcp47` to `dcp48` to reflect the new catalog version.
* [`site-config/hca-dcp/ma-prod/config.ts`](diffhunk://#diff-81471ce0dc457aa6aa8fc3d22d23917eb9faf31c3de46e416d65cf7a190eeaffL9-R9): Updated the `CATALOG` constant from `dcp47` to `dcp48` for the production environment.### Ticket

Closes #4478.

### Reviewers

@NoopDog .

### Changes

- Updated dcp catalog.
