### PR TITLE
feat: export cohort to biodata catalyst (#4640)

### DIFF
--- a/app/components/Export/components/AnVILExplorer/platform/ExportMethod/exportMethod.tsx
+++ b/app/components/Export/components/AnVILExplorer/platform/ExportMethod/exportMethod.tsx
@@ -1,0 +1,21 @@
+import { JSX } from "react";
+import { ComponentProps } from "react";
+import { ExportMethod as DXExportMethod } from "@databiosphere/findable-ui/lib/components/Export/components/ExportMethod/exportMethod";
+import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
+import { FEATURES } from "app/shared/entities";
+
+/**
+ * Export method component for platform based export.
+ * Hidden if the platform based export feature is not enabled (NCPI Export).
+ * @param props - Export method component props.
+ * @returns Export method component.
+ */
+export const ExportMethod = (
+  props: ComponentProps<typeof DXExportMethod>
+): JSX.Element | null => {
+  const isEnabled = useFeatureFlag(FEATURES.NCPI_EXPORT);
+
+  if (!isEnabled) return null;
+
+  return <DXExportMethod {...props} />;
+};

--- a/app/components/Export/components/AnVILExplorer/platform/ExportToPlatform/exportToPlatform.tsx
+++ b/app/components/Export/components/AnVILExplorer/platform/ExportToPlatform/exportToPlatform.tsx
@@ -1,0 +1,107 @@
+import { JSX } from "react";
+import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
+import { useFileManifest } from "@databiosphere/findable-ui/lib/hooks/useFileManifest/useFileManifest";
+import { useFileManifestFileCount } from "@databiosphere/findable-ui/lib/hooks/useFileManifest/useFileManifestFileCount";
+import { useFileManifestFormat } from "@databiosphere/findable-ui/lib/hooks/useFileManifest/useFileManifestFormat";
+import { useRequestFileLocation } from "@databiosphere/findable-ui/lib/hooks/useRequestFileLocation";
+import { useRequestManifest } from "@databiosphere/findable-ui/lib/hooks/useRequestManifest/useRequestManifest";
+import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/FluidPaper/fluidPaper";
+import { Loading } from "@databiosphere/findable-ui/lib/components/Loading/loading";
+import { ExportManifestDownloadFormatForm } from "@databiosphere/findable-ui/lib/components/Export/components/ExportForm/components/ExportManifestDownloadFormatForm/exportManifestDownloadFormatForm";
+import { ExportButton } from "@databiosphere/findable-ui/lib/components/Export/components/ExportForm/components/ExportButton/exportButton";
+import { ExportForm } from "@databiosphere/findable-ui/lib/components/Export/components/ExportForm/exportForm";
+import {
+  Section,
+  SectionActions,
+  SectionContent,
+} from "@databiosphere/findable-ui/lib/components/Export/export.styles";
+import { Button } from "@mui/material";
+import {
+  REL_ATTRIBUTE,
+  ANCHOR_TARGET,
+} from "@databiosphere/findable-ui/lib/components/Links/common/entities";
+import { PAPER_PANEL_STYLE } from "@databiosphere/findable-ui/lib/components/common/Paper/paper";
+import { MANIFEST_DOWNLOAD_FORMAT } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
+import { Props } from "./types";
+
+export const ExportToPlatform = ({
+  buttonLabel,
+  description,
+  fileManifestState,
+  fileSummaryFacetName,
+  filters,
+  formFacet,
+  speciesFacetName,
+  successTitle,
+  title,
+}: Props): JSX.Element => {
+  useFileManifest(filters, fileSummaryFacetName);
+  useFileManifestFileCount(filters, speciesFacetName, fileSummaryFacetName);
+
+  const fileManifestFormatState = useFileManifestFormat(
+    MANIFEST_DOWNLOAD_FORMAT.VERBATIM_PFB
+  );
+  const { fileManifestFormat } = fileManifestFormatState;
+
+  const requestManifest = useRequestManifest(fileManifestFormat, formFacet);
+  const { requestMethod, requestUrl } = requestManifest;
+
+  const response = useRequestFileLocation(requestUrl, requestMethod);
+  const url = "";
+
+  return url ? (
+    <FluidPaper>
+      <Section>
+        <SectionContent>
+          <h3>{successTitle}</h3>
+        </SectionContent>
+        <SectionActions>
+          <Button
+            {...BUTTON_PROPS.PRIMARY_CONTAINED}
+            href={url}
+            rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
+            target={ANCHOR_TARGET.BLANK}
+          >
+            {buttonLabel}
+          </Button>
+        </SectionActions>
+      </Section>
+    </FluidPaper>
+  ) : (
+    <div>
+      <Loading
+        loading={response.isLoading}
+        panelStyle={PAPER_PANEL_STYLE.FLUID}
+        text="Your link will be ready shortly..."
+      />
+      <FluidPaper>
+        <Section>
+          <SectionContent>
+            <h3>{title}</h3>
+            <p>{description}</p>
+          </SectionContent>
+          <ExportForm
+            Button={renderButton}
+            formFacet={formFacet}
+            isLoading={fileManifestState.isLoading}
+            onRequestManifest={(): void => response.run()}
+          >
+            <ExportManifestDownloadFormatForm
+              fileManifestFormatState={fileManifestFormatState}
+              manifestDownloadFormats={[MANIFEST_DOWNLOAD_FORMAT.VERBATIM_PFB]}
+            />
+          </ExportForm>
+        </Section>
+      </FluidPaper>
+    </div>
+  );
+};
+
+/**
+ * Build the export button.
+ * @param props - Button props e.g. "onClick" to request manifest.
+ * @returns button element.
+ */
+function renderButton({ ...props }): JSX.Element {
+  return <ExportButton {...props}>Request Link</ExportButton>;
+}

--- a/app/components/Export/components/AnVILExplorer/platform/ExportToPlatform/types.ts
+++ b/app/components/Export/components/AnVILExplorer/platform/ExportToPlatform/types.ts
@@ -1,0 +1,15 @@
+import { FormFacet } from "@databiosphere/findable-ui/lib/components/Export/common/entities";
+import { FileManifestState } from "@databiosphere/findable-ui/lib/providers/fileManifestState";
+import { Filters } from "@databiosphere/findable-ui/lib/common/entities";
+
+export interface Props {
+  buttonLabel: string;
+  description: string;
+  fileManifestState: FileManifestState;
+  fileSummaryFacetName: string;
+  filters: Filters;
+  formFacet: FormFacet;
+  speciesFacetName: string;
+  successTitle: string;
+  title: string;
+}

--- a/app/components/index.tsx
+++ b/app/components/index.tsx
@@ -13,6 +13,7 @@ export {
   DownloadIconSmall,
   InventoryIconSmall,
 } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/common/constants";
+export { ExportToPlatform } from "./Export/components/AnVILExplorer/platform/ExportToPlatform/exportToPlatform";
 export { DiscourseIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/DiscourseIcon/discourseIcon";
 export { GitHubIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/GitHubIcon/gitHubIcon";
 export { OpenInNewIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/OpenInNewIcon/openInNewIcon";

--- a/app/shared/entities.ts
+++ b/app/shared/entities.ts
@@ -1,4 +1,6 @@
 /**
  * Set of possible feature flags.
  */
-export enum FEATURES {}
+export enum FEATURES {
+  NCPI_EXPORT = "ncpiexport",
+}

--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
@@ -39,16 +39,13 @@ import {
   ChipProps as MChipProps,
   FadeProps as MFadeProps,
 } from "@mui/material";
-import React, { ReactNode } from "react";
+import React, { ComponentProps, ReactNode } from "react";
 import {
   ANVIL_CMG_CATEGORY_KEY,
   ANVIL_CMG_CATEGORY_LABEL,
   DATASET_RESPONSE,
 } from "../../../../../site-config/anvil-cmg/category";
-import {
-  ROUTE_EXPORT_TO_TERRA,
-  ROUTE_MANIFEST_DOWNLOAD,
-} from "../../../../../site-config/anvil-cmg/dev/export/constants";
+import { ROUTES } from "../../../../../site-config/anvil-cmg/dev/export/routes";
 import {
   AggregatedBioSampleResponse,
   AggregatedDatasetResponse,
@@ -452,7 +449,7 @@ export const buildDatasetExportMethodManifestDownload = (
     buttonLabel: "Request File Manifest",
     description:
       "Request a file manifest suitable for downloading this dataset to your HPC cluster or local machine.",
-    route: `${datasetPath}${ROUTE_MANIFEST_DOWNLOAD}`,
+    route: `${datasetPath}${ROUTES.MANIFEST_DOWNLOAD}`,
     title: "Download a File Manifest with Metadata",
   };
 };
@@ -486,7 +483,7 @@ export const buildDatasetExportMethodTerra = (
     buttonLabel: "Analyze in Terra",
     description:
       "Terra is a biomedical research platform to analyze data using workflows, Jupyter Notebooks, RStudio, and Galaxy.",
-    route: `${datasetPath}${ROUTE_EXPORT_TO_TERRA}`,
+    route: `${datasetPath}${ROUTES.TERRA}`,
     title: "Export Dataset Data and Metadata to Terra Workspace",
   };
 };
@@ -744,7 +741,7 @@ export const buildExportMethodManifestDownload = (
     buttonLabel: "Request File Manifest",
     description:
       "Request a file manifest for the current query containing the full list of selected files and the metadata for each file.",
-    route: ROUTE_MANIFEST_DOWNLOAD,
+    route: ROUTES.MANIFEST_DOWNLOAD,
     title: "Download a File Manifest with Metadata for the Selected Data",
   };
 };
@@ -764,7 +761,7 @@ export const buildExportMethodTerra = (
     buttonLabel: "Analyze in Terra",
     description:
       "Terra is a biomedical research platform to analyze data using workflows, Jupyter Notebooks, RStudio, and Galaxy.",
-    route: ROUTE_EXPORT_TO_TERRA,
+    route: ROUTES.TERRA,
     title: "Export Study Data and Metadata to Terra Workspace",
   };
 };
@@ -790,6 +787,77 @@ export const buildExportSelectedDataSummary = (
   return {
     isLoading: isFacetsLoading || isSummaryLoading,
     summaries: getExportSelectedDataSummary(filesFacets, summary),
+  };
+};
+
+/**
+ * Build props for ExportToPlatform component.
+ * @param props - Props to pass to the ExportToPlatform component.
+ * @returns model to be used as props for the ExportToPlatform component.
+ */
+export const buildExportToPlatform = (
+  props: Pick<
+    ComponentProps<typeof C.ExportToPlatform>,
+    "buttonLabel" | "description" | "successTitle" | "title"
+  >
+): ((
+  _: unknown,
+  viewContext: ViewContext<unknown>
+) => ComponentProps<typeof C.ExportToPlatform>) => {
+  return (_: unknown, viewContext: ViewContext<unknown>) => {
+    const {
+      exploreState: { filterState },
+      fileManifestState,
+    } = viewContext;
+    return {
+      ...props,
+      fileManifestState,
+      fileSummaryFacetName: ANVIL_CMG_CATEGORY_KEY.FILE_FILE_FORMAT,
+      filters: filterState,
+      formFacet: getFormFacets(fileManifestState),
+      speciesFacetName: ANVIL_CMG_CATEGORY_KEY.DONOR_ORGANISM_TYPE,
+    };
+  };
+};
+
+/**
+ * Build props for ExportToPlatform BackPageHero component.
+ * @param title - Title of the export method.
+ * @returns model to be used as props for the BackPageHero component.
+ */
+export const buildExportToPlatformHero = (
+  title: string
+): ((
+  _: unknown,
+  viewContext: ViewContext<unknown>
+) => React.ComponentProps<typeof C.BackPageHero>) => {
+  return (_, viewContext) => {
+    const {
+      exploreState: { tabValue },
+    } = viewContext;
+    return getExportMethodHero(tabValue, title);
+  };
+};
+
+/**
+ * Build props for ExportMethod component for display of the export to [platform] metadata section.
+ * @param props - Props to pass to the ExportMethod component.
+ * @returns model to be used as props for the ExportMethod component.
+ */
+export const buildExportToPlatformMethod = (
+  props: Pick<
+    ComponentProps<typeof ExportMethod>,
+    "buttonLabel" | "description" | "route" | "title"
+  >
+): ((
+  _: unknown,
+  viewContext: ViewContext<unknown>
+) => ComponentProps<typeof ExportMethod>) => {
+  return (_: unknown, viewContext: ViewContext<unknown>) => {
+    return {
+      ...props,
+      ...getExportMethodAccessibility(viewContext),
+    };
   };
 };
 

--- a/e2e/anvil/anvil-dataset.spec.ts
+++ b/e2e/anvil/anvil-dataset.spec.ts
@@ -10,7 +10,7 @@ import {
   DatasetAccess,
 } from "./common/constants";
 import { MUI_CLASSES } from "../features/common/constants";
-import { ROUTE_MANIFEST_DOWNLOAD } from "../../site-config/anvil-cmg/dev/export/constants";
+import { ROUTES } from "../../site-config/anvil-cmg/dev/export/routes";
 import { ANVIL_CMG_CATEGORY_KEY } from "../../site-config/anvil-cmg/category";
 
 const { describe } = test;
@@ -88,7 +88,7 @@ describe("Dataset", () => {
 
     // Navigate to the export file manifest page.
     const currentUrl = page.url();
-    await page.goto(`${currentUrl}${ROUTE_MANIFEST_DOWNLOAD}`);
+    await page.goto(`${currentUrl}${ROUTES.MANIFEST_DOWNLOAD}`);
 
     // Confirm the login alert is displayed.
     await expect(

--- a/pages/export/biodata-catalyst.tsx
+++ b/pages/export/biodata-catalyst.tsx
@@ -1,0 +1,28 @@
+import { JSX } from "react";
+import { ExportMethodView } from "@databiosphere/findable-ui/lib/views/ExportMethodView/exportMethodView";
+import { GetStaticProps } from "next";
+import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
+import { FEATURES } from "../../app/shared/entities";
+import Error from "next/error";
+
+export const getStaticProps: GetStaticProps = async () => {
+  return {
+    props: {
+      pageTitle: "Export to NHLBI BioData Catalyst",
+    },
+  };
+};
+
+/**
+ * Export method page for BioData Catalyst.
+ * @returns export method view component.
+ */
+const ExportMethodPage = (): JSX.Element => {
+  const isEnabled = useFeatureFlag(FEATURES.NCPI_EXPORT);
+
+  if (!isEnabled) return <Error statusCode={404} />;
+
+  return <ExportMethodView />;
+};
+
+export default ExportMethodPage;

--- a/site-config/anvil-cmg/dev/detail/dataset/export/export.ts
+++ b/site-config/anvil-cmg/dev/detail/dataset/export/export.ts
@@ -6,10 +6,7 @@ import { sideColumn as exportSideColumn } from "../../../export/exportSideColumn
 import * as V from "../../../../../../app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders";
 import * as C from "../../../../../../app/components";
 import { DatasetsResponse } from "app/apis/azul/anvil-cmg/common/responses";
-import {
-  ROUTE_EXPORT_TO_TERRA,
-  ROUTE_MANIFEST_DOWNLOAD,
-} from "../../../export/constants";
+import { ROUTES } from "../../../export/routes";
 import * as MDX from "../../../../../../app/components/common/MDXContent/anvil-cmg";
 
 /**
@@ -66,7 +63,7 @@ export const exportConfig: ExportConfig = {
           viewBuilder: V.renderDatasetExport,
         } as ComponentConfig<typeof C.ConditionalComponent, DatasetsResponse>,
       ],
-      route: ROUTE_EXPORT_TO_TERRA,
+      route: ROUTES.TERRA,
       top: [
         {
           children: [DATASET_ACCESSIBILITY_BADGE],
@@ -119,7 +116,7 @@ export const exportConfig: ExportConfig = {
           viewBuilder: V.renderDatasetExport,
         } as ComponentConfig<typeof C.ConditionalComponent, DatasetsResponse>,
       ],
-      route: ROUTE_MANIFEST_DOWNLOAD,
+      route: ROUTES.MANIFEST_DOWNLOAD,
       top: [
         {
           children: [DATASET_ACCESSIBILITY_BADGE],

--- a/site-config/anvil-cmg/dev/export/constants.ts
+++ b/site-config/anvil-cmg/dev/export/constants.ts
@@ -1,2 +1,35 @@
-export const ROUTE_EXPORT_TO_TERRA = "/export/export-to-terra";
-export const ROUTE_MANIFEST_DOWNLOAD = "/export/download-manifest";
+import { ROUTES } from "./routes";
+import { ComponentProps } from "react";
+import { ExportMethod } from "@databiosphere/findable-ui/lib/components/Export/components/ExportMethod/exportMethod";
+import { ExportToPlatform } from "../../../../app/components";
+
+export const EXPORTS: Record<
+  string,
+  Pick<
+    ComponentProps<typeof ExportToPlatform>,
+    "buttonLabel" | "description" | "successTitle" | "title"
+  >
+> = {
+  BIO_DATA_CATALYST: {
+    buttonLabel: "Open BioData Catalyst",
+    description:
+      "BDC-SB is a cloud workspace for analysis, storage, and computation using workflows, Jupyter Notebooks, and RStudio.",
+    successTitle: "Your BioData Catalyst Workspace Link is Ready",
+    title: "Analyze in BioData Catalyst",
+  },
+};
+
+export const EXPORT_METHODS: Record<
+  string,
+  Pick<
+    ComponentProps<typeof ExportMethod>,
+    "buttonLabel" | "description" | "route" | "title"
+  >
+> = {
+  BIO_DATA_CATALYST: {
+    buttonLabel: "Analyze in NHLBI BioData Catalyst",
+    description: EXPORTS.BIO_DATA_CATALYST.description,
+    route: ROUTES.BIO_DATA_CATALYST,
+    title: "Export to BioData Catalyst Powered by Seven Bridges (BDC-SB)",
+  },
+};

--- a/site-config/anvil-cmg/dev/export/export.ts
+++ b/site-config/anvil-cmg/dev/export/export.ts
@@ -4,9 +4,11 @@ import {
 } from "@databiosphere/findable-ui/lib/config/entities";
 import * as C from "../../../../app/components";
 import * as V from "../../../../app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders";
-import { ROUTE_EXPORT_TO_TERRA, ROUTE_MANIFEST_DOWNLOAD } from "./constants";
+import { ROUTES } from "./routes";
 import { mainColumn as exportMainColumn } from "./exportMainColumn";
 import { sideColumn as exportSideColumn } from "./exportSideColumn";
+import { ExportMethod } from "../../../../app/components/Export/components/AnVILExplorer/platform/ExportMethod/exportMethod";
+import { EXPORT_METHODS, EXPORTS } from "./constants";
 
 export const exportConfig: ExportConfig = {
   exportMethods: [
@@ -27,11 +29,38 @@ export const exportConfig: ExportConfig = {
         /* sideColumn */
         ...exportSideColumn,
       ],
-      route: ROUTE_EXPORT_TO_TERRA,
+      route: ROUTES.TERRA,
       top: [
         {
           component: C.BackPageHero,
           viewBuilder: V.buildExportMethodHeroTerra,
+        } as ComponentConfig<typeof C.BackPageHero>,
+      ],
+    },
+    {
+      mainColumn: [
+        /* mainColumn - top section - warning - some datasets are not available */
+        ...exportMainColumn,
+        /* mainColumn */
+        {
+          children: [
+            {
+              component: C.ExportToPlatform,
+              viewBuilder: V.buildExportToPlatform(EXPORTS.BIO_DATA_CATALYST),
+            } as ComponentConfig<typeof C.ExportToPlatform>,
+          ],
+          component: C.BackPageContentMainColumn,
+        } as ComponentConfig<typeof C.BackPageContentMainColumn>,
+        /* sideColumn */
+        ...exportSideColumn,
+      ],
+      route: ROUTES.BIO_DATA_CATALYST,
+      top: [
+        {
+          component: C.BackPageHero,
+          viewBuilder: V.buildExportToPlatformHero(
+            "Export to BioData Catalyst"
+          ),
         } as ComponentConfig<typeof C.BackPageHero>,
       ],
     },
@@ -52,7 +81,7 @@ export const exportConfig: ExportConfig = {
         /* sideColumn */
         ...exportSideColumn,
       ],
-      route: ROUTE_MANIFEST_DOWNLOAD,
+      route: ROUTES.MANIFEST_DOWNLOAD,
       top: [
         {
           component: C.BackPageHero,
@@ -75,6 +104,12 @@ export const exportConfig: ExportConfig = {
               component: C.ExportMethod,
               viewBuilder: V.buildExportMethodTerra,
             } as ComponentConfig<typeof C.ExportMethod>,
+            {
+              component: ExportMethod,
+              viewBuilder: V.buildExportToPlatformMethod(
+                EXPORT_METHODS.BIO_DATA_CATALYST
+              ),
+            } as ComponentConfig<typeof ExportMethod>,
             {
               component: C.ExportMethod,
               viewBuilder: V.buildExportMethodManifestDownload,

--- a/site-config/anvil-cmg/dev/export/routes.ts
+++ b/site-config/anvil-cmg/dev/export/routes.ts
@@ -1,0 +1,5 @@
+export const ROUTES = {
+  BIO_DATA_CATALYST: "/export/biodata-catalyst",
+  MANIFEST_DOWNLOAD: "/export/download-manifest",
+  TERRA: "/export/export-to-terra",
+} as const;


### PR DESCRIPTION
Closes #4640.

This pull request introduces a new "Export to BioData Catalyst" feature, including both the UI components and the necessary configuration to enable conditional display based on a feature flag. The implementation provides a dedicated export flow for BioData Catalyst, integrates it into the export page routing and configuration, and ensures it is only visible when the appropriate feature flag is enabled.

**Feature Implementation:**

* Added a new `ExportToBioDataCatalyst` component for exporting data to BioData Catalyst, including its props definition and export in the main components index. [[1]](diffhunk://#diff-61fd01a2850a8c809c46913954d74100898e185c3a6d4fb3edcdfa6403935295R1-R107) [[2]](diffhunk://#diff-551dc87ae9b81c966f839aa81157d8e4cabc29f851e8df01846358d2a439c8aeR1-R11) [[3]](diffhunk://#diff-54630ce9fc797cf0bc56c047535a25b98f4f6eaafb4964a015196b1c012a41deR16)
* Created the `ExportMethodNCPI` component to conditionally render the export method based on the `NCPI_EXPORT` feature flag.

**Feature Flag and Routing:**

* Introduced the `NCPI_EXPORT` feature flag in the `FEATURES` enum and used it to control the visibility of BioData Catalyst export features and routes. [[1]](diffhunk://#diff-9179e21a1c8349bf9c3f684a6c35b8793c928c2c79c94eb054ec6a89051eede0L4-R6) [[2]](diffhunk://#diff-d1949e89b5e11ad48fa1e7977fb05e4dffd1003ca8b47a7e57fd396f1f794d40R1-R28)
* Added the `/export/biodata-catalyst` route and integrated it into the export configuration, including a dedicated export method page and configuration entries. [[1]](diffhunk://#diff-7bf0c7bd4b5e8352a5de822a30251dcf626291776265133454c10caf335f46edR3) [[2]](diffhunk://#diff-899a81f4e8f44b8256620db53dc8a718d46443b98942ec6539a69e9b9fac6f83L7-R14) [[3]](diffhunk://#diff-899a81f4e8f44b8256620db53dc8a718d46443b98942ec6539a69e9b9fac6f83R43-R67) [[4]](diffhunk://#diff-899a81f4e8f44b8256620db53dc8a718d46443b98942ec6539a69e9b9fac6f83R108-R111) [[5]](diffhunk://#diff-d1949e89b5e11ad48fa1e7977fb05e4dffd1003ca8b47a7e57fd396f1f794d40R1-R28)

**View Model and Configuration Support:**

* Implemented view model builders for BioData Catalyst export, including methods to build props for both the export method and the main export component, and integrated them into the export configuration. [[1]](diffhunk://#diff-b96169dd3be278c94e1cb952ac1226940a54313bd300a63c667c2dbba9f35285R699-R735) [[2]](diffhunk://#diff-b96169dd3be278c94e1cb952ac1226940a54313bd300a63c667c2dbba9f35285R834-R856) [[3]](diffhunk://#diff-b96169dd3be278c94e1cb952ac1226940a54313bd300a63c667c2dbba9f35285R49)

<img width="1728" height="1253" alt="image" src="https://github.com/user-attachments/assets/a97d003c-dc56-48c7-9d10-eec05814edde" />

<img width="1732" height="1255" alt="image" src="https://github.com/user-attachments/assets/f62a4687-f5b2-4041-a411-139c549ebd91" />

<img width="1731" height="1254" alt="image" src="https://github.com/user-attachments/assets/ff8ea33b-16c3-4f51-8d6d-e776394adfb5" />
