### PR TITLE
chore: set default catalog to dcp54 for HCA #4576

### DIFF
--- a/site-config/hca-dcp/dev/config.ts
+++ b/site-config/hca-dcp/dev/config.ts
@@ -17,7 +17,7 @@ import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/m
 
 // Template constants
 const APP_TITLE = "HCA Data Explorer";
-const CATALOG = "dcp53";
+const CATALOG = "dcp54";
 const BROWSER_URL = "https://explore.data.humancellatlas.dev.clevercanary.com";
 const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const EXPORT_TO_TERRA_URL = "https://app.terra.bio";

--- a/site-config/hca-dcp/ma-prod/config.ts
+++ b/site-config/hca-dcp/ma-prod/config.ts
@@ -6,7 +6,7 @@ import { getAuthenticationConfig } from "./authentication/authentication";
 
 // Template constants
 const BROWSER_URL = "https://explore.data.humancellatlas.org";
-const CATALOG = "dcp53";
+const CATALOG = "dcp54";
 const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const PORTAL_URL = "https://data.humancellatlas.org";
 


### PR DESCRIPTION
### Ticket

Closes #4576.

### Reviewers

@noop.

#### Changes

This pull request updates the data catalog version used in both the `dev` and `ma-prod` configuration files for the HCA Data Explorer. The most important change is the catalog version bump, which ensures the application points to the latest dataset.

Configuration updates:

* Updated the `CATALOG` constant from `"dcp53"` to `"dcp54"` in `site-config/hca-dcp/dev/config.ts` to use the latest data catalog.
* Updated the `CATALOG` constant from `"dcp53"` to `"dcp54"` in `site-config/hca-dcp/ma-prod/config.ts` to use the latest data catalog.