### PR TITLE
feat: decouple anvil-cmg summary mapping from shared constants (#4529)

### DIFF
--- a/app/apis/azul/anvil-cmg/common/entities.ts
+++ b/app/apis/azul/anvil-cmg/common/entities.ts
@@ -81,7 +81,7 @@ export interface DonorEntityResponse {
  */
 export interface DonorSpecies {
   count: number;
-  species: null; // TODO - when species type is known (currently returns null value).
+  species: string | null;
 }
 
 /**

--- a/app/apis/azul/anvil-cmg/common/responses.ts
+++ b/app/apis/azul/anvil-cmg/common/responses.ts
@@ -107,9 +107,8 @@ export type SummaryResponse = {
   biosampleCount: number;
   datasetCount: number;
   donorCount: number;
-  donorDiagnosisDiseases: unknown[]; // TODO - when type is known.
-  donorDiagnosisPhenotypes: unknown[]; // TODO - when type is known.
   donorSpecies: DonorSpecies[];
   fileCount: number;
   fileFormats: FileFormat[];
+  totalFileSize: number;
 };

--- a/site-config/anvil-cmg/dev/index/common/constants.ts
+++ b/site-config/anvil-cmg/dev/index/common/constants.ts
@@ -1,9 +1,0 @@
-import { SUMMARY } from "app/components/Index/common/entities";
-
-// Template constants
-const { BIOSAMPLES, DONORS, FILE_FORMATS, TOTAL_FILE_SIZE } = SUMMARY;
-
-/**
- * Summary display order.
- */
-export const SUMMARIES = [BIOSAMPLES, DONORS, FILE_FORMATS, TOTAL_FILE_SIZE];

--- a/site-config/anvil-cmg/dev/index/summaryViewModelBuilder.ts
+++ b/site-config/anvil-cmg/dev/index/summaryViewModelBuilder.ts
@@ -26,5 +26,5 @@ export const buildSummaries = (
 function sumFileFormatCounts(summaryResponse: SummaryResponse): number {
   return (summaryResponse.fileFormats ?? []).reduce((accum, { count }) => {
     return accum + count;
-  }, 0 as number);
+  }, 0);
 }

--- a/site-config/anvil-cmg/dev/index/summaryViewModelBuilder.ts
+++ b/site-config/anvil-cmg/dev/index/summaryViewModelBuilder.ts
@@ -1,9 +1,30 @@
-import { AzulSummaryResponse } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
-import { mapSummary } from "../../../../app/components/Index/common/indexTransformer";
-import { SUMMARIES } from "./common/constants";
+import { SummaryResponse } from "../../../../app/apis/azul/anvil-cmg/common/responses";
+import { formatCountSize } from "@databiosphere/findable-ui/lib/utils/formatCountSize";
+import { formatFileSize } from "@databiosphere/findable-ui/lib/utils/formatFileSize";
 
+/**
+ * Maps the AnVIL-CMG summary response to summary display key-value pairs.
+ * @param summaryResponse - Response model returned from the summary API.
+ * @returns summary key-value pairs of [count, label].
+ */
 export const buildSummaries = (
-  summaryResponse: AzulSummaryResponse
+  summaryResponse: SummaryResponse
 ): [string, string][] => {
-  return mapSummary(SUMMARIES, summaryResponse);
+  return [
+    [formatCountSize(summaryResponse.biosampleCount), "BioSamples"],
+    [formatCountSize(summaryResponse.donorCount), "Donors"],
+    [formatCountSize(sumFileFormatCounts(summaryResponse)), "Files"],
+    [formatFileSize(summaryResponse.totalFileSize), ""],
+  ];
 };
+
+/**
+ * Sums the file counts across all file formats in the summary response.
+ * @param summaryResponse - Response model returned from the summary API.
+ * @returns total file count across all formats.
+ */
+function sumFileFormatCounts(summaryResponse: SummaryResponse): number {
+  return (summaryResponse.fileFormats ?? []).reduce((accum, { count }) => {
+    return accum + count;
+  }, 0 as number);
+}

--- a/site-config/anvil-cmg/dev/index/summaryViewModelBuilder.ts
+++ b/site-config/anvil-cmg/dev/index/summaryViewModelBuilder.ts
@@ -1,6 +1,6 @@
-import { SummaryResponse } from "../../../../app/apis/azul/anvil-cmg/common/responses";
 import { formatCountSize } from "@databiosphere/findable-ui/lib/utils/formatCountSize";
 import { formatFileSize } from "@databiosphere/findable-ui/lib/utils/formatFileSize";
+import { SummaryResponse } from "../../../../app/apis/azul/anvil-cmg/common/responses";
 
 /**
  * Maps the AnVIL-CMG summary response to summary display key-value pairs.


### PR DESCRIPTION
Closes #4529.

This pull request updates the summary response handling and display logic for the AnVIL-CMG application, focusing on improving type safety, adding new data fields, and simplifying summary mapping. The most important changes include updating API response types, adding support for total file size, and refactoring the summary view model builder to directly map and format summary values.

**API Type Improvements:**

* Changed the `species` field in the `DonorSpecies` interface from always `null` to `string | null`, allowing for actual species values when available.
* Added a `totalFileSize` field to the `SummaryResponse` type to support displaying the total size of files in summaries.

**Summary Mapping and Display Refactor:**

* Replaced the previous summary mapping logic in `summaryViewModelBuilder.ts` with a new `buildSummaries` function that directly formats and maps summary values, including bio samples, donors, files, and file size.
* Introduced a helper function `sumFileFormatCounts` to calculate the total file count across all file formats in the summary response.

**Configuration Cleanup:**

* Removed the summary display order constants and related imports from `constants.ts`, as the new mapping logic no longer relies on them.