### PR TITLE
feat: decouple hca-dcp summary mapping from shared constants (#4530)

### DIFF
--- a/app/apis/azul/hca-dcp/common/entities.ts
+++ b/app/apis/azul/hca-dcp/common/entities.ts
@@ -118,7 +118,7 @@ export interface ProjectsEntityResponse {
  * Model of project summary in the response from /index/summary API endpoint.
  */
 export interface ProjectSummary {
-  cellSuspensions: { totalCells: number };
+  cellSuspensions: { totalCells: number | null };
   projects: { estimatedCellCount: number };
 }
 

--- a/app/apis/azul/hca-dcp/common/entities.ts
+++ b/app/apis/azul/hca-dcp/common/entities.ts
@@ -119,7 +119,7 @@ export interface ProjectsEntityResponse {
  */
 export interface ProjectSummary {
   cellSuspensions: { totalCells: number | null };
-  projects: { estimatedCellCount: number };
+  projects: { estimatedCellCount: number | null };
 }
 
 /**

--- a/app/apis/azul/hca-dcp/common/responses.ts
+++ b/app/apis/azul/hca-dcp/common/responses.ts
@@ -75,5 +75,5 @@ export type SummaryResponse = {
   projects: ProjectSummary[];
   speciesCount: number;
   specimenCount: number;
-  totalFileSize: number | string;
+  totalFileSize: number;
 };

--- a/site-config/hca-dcp/dev/index/common/constants.ts
+++ b/site-config/hca-dcp/dev/index/common/constants.ts
@@ -1,9 +1,0 @@
-import { SUMMARY } from "app/components/Index/common/entities";
-
-// Template constants
-const { DONORS, ESTIMATED_CELLS, FILES, SPECIMENS } = SUMMARY;
-
-/**
- * Summary display order.
- */
-export const SUMMARIES = [ESTIMATED_CELLS, SPECIMENS, DONORS, FILES];

--- a/site-config/hca-dcp/dev/index/summaryViewModelBuilder.ts
+++ b/site-config/hca-dcp/dev/index/summaryViewModelBuilder.ts
@@ -1,9 +1,45 @@
-import { AzulSummaryResponse } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
-import { mapSummary } from "../../../../app/components/Index/common/indexTransformer";
-import { SUMMARIES } from "./common/constants";
+import { SummaryResponse } from "../../../../app/apis/azul/hca-dcp/common/responses";
+import { ProjectSummary } from "../../../../app/apis/azul/hca-dcp/common/entities";
+import { formatCountSize } from "@databiosphere/findable-ui/lib/utils/formatCountSize";
 
+/**
+ * Maps the HCA-DCP summary response to summary display key-value pairs.
+ * @param summaryResponse - Response model returned from the summary API.
+ * @returns summary key-value pairs of [count, label].
+ */
 export const buildSummaries = (
-  summaryResponse: AzulSummaryResponse
+  summaryResponse: SummaryResponse
 ): [string, string][] => {
-  return mapSummary(SUMMARIES, summaryResponse);
+  return [
+    [
+      formatCountSize(sumEstimatedCellCounts(summaryResponse)),
+      "Estimated Cells",
+    ],
+    [formatCountSize(summaryResponse.specimenCount), "Specimens"],
+    [formatCountSize(summaryResponse.donorCount), "Donors"],
+    [formatCountSize(summaryResponse.fileCount), "Files"],
+  ];
 };
+
+/**
+ * Sums the estimated cell counts across all projects in the summary response.
+ * Uses estimatedCellCount when available, falling back to totalCells.
+ * @param summaryResponse - Response model returned from the summary API.
+ * @returns total estimated cell count across all projects.
+ */
+function sumEstimatedCellCounts(summaryResponse: SummaryResponse): number {
+  return (summaryResponse.projects ?? []).reduce(
+    (accum, { cellSuspensions, projects }: ProjectSummary) => {
+      if (projects?.estimatedCellCount || projects?.estimatedCellCount === 0) {
+        accum += projects.estimatedCellCount;
+      } else if (
+        cellSuspensions?.totalCells ||
+        cellSuspensions?.totalCells === 0
+      ) {
+        accum += cellSuspensions.totalCells;
+      }
+      return accum;
+    },
+    0
+  );
+}

--- a/site-config/hca-dcp/dev/index/summaryViewModelBuilder.ts
+++ b/site-config/hca-dcp/dev/index/summaryViewModelBuilder.ts
@@ -1,6 +1,6 @@
-import { SummaryResponse } from "../../../../app/apis/azul/hca-dcp/common/responses";
-import { ProjectSummary } from "../../../../app/apis/azul/hca-dcp/common/entities";
 import { formatCountSize } from "@databiosphere/findable-ui/lib/utils/formatCountSize";
+import { ProjectSummary } from "../../../../app/apis/azul/hca-dcp/common/entities";
+import { SummaryResponse } from "../../../../app/apis/azul/hca-dcp/common/responses";
 
 /**
  * Maps the HCA-DCP summary response to summary display key-value pairs.


### PR DESCRIPTION
Closes #4530.

This pull request refactors the summary view model builder for the HCA-DCP project, streamlining how summary data is mapped and displayed. The changes remove legacy code, update data types for improved consistency, and introduce a new method for calculating estimated cell counts across projects.

Summary view model builder refactor:

* Replaced the legacy `mapSummary` and `SUMMARIES` approach with a new `buildSummaries` function that directly maps summary response fields to display pairs, improving clarity and maintainability.
* Introduced the `sumEstimatedCellCounts` function to aggregate estimated cell counts across all projects, using `estimatedCellCount` when available and falling back to `totalCells`.

Data model updates:

* Changed the `totalCells` property in `ProjectSummary.cellSuspensions` to allow `null`, improving handling of missing data.
* Updated `SummaryResponse.totalFileSize` to always be a `number`, ensuring type consistency.

Code cleanup:

* Removed unused imports and constants from `site-config/hca-dcp/dev/index/common/constants.ts`, eliminating obsolete summary mapping code.

