### PR TITLE
fix: add deadline date to RAS banner (#4681)

### DIFF
--- a/app/components/anvil/banner/RAS/ras.tsx
+++ b/app/components/anvil/banner/RAS/ras.tsx
@@ -13,8 +13,8 @@ export const RAS = (): JSX.Element => {
         As part of new federal government security policies, Terra is required
         to integrate with the NIH Researcher Authentication Service (RAS) for
         identity proofing and enhanced security. In order to link your NIH
-        authorization to Terra, users of eRA Commons must transition to the use
-        of{" "}
+        authorization to Terra, users of eRA Commons must transition by March
+        25, 2026 to the use of{" "}
         <Link
           href="https://login.gov"
           rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}


### PR DESCRIPTION
## Ticket
- Closes #4681.

## Summary
- Adds the March 25, 2026 deadline date to the RAS banner message for eRA Commons users transitioning to Login.gov

<img width="1381" height="59" alt="image" src="https://github.com/user-attachments/assets/4238c527-339a-4c67-8d6a-bfcf91c381c6" />


## Test plan
- [ ] Verify the RAS banner displays the updated text with the deadline date

🤖 Generated with [Claude Code](https://claude.com/claude-code)