### PR TITLE
chore: set default catalog to dcp53 for HCA #4567

### DIFF
--- a/site-config/hca-dcp/dev/config.ts
+++ b/site-config/hca-dcp/dev/config.ts
@@ -17,7 +17,7 @@ import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/m
 
 // Template constants
 const APP_TITLE = "HCA Data Explorer";
-const CATALOG = "dcp52";
+const CATALOG = "dcp53";
 const BROWSER_URL = "https://explore.data.humancellatlas.dev.clevercanary.com";
 const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const EXPORT_TO_TERRA_URL = "https://app.terra.bio";

--- a/site-config/hca-dcp/ma-prod/config.ts
+++ b/site-config/hca-dcp/ma-prod/config.ts
@@ -6,7 +6,7 @@ import { getAuthenticationConfig } from "./authentication/authentication";
 
 // Template constants
 const BROWSER_URL = "https://explore.data.humancellatlas.org";
-const CATALOG = "dcp52";
+const CATALOG = "dcp53";
 const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const PORTAL_URL = "https://data.humancellatlas.org";
 


### PR DESCRIPTION
### Ticket

#4567.

### Reviewers

@NoopDog .

### Changes

This pull request updates the catalog version used in the HCA Data Explorer configuration files for both the dev and ma-prod environments. The catalog is being incremented from "dcp52" to "dcp53" to ensure the application references the latest dataset.

Catalog version updates:

* Updated the `CATALOG` constant from `"dcp52"` to `"dcp53"` in `site-config/hca-dcp/dev/config.ts` to use the latest data catalog.
* Updated the `CATALOG` constant from `"dcp52"` to `"dcp53"` in `site-config/hca-dcp/ma-prod/config.ts` for consistency across environments.
