### PR TITLE
feat: update anvil cmg auth config to use ecm endpoint (#4694)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "2.26.1",
       "dependencies": {
-        "@databiosphere/findable-ui": "^49",
+        "@databiosphere/findable-ui": "^49.4.1",
         "@emotion/react": "^11",
         "@emotion/styled": "^11",
         "@mdx-js/loader": "^3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "check-system-status:anvil-cmg": "esrun e2e/anvil/anvil-check-system-status.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^49",
+    "@databiosphere/findable-ui": "^49.4.1",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@mdx-js/loader": "^3",

--- a/site-config/anvil-cmg/dev/authentication/constants.ts
+++ b/site-config/anvil-cmg/dev/authentication/constants.ts
@@ -16,7 +16,7 @@ export const GOOGLE_PROVIDER: OAuthProvider<GoogleProfile> = {
 export const TERRA_SERVICE = {
   endpoint: {
     nihStatus:
-      "https://firecloud-orchestration.dsde-dev.broadinstitute.org/api/nih/status",
+      "https://externalcreds.dsde-dev.broadinstitute.org/api/oauth/v1/ras",
     profile: "https://sam.dsde-dev.broadinstitute.org/register/user/v1",
     tos: "https://sam.dsde-dev.broadinstitute.org/register/user/v2/self/termsOfServiceDetails",
   },

--- a/site-config/anvil-cmg/prod/authentication/constants.ts
+++ b/site-config/anvil-cmg/prod/authentication/constants.ts
@@ -16,7 +16,7 @@ export const GOOGLE_PROVIDER: OAuthProvider<GoogleProfile> = {
 export const TERRA_SERVICE = {
   endpoint: {
     nihStatus:
-      "https://firecloud-orchestration.dsde-prod.broadinstitute.org/api/nih/status",
+      "https://externalcreds.dsde-prod.broadinstitute.org/api/oauth/v1/ras",
     profile: "https://sam.dsde-prod.broadinstitute.org/register/user/v1",
     tos: "https://sam.dsde-prod.broadinstitute.org/register/user/v2/self/termsOfServiceDetails",
   },


### PR DESCRIPTION
Closes #4694.

This pull request updates dependencies and modifies service endpoint URLs for authentication in both development and production configurations. The most important changes are grouped below:

Dependency update:

* Upgraded the `@databiosphere/findable-ui` dependency version in `package.json` from `^49` to `^49.4.1`, which may include bug fixes or new features.

Service endpoint changes:

* Changed the `nihStatus` endpoint in `site-config/anvil-cmg/dev/authentication/constants.ts` to use the new RAS OAuth endpoint (`https://externalcreds.dsde-dev.broadinstitute.org/api/oauth/v1/ras`) instead of the previous Firecloud Orchestration endpoint.
* Changed the `nihStatus` endpoint in `site-config/anvil-cmg/prod/authentication/constants.ts` to use the new RAS OAuth endpoint (`https://externalcreds.dsde-prod.broadinstitute.org/api/oauth/v1/ras`) instead of the previous Firecloud Orchestration endpoint.