### PR TITLE
feat: add ras banner (#4674)

### DIFF
--- a/app/components/anvil/banner/RAS/ras.tsx
+++ b/app/components/anvil/banner/RAS/ras.tsx
@@ -1,0 +1,38 @@
+import { Banner } from "@databiosphere/findable-ui/lib/components/common/Banner/banner";
+import {
+  ANCHOR_TARGET,
+  REL_ATTRIBUTE,
+} from "@databiosphere/findable-ui/lib/components/Links/common/entities";
+import { Link } from "@mui/material";
+import { JSX } from "react";
+
+export const RAS = (): JSX.Element => {
+  return (
+    <Banner>
+      <div>
+        As part of new federal government security policies, Terra is required
+        to integrate with the NIH Researcher Authentication Service (RAS) for
+        identity proofing and enhanced security. In order to link your NIH
+        authorization to Terra, users of eRA Commons must transition to the use
+        of{" "}
+        <Link
+          href="https://login.gov"
+          rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
+          target={ANCHOR_TARGET.BLANK}
+        >
+          Login.gov
+        </Link>{" "}
+        or ID.me credentials to access AnVIL controlled-access data in Terra.
+        See{" "}
+        <Link
+          href="https://support.terra.bio/hc/en-us/articles/32634034451099-RAS-Integration-for-AnVIL-Data"
+          rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
+          target={ANCHOR_TARGET.BLANK}
+        >
+          here
+        </Link>{" "}
+        for more details and instructions.
+      </div>
+    </Banner>
+  );
+};

--- a/site-config/anvil-cmg/dev/announcements/announcements.ts
+++ b/site-config/anvil-cmg/dev/announcements/announcements.ts
@@ -3,6 +3,11 @@ import {
   ComponentsConfig,
 } from "@databiosphere/findable-ui/lib/config/entities";
 import * as C from "../../../../app/components";
+import { RAS } from "../../../../app/components/anvil/banner/RAS/ras";
+
 export const announcements: ComponentsConfig = [
-  { component: C.Announcements } as ComponentConfig<typeof C.Announcements>,
+  {
+    component: C.Announcements,
+    props: { generalAnnouncement: RAS() },
+  } as ComponentConfig<typeof C.Announcements>,
 ];

--- a/site-config/anvil-cmg/dev/announcements/announcements.tsx
+++ b/site-config/anvil-cmg/dev/announcements/announcements.tsx
@@ -8,6 +8,6 @@ import { RAS } from "../../../../app/components/anvil/banner/RAS/ras";
 export const announcements: ComponentsConfig = [
   {
     component: C.Announcements,
-    props: { generalAnnouncement: RAS() },
+    props: { generalAnnouncement: <RAS /> },
   } as ComponentConfig<typeof C.Announcements>,
 ];


### PR DESCRIPTION
Closes #4674.

This pull request introduces a new banner component to inform users about the NIH Researcher Authentication Service (RAS) integration and updates the announcements configuration to display this information. The main changes are grouped by feature addition and configuration update:

RAS Banner Feature:

* Added the `RAS` banner component in `app/components/anvil/banner/RAS/ras.tsx` to communicate the requirement for users to link their NIH authorization to Terra via Login.gov or ID.me credentials, including helpful links for more information.

Announcements Configuration Update:

* Modified `site-config/anvil-cmg/dev/announcements/announcements.ts` to include the new `RAS` banner as a general announcement in the `Announcements` component, ensuring users see the RAS integration notice.

<img width="1441" height="900" alt="image" src="https://github.com/user-attachments/assets/51d434c9-32c6-4343-8012-dbda20bf223e" />
