### PR TITLE
chore: update findable to latest version v38.1.1 (#4533)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "2.19.1",
       "dependencies": {
-        "@databiosphere/findable-ui": "^38.1.0",
+        "@databiosphere/findable-ui": "^38.1.1",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@mdx-js/loader": "^3.0.1",
@@ -2488,9 +2488,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "38.1.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-38.1.0.tgz",
-      "integrity": "sha512-6SY8nJX22euMsa+mmuWohtjsNo44RzdAiguKFAZYMg983E87w3vpMzgMjR8sqsoX+uKDHNuGRpAccDtX0VSnhw==",
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-38.1.1.tgz",
+      "integrity": "sha512-WogR/uDc9ZUmex+lzhoY/0IZq5ytJL9HHlsuqo4Kd1y1NAq1ZpAhhyw0Ub0Sdi6U7vdRkMhfT8G71VQzm+wXmg==",
       "engines": {
         "node": "20.10.0"
       },
@@ -23333,9 +23333,9 @@
       "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw=="
     },
     "@databiosphere/findable-ui": {
-      "version": "38.1.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-38.1.0.tgz",
-      "integrity": "sha512-6SY8nJX22euMsa+mmuWohtjsNo44RzdAiguKFAZYMg983E87w3vpMzgMjR8sqsoX+uKDHNuGRpAccDtX0VSnhw==",
+      "version": "38.1.1",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-38.1.1.tgz",
+      "integrity": "sha512-WogR/uDc9ZUmex+lzhoY/0IZq5ytJL9HHlsuqo4Kd1y1NAq1ZpAhhyw0Ub0Sdi6U7vdRkMhfT8G71VQzm+wXmg==",
       "requires": {}
     },
     "@digitak/esrun": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "check-system-status:anvil-cmg": "esrun e2e/anvil/anvil-check-system-status.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^38.1.0",
+    "@databiosphere/findable-ui": "^38.1.1",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@mdx-js/loader": "^3.0.1",


### PR DESCRIPTION
### Ticket

Closes #4533.

### Reviewers

@NoopDog.

This pull request includes a minor update to the `package.json` file. The change updates the `@databiosphere/findable-ui` dependency from version `^38.1.0` to `^38.1.1`.