### PR TITLE
feat: remove 'beta' banner for anvil data explorer (#4487)

### DIFF
--- a/app/components/common/MDXContent/anvil-cmg/alertBetaAnnouncement.mdx
+++ b/app/components/common/MDXContent/anvil-cmg/alertBetaAnnouncement.mdx
@@ -1,4 +1,0 @@
-<Banner {...props}>
-  Welcome to our BETA release. Please see the [Beta
-  Announcement](/beta-announcement) to learn more.
-</Banner>

--- a/app/components/common/MDXContent/anvil-cmg/index.tsx
+++ b/app/components/common/MDXContent/anvil-cmg/index.tsx
@@ -2,7 +2,6 @@ export { Section } from "../../MDXMarkdown/components/Section/mdxSection.styles"
 export { default as Alert } from "../common/alert.mdx";
 export { default as ExportToTerraStart } from "../common/exportToTerraStart.mdx";
 export { default as ExportToTerraSuccess } from "../common/exportToTerraSuccess.mdx";
-export { default as AlertBetaAnnouncement } from "./alertBetaAnnouncement.mdx";
 export { default as AlertEntityListWarning } from "./alertEntityListWarning.mdx";
 export { default as AlertExportWarning } from "./alertExportWarning.mdx";
 export { default as AlertExportWarningContent } from "./alertExportWarningContent.mdx";

--- a/site-config/anvil-cmg/dev/announcements/announcements.ts
+++ b/site-config/anvil-cmg/dev/announcements/announcements.ts
@@ -3,13 +3,6 @@ import {
   ComponentsConfig,
 } from "@databiosphere/findable-ui/lib/config/entities";
 import * as C from "../../../../app/components";
-import * as MDX from "../../../../app/components/common/MDXContent/anvil-cmg";
-
 export const announcements: ComponentsConfig = [
-  {
-    component: C.Announcements,
-    props: {
-      generalAnnouncement: MDX.AlertBetaAnnouncement({}),
-    },
-  } as ComponentConfig<typeof C.Announcements>,
+  { component: C.Announcements } as ComponentConfig<typeof C.Announcements>,
 ];


### PR DESCRIPTION
### Ticket

Closes #4487.

### Reviewers

@NoopDog.

This pull request removes the `AlertBetaAnnouncement` component and its associated references from the codebase. This cleanup simplifies the code by removing unused beta-related content.

### Removal of `AlertBetaAnnouncement` Component:

* [`app/components/common/MDXContent/anvil-cmg/alertBetaAnnouncement.mdx`](diffhunk://#diff-4ec4607a17caa4f45c05428a15486bf4cce319063a1721b13ddb8527817216f4L1-L4): Deleted the `AlertBetaAnnouncement` component, which displayed a banner for the beta release announcement.

* [`app/components/common/MDXContent/anvil-cmg/index.tsx`](diffhunk://#diff-e487337c4efb4c38f7190580a68889464632474a58fbc153ac2e2f77a1cf78a3L5): Removed the export for the `AlertBetaAnnouncement` component.

* [`site-config/anvil-cmg/dev/announcements/announcements.ts`](diffhunk://#diff-164750125159b547f7eaf3598857733080db6eaf76abbdf30f7ad192c8bdab7cL6-R7): Removed the usage of `AlertBetaAnnouncement` in the `announcements` configuration. This change eliminates the reference to the deleted component and simplifies the configuration.

<img width="1242" alt="image" src="https://github.com/user-attachments/assets/a81c34aa-c929-4f7c-a5bf-7c1a5a5e548e" />
