### PR TITLE
chore: update findable-ui to latest version 41.2.0 (#4547)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "2.20.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^40.0.0",
+        "@databiosphere/findable-ui": "^41.2.0",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@mdx-js/loader": "^3.0.1",
@@ -2488,9 +2488,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "40.0.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-40.0.0.tgz",
-      "integrity": "sha512-bGUTr3bEK7FtwsqEGiDp33gAAfnsreTemGzz04cpmqPo/bL9waPmijvToSD1KT3+Ace8cT2YvHqAjnvPjwKVjA==",
+      "version": "41.2.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-41.2.0.tgz",
+      "integrity": "sha512-8A3ol9/DH6IbQZWEBc1x6pI88KpmaJllgZWB1pShWfclFeLuJArVS8BTaXJYNfJwwUrmSgeq4oat9NYb0Izagg==",
       "engines": {
         "node": "20.10.0"
       },
@@ -23334,9 +23334,9 @@
       "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw=="
     },
     "@databiosphere/findable-ui": {
-      "version": "40.0.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-40.0.0.tgz",
-      "integrity": "sha512-bGUTr3bEK7FtwsqEGiDp33gAAfnsreTemGzz04cpmqPo/bL9waPmijvToSD1KT3+Ace8cT2YvHqAjnvPjwKVjA==",
+      "version": "41.2.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-41.2.0.tgz",
+      "integrity": "sha512-8A3ol9/DH6IbQZWEBc1x6pI88KpmaJllgZWB1pShWfclFeLuJArVS8BTaXJYNfJwwUrmSgeq4oat9NYb0Izagg==",
       "requires": {}
     },
     "@digitak/esrun": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "check-system-status:anvil-cmg": "esrun e2e/anvil/anvil-check-system-status.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^40.0.0",
+    "@databiosphere/findable-ui": "^41.2.0",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@mdx-js/loader": "^3.0.1",


### PR DESCRIPTION
### Ticket

Closes #4547.

### Reviewers

@NoopDog.

This pull request updates the version of the `@databiosphere/findable-ui` dependency in the `package.json` file to ensure compatibility with the latest features and fixes.

Dependency update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L35-R35): Upgraded `@databiosphere/findable-ui` from version `^40.0.0` to `^41.2.0`.