### PR TITLE
chore: update hca-dcp catalog to dcp57

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ Thumbs.db
 # IDEs and editors
 .idea
 /.vscode
+.claude
 
 # hygen
 _templates

--- a/site-config/hca-dcp/dev/config.ts
+++ b/site-config/hca-dcp/dev/config.ts
@@ -18,7 +18,7 @@ import { FILTER_SORT } from "@databiosphere/findable-ui/lib/common/filters/sort/
 
 // Template constants
 const APP_TITLE = "HCA Data Explorer";
-const CATALOG = "dcp56";
+const CATALOG = "dcp57";
 const BROWSER_URL = "https://explore.data.humancellatlas.dev.clevercanary.com";
 const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const EXPORT_TO_TERRA_URL = "https://app.terra.bio";

--- a/site-config/hca-dcp/ma-prod/config.ts
+++ b/site-config/hca-dcp/ma-prod/config.ts
@@ -6,7 +6,7 @@ import { getAuthenticationConfig } from "./authentication/authentication";
 
 // Template constants
 const BROWSER_URL = "https://explore.data.humancellatlas.org";
-const CATALOG = "dcp56";
+const CATALOG = "dcp57";
 const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const PORTAL_URL = "https://data.humancellatlas.org";
 


### PR DESCRIPTION
## Ticket
Closes #4685

## Summary
- Update HCA DCP default catalog from dcp56 to dcp57
- Add `.claude` to gitignore

## Test plan
- [ ] Verify dev and prod configs use dcp57
- [ ] Confirm data loads correctly with new catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)