### PR TITLE
fix: file format filter dropped from curl manifest request (#4481)

### DIFF
--- a/app/viewModelBuilders/azul/anvil-cmg/common/dataDictionaryMapper/dataDictionaryMapper.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/dataDictionaryMapper/dataDictionaryMapper.ts
@@ -1,7 +1,4 @@
-import {
-  Attribute,
-  DataDictionary,
-} from "@databiosphere/findable-ui/lib/common/entities";
+import { DataDictionary } from "@databiosphere/findable-ui/lib/common/entities";
 
 /**
  * Returns a data dictionary built from the given data dictionary.
@@ -10,7 +7,7 @@ import {
  */
 export function buildDataDictionary(
   dataDictionary: DataDictionary
-): DataDictionary<Attribute> {
+): DataDictionary {
   return {
     ...dataDictionary,
     classes: dataDictionary.classes.map((classData) => {

--- a/app/viewModelBuilders/azul/anvil-cmg/common/dataDictionaryMapper/tableOptions.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/dataDictionaryMapper/tableOptions.ts
@@ -1,10 +1,14 @@
 import { TableOptions } from "@tanstack/react-table";
 import { Attribute } from "@databiosphere/findable-ui/lib/common/entities";
+import { COLUMN_DEFS } from "./constants";
 
 export const TABLE_OPTIONS: Omit<
   TableOptions<Attribute>,
-  "columns" | "data" | "getCoreRowModel"
+  "data" | "getCoreRowModel"
 > = {
+  columns: COLUMN_DEFS,
+  enableColumnFilters: false,
+  enableGlobalFilter: false,
   initialState: {
     columnVisibility: { classKey: false },
     expanded: true,

--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
@@ -543,6 +543,7 @@ export const buildDatasetTerraExport = (
     formFacet,
     manifestDownloadFormat: MANIFEST_DOWNLOAD_FORMAT.VERBATIM_PFB,
     manifestDownloadFormats: [MANIFEST_DOWNLOAD_FORMAT.VERBATIM_PFB],
+    speciesFacetName: ANVIL_CMG_CATEGORY_KEY.DONOR_ORGANISM_TYPE,
   };
 };
 
@@ -791,6 +792,7 @@ export const buildExportToTerra = (
     formFacet,
     manifestDownloadFormat: MANIFEST_DOWNLOAD_FORMAT.VERBATIM_PFB,
     manifestDownloadFormats: [MANIFEST_DOWNLOAD_FORMAT.VERBATIM_PFB],
+    speciesFacetName: ANVIL_CMG_CATEGORY_KEY.DONOR_ORGANISM_TYPE,
   };
 };
 
@@ -902,6 +904,7 @@ export const buildManifestDownload = (
     fileSummaryFacetName: ANVIL_CMG_CATEGORY_KEY.FILE_FILE_FORMAT,
     filters: filterState,
     formFacet,
+    speciesFacetName: ANVIL_CMG_CATEGORY_KEY.DONOR_ORGANISM_TYPE,
   };
 };
 

--- a/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
@@ -837,6 +837,7 @@ export const buildDownloadCurlCommand = (
     fileSummaryFacetName: HCA_DCP_CATEGORY_KEY.FILE_FORMAT,
     filters: filterState,
     formFacet,
+    speciesFacetName: HCA_DCP_CATEGORY_KEY.GENUS_SPECIES,
   };
 };
 
@@ -864,6 +865,7 @@ export const buildDownloadEntityCurlCommand = (
     fileSummaryFacetName: HCA_DCP_CATEGORY_KEY.FILE_FORMAT,
     filters,
     formFacet,
+    speciesFacetName: HCA_DCP_CATEGORY_KEY.GENUS_SPECIES,
   };
 };
 
@@ -925,6 +927,7 @@ export const buildExportEntityToTerra = (
     formFacet,
     manifestDownloadFormat: MANIFEST_DOWNLOAD_FORMAT.TERRA_PFB,
     manifestDownloadFormats: [MANIFEST_DOWNLOAD_FORMAT.TERRA_PFB],
+    speciesFacetName: HCA_DCP_CATEGORY_KEY.GENUS_SPECIES,
   };
 };
 
@@ -1113,6 +1116,7 @@ export const buildExportToTerra = (
     formFacet,
     manifestDownloadFormat: MANIFEST_DOWNLOAD_FORMAT.TERRA_PFB,
     manifestDownloadFormats: [MANIFEST_DOWNLOAD_FORMAT.TERRA_PFB],
+    speciesFacetName: HCA_DCP_CATEGORY_KEY.GENUS_SPECIES,
   };
 };
 
@@ -1314,6 +1318,7 @@ export const buildManifestDownload = (
     fileSummaryFacetName: HCA_DCP_CATEGORY_KEY.FILE_FORMAT,
     filters: filterState,
     formFacet,
+    speciesFacetName: HCA_DCP_CATEGORY_KEY.GENUS_SPECIES,
   };
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "2.19.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^35.2.0",
+        "@databiosphere/findable-ui": "^37.1.0",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@mdx-js/loader": "^3.0.1",
@@ -2487,9 +2487,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "35.2.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-35.2.0.tgz",
-      "integrity": "sha512-NtVJ+0XbvCRP8icZ23YX4cx/k/MU4II1r9XD6r+8jG3JFTwz/Fnv5PmvFJbr+TedvQd8igPvPSDw5560OeMrrA==",
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-37.1.0.tgz",
+      "integrity": "sha512-hDsPhuflQoHhMcOv+a8uD6GyuPuZbD9ZXYDnO3HAOvZMtCiAzWsqgrt7i9Z/Xnj+IzSQQqKSPMhw51im7ylvNQ==",
       "engines": {
         "node": "20.10.0"
       },
@@ -2499,6 +2499,7 @@
         "@mui/icons-material": "^7.0.1",
         "@mui/material": "^7.0.1",
         "@observablehq/plot": "^0.6.17",
+        "@tanstack/match-sorter-utils": "^8.19.4",
         "@tanstack/react-table": "^8.19.2",
         "@tanstack/react-virtual": "^3.0.0-beta.59",
         "copy-to-clipboard": "3.3.1",
@@ -5762,6 +5763,28 @@
       "engines": {
         "node": ">=14.16"
       }
+    },
+    "node_modules/@tanstack/match-sorter-utils": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.19.4.tgz",
+      "integrity": "sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==",
+      "peer": true,
+      "dependencies": {
+        "remove-accents": "0.5.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/match-sorter-utils/node_modules/remove-accents": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+      "peer": true
     },
     "node_modules/@tanstack/react-table": {
       "version": "8.19.2",
@@ -23311,9 +23334,9 @@
       "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw=="
     },
     "@databiosphere/findable-ui": {
-      "version": "35.2.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-35.2.0.tgz",
-      "integrity": "sha512-NtVJ+0XbvCRP8icZ23YX4cx/k/MU4II1r9XD6r+8jG3JFTwz/Fnv5PmvFJbr+TedvQd8igPvPSDw5560OeMrrA==",
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-37.1.0.tgz",
+      "integrity": "sha512-hDsPhuflQoHhMcOv+a8uD6GyuPuZbD9ZXYDnO3HAOvZMtCiAzWsqgrt7i9Z/Xnj+IzSQQqKSPMhw51im7ylvNQ==",
       "requires": {}
     },
     "@digitak/esrun": {
@@ -25374,6 +25397,23 @@
       "dev": true,
       "requires": {
         "defer-to-connect": "^2.0.1"
+      }
+    },
+    "@tanstack/match-sorter-utils": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.19.4.tgz",
+      "integrity": "sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==",
+      "peer": true,
+      "requires": {
+        "remove-accents": "0.5.0"
+      },
+      "dependencies": {
+        "remove-accents": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+          "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+          "peer": true
+        }
       }
     },
     "@tanstack/react-table": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "check-system-status:anvil-cmg": "esrun e2e/anvil/anvil-check-system-status.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^35.2.0",
+    "@databiosphere/findable-ui": "^37.1.0",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@mdx-js/loader": "^3.0.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -31,6 +31,7 @@ import TagManager from "react-gtm-module";
 import { BREAKPOINTS } from "../site-config/common/constants";
 import { LayoutDimensionsProvider } from "@databiosphere/findable-ui/lib/providers/layoutDimensions/provider";
 import { ServicesProvider } from "@databiosphere/findable-ui/lib/providers/services/provider";
+import { DataDictionaryStateProvider } from "@databiosphere/findable-ui/lib/providers/dataDictionaryState/provider";
 
 const FEATURE_FLAGS = Object.values(FEATURES);
 const SESSION_TIMEOUT = 15 * 60 * 1000; // 15 minutes
@@ -95,29 +96,31 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
                         <Header {...header} />
                       </ThemeProvider>
                       <ExploreStateProvider entityListType={entityListType}>
-                        <FileManifestStateProvider>
-                          <Main>
-                            <ErrorBoundary
-                              fallbackRender={({
-                                error,
-                                reset,
-                              }: {
-                                error: DataExplorerError;
-                                reset: () => void;
-                              }): JSX.Element => (
-                                <Error
-                                  errorMessage={error.message}
-                                  requestUrlMessage={error.requestUrlMessage}
-                                  rootPath={redirectRootToPath}
-                                  onReset={reset}
-                                />
-                              )}
-                            >
-                              <Component {...pageProps} />
-                              <Floating {...floating} />
-                            </ErrorBoundary>
-                          </Main>
-                        </FileManifestStateProvider>
+                        <DataDictionaryStateProvider>
+                          <FileManifestStateProvider>
+                            <Main>
+                              <ErrorBoundary
+                                fallbackRender={({
+                                  error,
+                                  reset,
+                                }: {
+                                  error: DataExplorerError;
+                                  reset: () => void;
+                                }): JSX.Element => (
+                                  <Error
+                                    errorMessage={error.message}
+                                    requestUrlMessage={error.requestUrlMessage}
+                                    rootPath={redirectRootToPath}
+                                    onReset={reset}
+                                  />
+                                )}
+                              >
+                                <Component {...pageProps} />
+                                <Floating {...floating} />
+                              </ErrorBoundary>
+                            </Main>
+                          </FileManifestStateProvider>
+                        </DataDictionaryStateProvider>
                       </ExploreStateProvider>
                       <Footer {...footer} />
                     </AppLayout>

--- a/pages/data-dictionary/[dictionary]/index.tsx
+++ b/pages/data-dictionary/[dictionary]/index.tsx
@@ -34,9 +34,8 @@ export const getStaticPaths: GetStaticPaths = async () => {
   };
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- dictionary will be used by DataDictionaryView in future findable-ui releases.
 const Page = ({ dictionary }: Props): JSX.Element => {
-  return <DataDictionaryView />;
+  return <DataDictionaryView dictionary={dictionary} />;
 };
 
 Page.Main = Main;

--- a/site-config/anvil-cmg/dev/config.ts
+++ b/site-config/anvil-cmg/dev/config.ts
@@ -21,7 +21,6 @@ import { floating } from "./layout/floating";
 import dataDictionary from "./dataDictionary/data-dictionary.json";
 import { TABLE_OPTIONS } from "../../../app/viewModelBuilders/azul/anvil-cmg/common/dataDictionaryMapper/tableOptions";
 import { buildDataDictionary } from "../../../app/viewModelBuilders/azul/anvil-cmg/common/dataDictionaryMapper/dataDictionaryMapper";
-import { COLUMN_DEFS } from "../../../app/viewModelBuilders/azul/anvil-cmg/common/dataDictionaryMapper/constants";
 
 // Template constants
 const APP_TITLE = "AnVIL Data Explorer";
@@ -134,7 +133,6 @@ export function makeConfig(
     contentDir: "anvil-cmg",
     dataDictionaries: [
       {
-        columnDefs: COLUMN_DEFS,
         dataDictionary: buildDataDictionary(dataDictionary),
         path: "anvil-findability-subset",
         tableOptions: TABLE_OPTIONS,


### PR DESCRIPTION
### Ticket

Closes #4481.

### Reviewers

@NoopDog.

### Changes

- Updated `findable-ui` to version `v37.1.0`.

This pull request includes updates to improve data dictionary handling, enhance species facet support, and update dependencies. Key changes include simplifying the `DataDictionary` type, adding species facet names across multiple view models, and integrating new providers for better state management.

### Data Dictionary Updates:

* [`app/viewModelBuilders/azul/anvil-cmg/common/dataDictionaryMapper/dataDictionaryMapper.ts`](diffhunk://#diff-2c204bc7e782eee8709000c54a08a41dac64acdd04bbe937075db0988b979caeL1-R1): Removed the `Attribute` type from `DataDictionary` and adjusted the `buildDataDictionary` function to reflect this simplification. [[1]](diffhunk://#diff-2c204bc7e782eee8709000c54a08a41dac64acdd04bbe937075db0988b979caeL1-R1) [[2]](diffhunk://#diff-2c204bc7e782eee8709000c54a08a41dac64acdd04bbe937075db0988b979caeL13-R10)
* [`site-config/anvil-cmg/dev/config.ts`](diffhunk://#diff-182ccee01c1afc26a75de551cc0e58dae8b1eacd07a94d431ba177cd4f6496e3L24): Removed unused `COLUMN_DEFS` import and references to streamline configuration files. [[1]](diffhunk://#diff-182ccee01c1afc26a75de551cc0e58dae8b1eacd07a94d431ba177cd4f6496e3L24) [[2]](diffhunk://#diff-182ccee01c1afc26a75de551cc0e58dae8b1eacd07a94d431ba177cd4f6496e3L137)

### Species Facet Integration:

* [`app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts`](diffhunk://#diff-b96169dd3be278c94e1cb952ac1226940a54313bd300a63c667c2dbba9f35285R546): Added `speciesFacetName` property with `ANVIL_CMG_CATEGORY_KEY.DONOR_ORGANISM_TYPE` in multiple functions (`buildDatasetTerraExport`, `buildExportToTerra`, and others). [[1]](diffhunk://#diff-b96169dd3be278c94e1cb952ac1226940a54313bd300a63c667c2dbba9f35285R546) [[2]](diffhunk://#diff-b96169dd3be278c94e1cb952ac1226940a54313bd300a63c667c2dbba9f35285R795) [[3]](diffhunk://#diff-b96169dd3be278c94e1cb952ac1226940a54313bd300a63c667c2dbba9f35285R907)
* [`app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts`](diffhunk://#diff-178d98a1be1f94d92cf0053329d9566eae61c65847d66472221a5323f832c4d1R840): Added `speciesFacetName` property with `HCA_DCP_CATEGORY_KEY.GENUS_SPECIES` in multiple functions (`buildDownloadCurlCommand`, `buildExportToTerra`, and others). [[1]](diffhunk://#diff-178d98a1be1f94d92cf0053329d9566eae61c65847d66472221a5323f832c4d1R840) [[2]](diffhunk://#diff-178d98a1be1f94d92cf0053329d9566eae61c65847d66472221a5323f832c4d1R868) [[3]](diffhunk://#diff-178d98a1be1f94d92cf0053329d9566eae61c65847d66472221a5323f832c4d1R930) [[4]](diffhunk://#diff-178d98a1be1f94d92cf0053329d9566eae61c65847d66472221a5323f832c4d1R1119) [[5]](diffhunk://#diff-178d98a1be1f94d92cf0053329d9566eae61c65847d66472221a5323f832c4d1R1321)

### Dependency Updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L35-R35): Upgraded `@databiosphere/findable-ui` dependency from version `^35.2.0` to `^37.1.0`.

### State Management Enhancements:

* [`pages/_app.tsx`](diffhunk://#diff-a9827ce1be32c607c948881a89b99c592f752898f9c49e0dea0b7199eb151029R34): Integrated `DataDictionaryStateProvider` for improved state handling in the application. [[1]](diffhunk://#diff-a9827ce1be32c607c948881a89b99c592f752898f9c49e0dea0b7199eb151029R34) [[2]](diffhunk://#diff-a9827ce1be32c607c948881a89b99c592f752898f9c49e0dea0b7199eb151029R99) [[3]](diffhunk://#diff-a9827ce1be32c607c948881a89b99c592f752898f9c49e0dea0b7199eb151029R123)

### Component Updates:

* `pages/data-dictionary/[dictionary]/index.tsx`: Updated `DataDictionaryView` to accept a `dictionary` prop for dynamic rendering. ([pages/data-dictionary/[dictionary]/index.tsxL37-R38](diffhunk://#diff-7778ec9fc3a99a7d95e5bdcd745dde1dec30eaeda9b22e84f340846c83601220L37-R38))