### PR TITLE
fix: temporarily disable test anvilcatalog-sort.spec.ts (#4507)

### DIFF
--- a/e2e/anvil-catalog/anvilcatalog-sort.spec.ts
+++ b/e2e/anvil-catalog/anvilcatalog-sort.spec.ts
@@ -1,29 +1,38 @@
 import { test } from "@playwright/test";
 import { testSortCatalog } from "../testFunctions";
 import { ANVIL_CATALOG_TABS } from "./anvilcatalog-tabs";
-test("On the Consortia tab, expect clicking the column header (the sort button) to keep the first element of the column visible", async ({
-  page,
-}) => {
-  const testResult = await testSortCatalog(page, ANVIL_CATALOG_TABS.CONSORTIA);
-  if (!testResult) {
-    test.fail();
-  }
-});
 
-test("On the Studies tab, expect clicking the column header (the sort button) to keep the first element of the column visible", async ({
-  page,
-}) => {
-  const testResult = await testSortCatalog(page, ANVIL_CATALOG_TABS.STUDIES);
-  if (!testResult) {
-    test.fail();
-  }
-});
+test.describe.skip("AnVIL Catalog Table Sort Tests", () => {
+  test("On the Consortia tab, expect clicking the column header (the sort button) to keep the first element of the column visible", async ({
+    page,
+  }) => {
+    const testResult = await testSortCatalog(
+      page,
+      ANVIL_CATALOG_TABS.CONSORTIA
+    );
+    if (!testResult) {
+      test.fail();
+    }
+  });
 
-test("On the Workspaces tab, expect clicking the column header (the sort button) to keep the first element of the column visible", async ({
-  page,
-}) => {
-  const testResult = await testSortCatalog(page, ANVIL_CATALOG_TABS.WORKSPACES);
-  if (!testResult) {
-    test.fail();
-  }
+  test("On the Studies tab, expect clicking the column header (the sort button) to keep the first element of the column visible", async ({
+    page,
+  }) => {
+    const testResult = await testSortCatalog(page, ANVIL_CATALOG_TABS.STUDIES);
+    if (!testResult) {
+      test.fail();
+    }
+  });
+
+  test("On the Workspaces tab, expect clicking the column header (the sort button) to keep the first element of the column visible", async ({
+    page,
+  }) => {
+    const testResult = await testSortCatalog(
+      page,
+      ANVIL_CATALOG_TABS.WORKSPACES
+    );
+    if (!testResult) {
+      test.fail();
+    }
+  });
 });


### PR DESCRIPTION
### Ticket

Closes #4507.

### Reviewers

@NoopDog.

This pull request makes formatting improvements to the `e2e/anvil-catalog/anvilcatalog-sort.spec.ts` file and introduces a skip directive for a test suite. The changes enhance readability and add a conditional skip for the test suite.

### Test suite changes:

* Added `test.describe.skip` to conditionally skip the "AnVIL Catalog Table Sort Tests" suite, likely for debugging or temporary exclusion of tests. (`[e2e/anvil-catalog/anvilcatalog-sort.spec.tsR4-R12](diffhunk://#diff-ec82a3cd69fa4354cb7fc0d5b44fc14fa69702709e383b26eae63c7d0ba62ab7R4-R12)`)

### Code formatting improvements:

* Reformatted the `testSortCatalog` function calls across multiple tests to improve readability by breaking arguments into multiple lines. (`[[1]](diffhunk://#diff-ec82a3cd69fa4354cb7fc0d5b44fc14fa69702709e383b26eae63c7d0ba62ab7R4-R12)`, `[[2]](diffhunk://#diff-ec82a3cd69fa4354cb7fc0d5b44fc14fa69702709e383b26eae63c7d0ba62ab7L25-R38)`)