### PR TITLE
fix: hca download matrices and copy to clipboard buttons not working (#4628)

### DIFF
--- a/app/apis/azul/hca-dcp/common/entities.ts
+++ b/app/apis/azul/hca-dcp/common/entities.ts
@@ -69,11 +69,11 @@ export interface FileTypeSummary {
  * Model of file "leaf" values in matrix tree response from Azul.
  */
 export interface ProjectMatrixFileResponse {
+  azul_url: string;
   contentDescription: string[];
   matrixCellCount?: number;
   name: string;
   size: number;
-  url: string;
   uuid: string;
   version: string;
 }

--- a/app/viewModelBuilders/azul/hca-dcp/common/projectMatrixMapper/projectMatrixMapper.ts
+++ b/app/viewModelBuilders/azul/hca-dcp/common/projectMatrixMapper/projectMatrixMapper.ts
@@ -84,11 +84,11 @@ function createMatrixView(
 ): ProjectMatrixView {
   // Create matrix view, starting with core file values.
   const {
+    azul_url,
     contentDescription,
     matrixCellCount,
     name,
     size,
-    url,
     uuid,
     version,
   } = file;
@@ -98,7 +98,7 @@ function createMatrixView(
     id: uuid,
     matrixCellCount,
     size,
-    url,
+    url: azul_url,
     version,
   };
   // Convert meta values into arrays. There may be identical files in separate branches of the tree and we'll


### PR DESCRIPTION
Closes #4628.

This pull request updates the way matrix file URLs are handled in the HCA DCP project matrix mapping. The main change is a shift from using a generic `url` property to a more specifically named `azul_url`, ensuring clarity and consistency in how matrix file URLs are referenced and mapped throughout the codebase.

**Matrix file URL property update:**

* Changed the `ProjectMatrixFileResponse` interface in `entities.ts` to replace the `url` property with `azul_url`, clarifying the source and purpose of the URL.
* Updated the `createMatrixView` function in `projectMatrixMapper.ts` to destructure and use `azul_url` instead of `url`, and to map `azul_url` to the `url` property in the resulting view model. [[1]](diffhunk://#diff-c5700eb3c80d86ddce3f39510aa5b5c1d94c2eba97dbdb4c182aa2939113ef07R87-L91) [[2]](diffhunk://#diff-c5700eb3c80d86ddce3f39510aa5b5c1d94c2eba97dbdb4c182aa2939113ef07L101-R101)