### PR TITLE
fix: fix data dictionary table overflow on smaller viewports (#4542)

### DIFF
--- a/app/viewModelBuilders/azul/anvil-cmg/common/dataDictionaryMapper/constants.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/dataDictionaryMapper/constants.ts
@@ -1,6 +1,7 @@
 import { MarkdownCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/MarkdownCell/markdownCell";
 import { Attribute } from "@databiosphere/findable-ui/lib/common/entities";
 import { ColumnDef, CellContext } from "@tanstack/react-table";
+import { BasicCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/BasicCell/basicCell";
 
 export const COLUMN_DEFS: ColumnDef<Attribute>[] = [
   {
@@ -35,12 +36,17 @@ export const COLUMN_DEFS: ColumnDef<Attribute>[] = [
   },
   {
     accessorKey: "name",
+    cell: (cellContext) =>
+      BasicCell({
+        TypographyProps: { noWrap: true },
+        value: cellContext.getValue() as string,
+      }),
     enableColumnFilter: false,
     header: "Name",
     meta: {
       width: {
         max: "1fr",
-        min: "180px",
+        min: "240px",
       },
     },
   },


### PR DESCRIPTION
### Ticket

Closes #4542.

### Reviewers

@NoopDog.

This pull request updates the `COLUMN_DEFS` configuration in the `dataDictionaryMapper/constants.ts` file to enhance table rendering by introducing a new cell type and adjusting column width.

### Table rendering improvements:

* Added the `BasicCell` component to the imports to support the new cell type. (`app/viewModelBuilders/azul/anvil-cmg/common/dataDictionaryMapper/constants.ts`, [app/viewModelBuilders/azul/anvil-cmg/common/dataDictionaryMapper/constants.tsR4](diffhunk://#diff-60f739fb6c68f87a3515114aa3a398cb9586f2949f7fe3b91b101bac5f6a0e88R4))
* Updated the `name` column definition to use the `BasicCell` component with `TypographyProps` for no-wrap text and dynamic value rendering. (`app/viewModelBuilders/azul/anvil-cmg/common/dataDictionaryMapper/constants.ts`, [app/viewModelBuilders/azul/anvil-cmg/common/dataDictionaryMapper/constants.tsR39-R49](diffhunk://#diff-60f739fb6c68f87a3515114aa3a398cb9586f2949f7fe3b91b101bac5f6a0e88R39-R49))
* Increased the minimum column width for the `name` column from `180px` to `240px` for better readability. (`app/viewModelBuilders/azul/anvil-cmg/common/dataDictionaryMapper/constants.ts`, [app/viewModelBuilders/azul/anvil-cmg/common/dataDictionaryMapper/constants.tsR39-R49](diffhunk://#diff-60f739fb6c68f87a3515114aa3a398cb9586f2949f7fe3b91b101bac5f6a0e88R39-R49))

<img width="499" height="1041" alt="image" src="https://github.com/user-attachments/assets/cf9b5670-ef9d-47fe-99c9-fd2f554b5f62" />
