### PR TITLE
fix: build error due to oversized response (#4570)

### DIFF
--- a/pages/[entityListType]/[...params].tsx
+++ b/pages/[entityListType]/[...params].tsx
@@ -182,7 +182,7 @@ export const getStaticPaths: GetStaticPaths<PageUrl> = async () => {
         const azulCatalogResponse = await fetchCatalog();
         const catalogs = getCatalogs(azulCatalogResponse, defaultCatalog);
         // Define the list params.
-        const listParams = { size: "100" };
+        const listParams = { size: "75" };
         // Fetch entities for each catalog and process the paths.
         for (const catalog of catalogs) {
           const entitiesResponse = await getEntities(


### PR DESCRIPTION
Closes #4570.

This pull request makes a minor adjustment to the number of entities fetched per catalog page. The change reduces the page size from 100 to 75 in the `getStaticPaths` function.

* Reduced the `size` parameter in the `listParams` object from 100 to 75 in `pages/[entityListType]/[...params].tsx` to control the number of entities fetched per catalog page. ([pages/[entityListType]/[...params].tsxL185-R185](diffhunk://#diff-04f84f26a12d415d2631e7543023d0f6bbf42d6b5565e4d1dacbae4c700ea47bL185-R185))