### PR TITLE
fix: allow errors from file manifest state provider to be caught by error boundary (#4601)

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -97,29 +97,29 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
                       </ThemeProvider>
                       <ExploreStateProvider entityListType={entityListType}>
                         <DataDictionaryStateProvider>
-                          <FileManifestStateProvider>
-                            <Main>
-                              <ErrorBoundary
-                                fallbackRender={({
-                                  error,
-                                  reset,
-                                }: {
-                                  error: DataExplorerError;
-                                  reset: () => void;
-                                }): JSX.Element => (
-                                  <Error
-                                    errorMessage={error.message}
-                                    requestUrlMessage={error.requestUrlMessage}
-                                    rootPath={redirectRootToPath}
-                                    onReset={reset}
-                                  />
-                                )}
-                              >
+                          <Main>
+                            <ErrorBoundary
+                              fallbackRender={({
+                                error,
+                                reset,
+                              }: {
+                                error: DataExplorerError;
+                                reset: () => void;
+                              }): JSX.Element => (
+                                <Error
+                                  errorMessage={error.message}
+                                  requestUrlMessage={error.requestUrlMessage}
+                                  rootPath={redirectRootToPath}
+                                  onReset={reset}
+                                />
+                              )}
+                            >
+                              <FileManifestStateProvider>
                                 <Component {...pageProps} />
                                 <Floating {...floating} />
-                              </ErrorBoundary>
-                            </Main>
-                          </FileManifestStateProvider>
+                              </FileManifestStateProvider>
+                            </ErrorBoundary>
+                          </Main>
                         </DataDictionaryStateProvider>
                       </ExploreStateProvider>
                       <Footer {...footer} />


### PR DESCRIPTION
Closes #4601

This indirectly solves the endless request issue, as well as ensuring that the errors get displayed (but does not solve the broader issue of errors outside of the boundary potentially causing repeated renders -- see comments on DataBiosphere/findable-ui#711)
