### PR TITLE
feat: switch from files.url to files.azul_url (#4575)

### DIFF
--- a/app/apis/azul/anvil-cmg/common/entities.ts
+++ b/app/apis/azul/anvil-cmg/common/entities.ts
@@ -89,6 +89,7 @@ export interface DonorSpecies {
  */
 export interface FileEntity {
   accessible: boolean;
+  azul_url: string;
   data_modality: string[];
   date_created: string;
   document_id: string;
@@ -98,7 +99,6 @@ export interface FileEntity {
   file_name: string;
   file_size: number;
   file_type: string;
-  url: string;
 }
 
 /**

--- a/app/apis/azul/hca-dcp/common/entities.ts
+++ b/app/apis/azul/hca-dcp/common/entities.ts
@@ -41,6 +41,7 @@ export interface FilesEntityResponse {
  */
 export interface FileResponse {
   accessible: boolean;
+  azul_url: string;
   contentDescription: (string | null)[];
   drs_uri: string;
   fileSource: string | null;
@@ -50,7 +51,6 @@ export interface FileResponse {
   name: string;
   sha256: string;
   size: number;
-  url: string | null; // TODO confirm null is possible.
   uuid: string;
   version: string;
 }

--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
@@ -822,7 +822,7 @@ export const buildFileDownload = (
     entityName: processEntityValue(response.files, "file_name"),
     relatedEntityId: dataset.dataset_id[0],
     relatedEntityName: dataset.title[0],
-    url: processEntityValue(response.files, "url", LABEL.EMPTY),
+    url: processEntityValue(response.files, "azul_url", LABEL.EMPTY),
   };
 };
 

--- a/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
@@ -1176,7 +1176,7 @@ export const buildFileDownload = (
     entityName: processEntityValue(filesResponse.files, "name"),
     relatedEntityId: project.projectId[0],
     relatedEntityName: project.projectTitle[0],
-    url: processEntityValue(filesResponse.files, "url", LABEL.EMPTY),
+    url: processEntityValue(filesResponse.files, "azul_url", LABEL.EMPTY),
   };
 };
 


### PR DESCRIPTION
Closes #4575.

This pull request updates how file download URLs are handled in both the Anvil-CMG and HCA-DCP entities and view model builders. The main change is replacing the previous `url` property with a new `azul_url` property to standardize access to file download links.

**Entity interface updates:**

* Replaced the `url` property with `azul_url` in the `FileEntity` interface in `app/apis/azul/anvil-cmg/common/entities.ts` to reflect the new naming convention. [[1]](diffhunk://#diff-cc0b97be4ee7728bd97e67bee9c0e2f8a48e620b5b54dfdd6841f5b78e3f952aR92) [[2]](diffhunk://#diff-cc0b97be4ee7728bd97e67bee9c0e2f8a48e620b5b54dfdd6841f5b78e3f952aL101)
* Replaced the `url` property with `azul_url` in the `FileResponse` interface in `app/apis/azul/hca-dcp/common/entities.ts` for consistency across APIs. [[1]](diffhunk://#diff-3bfb63035ad3a99bea2603b16430777e07d41d9f274591b9600e021d98d7b8ccR44) [[2]](diffhunk://#diff-3bfb63035ad3a99bea2603b16430777e07d41d9f274591b9600e021d98d7b8ccL53)

**View model builder updates:**

* Updated `buildFileDownload` in `app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts` to use the new `azul_url` property instead of `url` when constructing file download objects.
* Updated `buildFileDownload` in `app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts` to use `azul_url` instead of `url`, ensuring the view models reference the correct property.