### PR TITLE
chore: update findable to 35.2.0 (#4510)

### DIFF
--- a/e2e/anvil/anvil-dataset.spec.ts
+++ b/e2e/anvil/anvil-dataset.spec.ts
@@ -4,6 +4,7 @@ import {
   BUTTON_TEXT_EXPORT,
   BUTTON_TEXT_REQUEST_ACCESS,
   BUTTON_TEXT_REQUEST_FILE_MANIFEST,
+  BUTTON_TEXT_REQUEST_LINK,
   CHIP_TEXT_ACCESS_GRANTED,
   CHIP_TEXT_ACCESS_REQUIRED,
   DatasetAccess,
@@ -106,16 +107,16 @@ describe("Dataset", () => {
     // Confirm file manifest export method is visible and click it.
     await clickLink(page, BUTTON_TEXT_REQUEST_FILE_MANIFEST);
 
-    // Confirm the file manifest page is loaded: check there are two buttons
-    // (one for download, one for copy to clipboard).
-    const buttons = page.locator(`${MUI_CLASSES.BUTTON_GROUP} button`);
+    // Confirm the file manifest page is loaded: check there is one button to request the manifest.
+    const buttons = page.locator(`${MUI_CLASSES.BUTTON}`, {
+      hasText: BUTTON_TEXT_REQUEST_LINK,
+    });
 
-    // Ensure there are exactly two buttons.
-    await expect(buttons).toHaveCount(2);
+    // Ensure there is exactly one button.
+    await expect(buttons).toHaveCount(1);
 
-    // Ensure both buttons are visible.
-    await expect(buttons.nth(0)).toBeVisible();
-    await expect(buttons.nth(1)).toBeVisible();
+    // Ensure the button is visible.
+    await expect(buttons).toBeVisible();
   });
 
   test("displays download file manifest selected data", async ({ page }) => {

--- a/e2e/anvil/common/constants.tsx
+++ b/e2e/anvil/common/constants.tsx
@@ -3,6 +3,7 @@ export const CHIP_TEXT_ACCESS_REQUIRED = "Required";
 export const BUTTON_TEXT_ANALYZE_IN_TERRA = "Analyze in Terra";
 export const BUTTON_TEXT_EXPORT = "Export";
 export const BUTTON_TEXT_REQUEST_ACCESS = "Request Access";
+export const BUTTON_TEXT_REQUEST_LINK = "Request Link";
 export const BUTTON_TEXT_REQUEST_FILE_MANIFEST = "Request File Manifest";
 
 export type DatasetAccess =

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "2.18.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^35.1.0",
+        "@databiosphere/findable-ui": "^35.2.0",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@mdx-js/loader": "^3.0.1",
@@ -2487,9 +2487,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "35.1.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-35.1.0.tgz",
-      "integrity": "sha512-ZwwAqO4IZlrc3OdzQlXgksnyUlh+Ca7Yv8loUbBs7OtqOm3wpHulpTyh41cn9bnWqAO7Hc9jlg1has9i7sgg7w==",
+      "version": "35.2.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-35.2.0.tgz",
+      "integrity": "sha512-NtVJ+0XbvCRP8icZ23YX4cx/k/MU4II1r9XD6r+8jG3JFTwz/Fnv5PmvFJbr+TedvQd8igPvPSDw5560OeMrrA==",
       "engines": {
         "node": "20.10.0"
       },
@@ -23311,9 +23311,9 @@
       "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw=="
     },
     "@databiosphere/findable-ui": {
-      "version": "35.1.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-35.1.0.tgz",
-      "integrity": "sha512-ZwwAqO4IZlrc3OdzQlXgksnyUlh+Ca7Yv8loUbBs7OtqOm3wpHulpTyh41cn9bnWqAO7Hc9jlg1has9i7sgg7w==",
+      "version": "35.2.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-35.2.0.tgz",
+      "integrity": "sha512-NtVJ+0XbvCRP8icZ23YX4cx/k/MU4II1r9XD6r+8jG3JFTwz/Fnv5PmvFJbr+TedvQd8igPvPSDw5560OeMrrA==",
       "requires": {}
     },
     "@digitak/esrun": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "check-system-status:anvil-cmg": "esrun e2e/anvil/anvil-check-system-status.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^35.1.0",
+    "@databiosphere/findable-ui": "^35.2.0",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@mdx-js/loader": "^3.0.1",


### PR DESCRIPTION
### Ticket

Closes #4510.

### Reviewers

@NoopDog.

This pull request introduces changes to the `e2e/anvil` test suite and updates a package dependency. The most notable changes include adding support for a "Request Link" button in the dataset tests and updating the `@databiosphere/findable-ui` package version.

### Changes to dataset tests:

* [`e2e/anvil/anvil-dataset.spec.ts`](diffhunk://#diff-7253a9339c275cab9bf6fe319f1acb5c774e511a24bd9f9cff2f7c86e778d0baR7): Added `BUTTON_TEXT_REQUEST_LINK` to the imports and updated the test logic to verify the presence of a single "Request Link" button instead of two buttons for file manifest actions. [[1]](diffhunk://#diff-7253a9339c275cab9bf6fe319f1acb5c774e511a24bd9f9cff2f7c86e778d0baR7) [[2]](diffhunk://#diff-7253a9339c275cab9bf6fe319f1acb5c774e511a24bd9f9cff2f7c86e778d0baL109-R119)
* [`e2e/anvil/common/constants.tsx`](diffhunk://#diff-ed4f990b27b686ffb7a3d8d6e4a3168df5ebc2827845f2ecf1fd863cff279132R6): Added a new constant `BUTTON_TEXT_REQUEST_LINK` to represent the text for the "Request Link" button.

### Dependency update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L35-R35): Updated the `@databiosphere/findable-ui` dependency from version `^35.1.0` to `^35.2.0`.
 
<img width="1736" alt="image" src="https://github.com/user-attachments/assets/2fb8c932-348c-4413-b91b-983ac74556df" />
 