### PR TITLE
feat: added example JSON #4610

### DIFF
--- a/public/api/v0/facets/response.json
+++ b/public/api/v0/facets/response.json
@@ -1,0 +1,54 @@
+{
+  "query": "public bam files for latino foobar patients with diabetes or foobaz",
+  "facets": [
+    {
+      "facet": "Access",
+      "selectedValues": [
+        {
+          "term": "Granted",
+          "mention": "public"
+        }
+      ]
+    },
+    {
+      "facet": "Diagnosis",
+      "selectedValues": [
+        {
+          "term": "MONDO:0005015",
+          "mention": "diabetes"
+        },
+        {
+          "term": "unknown",
+          "mention": "foobaz"
+        }
+      ]
+    },
+    {
+      "facet": "File Format",
+      "selectedValues": [
+        {
+          "term": ".bam",
+          "mention": "bam"
+        }
+      ]
+    },
+    {
+      "facet": "Reported Ethnicity",
+      "selectedValues": [
+        {
+          "term": "Hispanic or Latino",
+          "mention": "latino"
+        }
+      ]
+    },
+    {
+      "facet": "unknown",
+      "selectedValues": [
+        {
+          "term": "unknown",
+          "mention": "foobar"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Ticket

Closes #4610.

### Reviewers

@noop.

### Changes

This pull request adds a new example API response file for facets in the `public/api/v0/facets/response.json` file. The file demonstrates how user queries are parsed into facets and selected values, mapping terms from the query to standardized facet categories and terms.

New example API response:

* Added `public/api/v0/facets/response.json` to provide a sample response showing how a query is broken down into facets such as "Access", "Diagnosis", "File Format", and "Reported Ethnicity", with corresponding selected values and mentions from the query.