### PR TITLE
chore: set default catalog to dcp51 for HCA #4549

### DIFF
--- a/site-config/hca-dcp/dev/config.ts
+++ b/site-config/hca-dcp/dev/config.ts
@@ -24,7 +24,7 @@ import { buildSummaries } from "./index/summaryViewModelBuilder";
 
 // Template constants
 const APP_TITLE = "HCA Data Explorer";
-const CATALOG = "dcp50";
+const CATALOG = "dcp51";
 const BROWSER_URL = "https://explore.data.humancellatlas.dev.clevercanary.com";
 const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const EXPORT_TO_TERRA_URL = "https://app.terra.bio";

--- a/site-config/hca-dcp/ma-prod/config.ts
+++ b/site-config/hca-dcp/ma-prod/config.ts
@@ -6,7 +6,7 @@ import { getAuthenticationConfig } from "./authentication/authentication";
 
 // Template constants
 const BROWSER_URL = "https://explore.data.humancellatlas.org";
-const CATALOG = "dcp50";
+const CATALOG = "dcp51";
 const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const PORTAL_URL = "https://data.humancellatlas.org";
 


### PR DESCRIPTION
### Ticket

Closes #4549.

### Reviewers

@noop.

### Changes
This pull request updates the data catalog version used in the HCA Data Explorer configuration files for both the development and production environments. The main change is switching the catalog from version `dcp50` to `dcp51`, ensuring the application points to the latest dataset.

Configuration updates:

* Updated the `CATALOG` constant from `dcp50` to `dcp51` in `site-config/hca-dcp/dev/config.ts` to use the latest catalog in the development environment.
* Updated the `CATALOG` constant from `dcp50` to `dcp51` in `site-config/hca-dcp/ma-prod/config.ts` to use the latest catalog in the production environment.