### PR TITLE
feat: removed auth for exports #4482

### DIFF
--- a/site-config/hca-dcp/cc-ma-dev/config.ts
+++ b/site-config/hca-dcp/cc-ma-dev/config.ts
@@ -33,9 +33,6 @@ export function makeManagedAccessConfig(config: SiteConfig): SiteConfig {
   // Add authentication to the config.
   cloneConfig.authentication = getAuthenticationConfig();
 
-  // Require authentication for exports
-  cloneConfig.exportsRequireAuth = true;
-
   // Update categoryGroupConfig.
   cloneConfig.categoryGroupConfig = getMACategoryGroupConfig(
     cloneConfig.categoryGroupConfig


### PR DESCRIPTION
This pull request modifies the `makeManagedAccessConfig` function in the `site-config/hca-dcp/cc-ma-dev/config.ts` file. The key change is the removal of the requirement for authentication on exports.

### Changes to export authentication:

* Removed the `exportsRequireAuth` property, which previously enforced authentication for exports. This change simplifies the configuration by no longer requiring authentication for export operations.
 
### Ticket

Closes #4482.

### Reviewers

@NoopDog.

### Changes

- Removed auth requirement for exports and downloads for HCA.
