### PR TITLE
fix: error exporting datasets with 'unspecified' organism_type in anvil explorer (#4579)

### DIFF
--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
@@ -1272,20 +1272,27 @@ export function getExportSelectedDataSummary(
 function getExportTerraEntityFilters(
   datasetsResponse: DatasetsResponse
 ): Filters {
-  return [
-    ...getExportEntityFilters(datasetsResponse),
-    {
-      categoryKey: ANVIL_CMG_CATEGORY_KEY.DONOR_ORGANISM_TYPE,
-      value: processRawEntityArrayValue(
-        datasetsResponse.donors,
-        "organism_type"
-      ),
-    },
-    {
-      categoryKey: ANVIL_CMG_CATEGORY_KEY.FILE_FILE_FORMAT,
-      value: processRawEntityArrayValue(datasetsResponse.files, "file_format"),
-    },
-  ];
+  const filters: Filters = [];
+
+  filters.push(...getExportEntityFilters(datasetsResponse));
+
+  // Add donor organism type filter if donor organism type values are available on the dataset.
+  const donorOrganismType = processRawEntityArrayValue(
+    datasetsResponse.donors,
+    "organism_type"
+  );
+  filters.push({
+    categoryKey: ANVIL_CMG_CATEGORY_KEY.DONOR_ORGANISM_TYPE,
+    value: donorOrganismType.length > 0 ? donorOrganismType : [null],
+  });
+
+  // Add file format filter.
+  filters.push({
+    categoryKey: ANVIL_CMG_CATEGORY_KEY.FILE_FILE_FORMAT,
+    value: processRawEntityArrayValue(datasetsResponse.files, "file_format"),
+  });
+
+  return filters;
 }
 
 /**

--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
@@ -1276,7 +1276,7 @@ function getExportTerraEntityFilters(
 
   filters.push(...getExportEntityFilters(datasetsResponse));
 
-  // Add donor organism type filter if donor organism type values are available on the dataset.
+  // Add donor organism type filter (add `[null]` if no values are available).
   const donorOrganismType = processRawEntityArrayValue(
     datasetsResponse.donors,
     "organism_type"


### PR DESCRIPTION
Closes #4579.

This pull request refactors the logic for generating export filters in the `getExportTerraEntityFilters` function to improve clarity and robustness. The main changes involve restructuring how filters are built and handling cases where donor organism type values may be missing.

Improvements to filter construction:

* Refactored `getExportTerraEntityFilters` to build the `filters` array step-by-step instead of using array spread syntax, making the logic clearer and easier to maintain.

Robustness enhancements:

* Updated donor organism type filter logic to add `[null]` as a value when no donor organism type values are available, ensuring the filter always has a value.

Feature consistency:

* Explicitly added the file format filter to the `filters` array, maintaining consistent export filter behavior.