### PR TITLE
chore: set default catalog to dcp52 for HCA #4556

### DIFF
--- a/site-config/hca-dcp/dev/config.ts
+++ b/site-config/hca-dcp/dev/config.ts
@@ -17,7 +17,7 @@ import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/m
 
 // Template constants
 const APP_TITLE = "HCA Data Explorer";
-const CATALOG = "dcp51";
+const CATALOG = "dcp52";
 const BROWSER_URL = "https://explore.data.humancellatlas.dev.clevercanary.com";
 const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const EXPORT_TO_TERRA_URL = "https://app.terra.bio";

--- a/site-config/hca-dcp/ma-prod/config.ts
+++ b/site-config/hca-dcp/ma-prod/config.ts
@@ -6,7 +6,7 @@ import { getAuthenticationConfig } from "./authentication/authentication";
 
 // Template constants
 const BROWSER_URL = "https://explore.data.humancellatlas.org";
-const CATALOG = "dcp51";
+const CATALOG = "dcp52";
 const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const PORTAL_URL = "https://data.humancellatlas.org";
 


### PR DESCRIPTION
### Ticket

#4556

### Reviewers

@noop.

### Changes

This pull request updates the catalog version used in the HCA Data Explorer configuration for both the dev and ma-prod environments. The main change is incrementing the catalog from "dcp51" to "dcp52" to ensure the application references the latest dataset.

Configuration updates:

* Updated the `CATALOG` constant from `"dcp51"` to `"dcp52"` in `site-config/hca-dcp/dev/config.ts` to use the latest data catalog in the dev environment.
* Updated the `CATALOG` constant from `"dcp51"` to `"dcp52"` in `site-config/hca-dcp/ma-prod/config.ts` to use the latest data catalog in the ma-prod environment.