### PR TITLE
chore: upgrade findable-ui to 49.4.1

### DIFF
--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
@@ -19,10 +19,7 @@ import { CurrentQuery } from "@databiosphere/findable-ui/lib/components/Export/c
 import { Summary } from "@databiosphere/findable-ui/lib/components/Export/components/ExportSummary/components/ExportSelectedDataSummary/exportSelectedDataSummary";
 import { ANCHOR_TARGET } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import { ViewContext } from "@databiosphere/findable-ui/lib/config/entities";
-import {
-  FILE_MANIFEST_TYPE,
-  FileFacet,
-} from "@databiosphere/findable-ui/lib/hooks/useFileManifest/common/entities";
+import { FileFacet } from "@databiosphere/findable-ui/lib/hooks/useFileManifest/common/entities";
 import {
   findFacet,
   isFacetTermSelected,
@@ -617,7 +614,6 @@ export const buildDatasetTerraExport = (
     ExportToTerraStart: MDX.ExportToTerraStart,
     ExportToTerraSuccess: MDX.ExportToTerraSuccess,
     fileManifestState,
-    fileManifestType: FILE_MANIFEST_TYPE.ENTITY_EXPORT_TO_TERRA,
     fileSummaryFacetName: ANVIL_CMG_CATEGORY_KEY.FILE_FILE_FORMAT,
     filters,
     formFacet,
@@ -951,7 +947,6 @@ export const buildExportToTerra = (
     ExportToTerraStart: MDX.ExportToTerraStart,
     ExportToTerraSuccess: MDX.ExportToTerraSuccess,
     fileManifestState,
-    fileManifestType: FILE_MANIFEST_TYPE.EXPORT_TO_TERRA,
     fileSummaryFacetName: ANVIL_CMG_CATEGORY_KEY.FILE_FILE_FORMAT,
     filters: filterState,
     formFacet,
@@ -1075,7 +1070,6 @@ export const buildManifestDownload = (
     ManifestDownloadStart: MDX.ManifestDownloadStart,
     ManifestDownloadSuccess: MDX.ManifestDownloadSuccess,
     fileManifestState,
-    fileManifestType: FILE_MANIFEST_TYPE.DOWNLOAD_MANIFEST,
     fileSummaryFacetName: ANVIL_CMG_CATEGORY_KEY.FILE_FILE_FORMAT,
     filters: filterState,
     formFacet,

--- a/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
@@ -28,10 +28,7 @@ import {
 } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import { getConfig } from "@databiosphere/findable-ui/lib/config/config";
 import { ViewContext } from "@databiosphere/findable-ui/lib/config/entities";
-import {
-  FILE_MANIFEST_TYPE,
-  FileFacet,
-} from "@databiosphere/findable-ui/lib/hooks/useFileManifest/common/entities";
+import { FileFacet } from "@databiosphere/findable-ui/lib/hooks/useFileManifest/common/entities";
 import {
   findFacet,
   isFacetTermSelected,
@@ -832,7 +829,6 @@ export const buildDownloadCurlCommand = (
     DownloadCurlStart: MDX.DownloadCurlCommandStart,
     DownloadCurlSuccess: MDX.DownloadCurlCommandSuccess,
     fileManifestState,
-    fileManifestType: FILE_MANIFEST_TYPE.BULK_DOWNLOAD,
     fileSummaryFacetName: HCA_DCP_CATEGORY_KEY.FILE_FORMAT,
     filters: filterState,
     formFacet,
@@ -860,7 +856,6 @@ export const buildDownloadEntityCurlCommand = (
     DownloadCurlStart: MDX.DownloadCurlCommandStart,
     DownloadCurlSuccess: MDX.DownloadCurlCommandSuccess,
     fileManifestState,
-    fileManifestType: FILE_MANIFEST_TYPE.ENTITY_BULK_DOWNLOAD,
     fileSummaryFacetName: HCA_DCP_CATEGORY_KEY.FILE_FORMAT,
     filters,
     formFacet,
@@ -920,7 +915,6 @@ export const buildExportEntityToTerra = (
     ExportToTerraStart: MDX.ExportToTerra,
     ExportToTerraSuccess: MDX.ExportToTerraSuccess,
     fileManifestState,
-    fileManifestType: FILE_MANIFEST_TYPE.ENTITY_EXPORT_TO_TERRA,
     fileSummaryFacetName: HCA_DCP_CATEGORY_KEY.FILE_FORMAT,
     filters,
     formFacet,
@@ -1109,7 +1103,6 @@ export const buildExportToTerra = (
     ExportToTerraStart: MDX.ExportToTerraStart,
     ExportToTerraSuccess: MDX.ExportToTerraSuccessWithWarning,
     fileManifestState,
-    fileManifestType: FILE_MANIFEST_TYPE.EXPORT_TO_TERRA,
     fileSummaryFacetName: HCA_DCP_CATEGORY_KEY.FILE_FORMAT,
     filters: filterState,
     formFacet,
@@ -1313,7 +1306,6 @@ export const buildManifestDownload = (
     ManifestDownloadStart: MDX.ManifestDownloadStart,
     ManifestDownloadSuccess: MDX.ManifestDownloadSuccess,
     fileManifestState,
-    fileManifestType: FILE_MANIFEST_TYPE.DOWNLOAD_MANIFEST,
     fileSummaryFacetName: HCA_DCP_CATEGORY_KEY.FILE_FORMAT,
     filters: filterState,
     formFacet,
@@ -1334,7 +1326,6 @@ export const buildManifestDownloadEntity = (
   // Get the metadata filters.
   const metadataFilters = getMetadataFilters(filters);
   return {
-    fileManifestType: FILE_MANIFEST_TYPE.ENTITY_DOWNLOAD_MANIFEST,
     filters,
     metadataFilters,
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "2.26.1",
       "dependencies": {
-        "@databiosphere/findable-ui": "^48",
+        "@databiosphere/findable-ui": "^49",
         "@emotion/react": "^11",
         "@emotion/styled": "^11",
         "@mdx-js/loader": "^3",
@@ -1052,9 +1052,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "48.1.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-48.1.0.tgz",
-      "integrity": "sha512-J1Qt37wUODYhOB0uZELaRsfFEjlCH2zA3hASU3YYFMNGCg1vnn+8TWEbzXENiORku5sXs8cUoNdJYjacrS0RLQ==",
+      "version": "49.4.1",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-49.4.1.tgz",
+      "integrity": "sha512-IYwn9Gn5GZzCtNZwJ/VZz2bjDXFlsYsJNqnQDMW1cirMHayEas2ObbH5X6J4nLD5SMHrLSsLLwGV9M57nSyK4A==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "check-system-status:anvil-cmg": "esrun e2e/anvil/anvil-check-system-status.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^48",
+    "@databiosphere/findable-ui": "^49",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@mdx-js/loader": "^3",

--- a/site-config/anvil-cmg/dev/config.ts
+++ b/site-config/anvil-cmg/dev/config.ts
@@ -50,17 +50,14 @@ export function makeConfig(
         {
           categoryConfigs: [
             {
-              enableChartView: false,
               key: ANVIL_CMG_CATEGORY_KEY.DATASET_TITLE,
               label: ANVIL_CMG_CATEGORY_LABEL.DATASET_TITLE,
             },
             {
-              enableChartView: false,
               key: ANVIL_CMG_CATEGORY_KEY.DATASET_REGISTERED_ID,
               label: ANVIL_CMG_CATEGORY_LABEL.DATASET_REGISTERED_ID,
             },
             {
-              enableChartView: false,
               key: ANVIL_CMG_CATEGORY_KEY.DATASET_CONSENT_GROUP,
               label: ANVIL_CMG_CATEGORY_LABEL.DATASET_CONSENT_GROUP,
             },

--- a/site-config/anvil-cmg/dev/config.ts
+++ b/site-config/anvil-cmg/dev/config.ts
@@ -50,14 +50,17 @@ export function makeConfig(
         {
           categoryConfigs: [
             {
+              chart: { enable: false },
               key: ANVIL_CMG_CATEGORY_KEY.DATASET_TITLE,
               label: ANVIL_CMG_CATEGORY_LABEL.DATASET_TITLE,
             },
             {
+              chart: { enable: false },
               key: ANVIL_CMG_CATEGORY_KEY.DATASET_REGISTERED_ID,
               label: ANVIL_CMG_CATEGORY_LABEL.DATASET_REGISTERED_ID,
             },
             {
+              chart: { enable: false },
               key: ANVIL_CMG_CATEGORY_KEY.DATASET_CONSENT_GROUP,
               label: ANVIL_CMG_CATEGORY_LABEL.DATASET_CONSENT_GROUP,
             },

--- a/site-config/hca-dcp/dev/index/common/category.ts
+++ b/site-config/hca-dcp/dev/index/common/category.ts
@@ -26,7 +26,6 @@ export const BIONETWORK_NAME: CategoryConfig = {
 };
 
 export const CONTACT_NAME: CategoryConfig = {
-  enableChartView: false,
   key: HCA_DCP_CATEGORY_KEY.CONTACT_NAME,
   label: HCA_DCP_CATEGORY_LABEL.CONTACT_NAME,
 };
@@ -37,13 +36,11 @@ export const CONTENT_DESCRIPTION: CategoryConfig = {
 };
 
 export const DEVELOPMENT_STAGE: CategoryConfig = {
-  enableChartView: false,
   key: HCA_DCP_CATEGORY_KEY.DEVELOPMENT_STAGE,
   label: HCA_DCP_CATEGORY_LABEL.DEVELOPMENT_STAGE,
 };
 
 export const DONOR_DISEASE: CategoryConfig = {
-  enableChartView: false,
   key: HCA_DCP_CATEGORY_KEY.DONOR_DISEASE,
   label: HCA_DCP_CATEGORY_LABEL.DONOR_DISEASE,
 };
@@ -64,7 +61,6 @@ export const GENUS_SPECIES: CategoryConfig = {
 };
 
 export const INSTITUTION: CategoryConfig = {
-  enableChartView: false,
   key: HCA_DCP_CATEGORY_KEY.INSTITUTION,
   label: HCA_DCP_CATEGORY_LABEL.INSTITUTION,
 };
@@ -105,7 +101,6 @@ export const PRESERVATION_METHOD: CategoryConfig = {
 };
 
 export const PROJECT_TITLE: CategoryConfig = {
-  enableChartView: false,
   key: HCA_DCP_CATEGORY_KEY.PROJECT_TITLE,
   label: HCA_DCP_CATEGORY_LABEL.PROJECT_TITLE,
 };

--- a/site-config/hca-dcp/dev/index/common/category.ts
+++ b/site-config/hca-dcp/dev/index/common/category.ts
@@ -26,6 +26,7 @@ export const BIONETWORK_NAME: CategoryConfig = {
 };
 
 export const CONTACT_NAME: CategoryConfig = {
+  chart: { enable: false },
   key: HCA_DCP_CATEGORY_KEY.CONTACT_NAME,
   label: HCA_DCP_CATEGORY_LABEL.CONTACT_NAME,
 };
@@ -36,11 +37,13 @@ export const CONTENT_DESCRIPTION: CategoryConfig = {
 };
 
 export const DEVELOPMENT_STAGE: CategoryConfig = {
+  chart: { enable: false },
   key: HCA_DCP_CATEGORY_KEY.DEVELOPMENT_STAGE,
   label: HCA_DCP_CATEGORY_LABEL.DEVELOPMENT_STAGE,
 };
 
 export const DONOR_DISEASE: CategoryConfig = {
+  chart: { enable: false },
   key: HCA_DCP_CATEGORY_KEY.DONOR_DISEASE,
   label: HCA_DCP_CATEGORY_LABEL.DONOR_DISEASE,
 };
@@ -61,6 +64,7 @@ export const GENUS_SPECIES: CategoryConfig = {
 };
 
 export const INSTITUTION: CategoryConfig = {
+  chart: { enable: false },
   key: HCA_DCP_CATEGORY_KEY.INSTITUTION,
   label: HCA_DCP_CATEGORY_LABEL.INSTITUTION,
 };
@@ -101,6 +105,7 @@ export const PRESERVATION_METHOD: CategoryConfig = {
 };
 
 export const PROJECT_TITLE: CategoryConfig = {
+  chart: { enable: false },
   key: HCA_DCP_CATEGORY_KEY.PROJECT_TITLE,
   label: HCA_DCP_CATEGORY_LABEL.PROJECT_TITLE,
 };


### PR DESCRIPTION
## Ticket
Closes #4691

## Summary
- Upgrade @databiosphere/findable-ui from ^48 to ^49 (v49.4.1)
- Remove deprecated `enableChartView` property from CategoryConfig
- Remove deprecated `fileManifestType` property from view model builders

## Test plan
- [ ] Verify anvil-cmg builds successfully
- [ ] Verify hca-dcp builds successfully
- [ ] Verify no regressions in export functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)