### PR TITLE
docs: add study entity PRD (#4376)

### DIFF
--- a/prds/study-entity/example-datasets-response.json
+++ b/prds/study-entity/example-datasets-response.json
@@ -1,0 +1,311 @@
+{
+  "hits": [
+    {
+      "entryId": "3e1a790a-8680-4dd2-b6f1-93ea3cba5e01",
+      "sources": [
+        {
+          "source_prefix": "/0",
+          "source_spec": "tdr:bigquery:gcp:datarepo-3ef65a17:ANVIL_CCDG_Broad_NP_Epilepsy_LEBABM_GRU_GSA_MD_20250721_ANV5_202508051741",
+          "source_id": "7ea46791-7b08-4955-95a6-b606f7b916d6"
+        }
+      ],
+      "bundles": [
+        {
+          "bundle_uuid": "003db4c0-075b-a933-8993-697726aa77e0",
+          "bundle_version": "2022-06-01T00:00:00.000000Z"
+        }
+      ],
+      "studies": [
+        {
+          "study_name": "Center for Common Disease Genomics [CCDG] - Neuropsychiatric: Epilepsy: Epi25 Consortium (phs001489)",
+          "registered_identifier": "phs001489",
+          "consortia": ["CCDG"]
+        }
+      ],
+      "datasets": [
+        {
+          "document_id": "3e1a790a-8680-4dd2-b6f1-93ea3cba5e01",
+          "source_datarepo_row_ids": [
+            "workspace_attributes:2fb99410-4515-4db6-90c5-e4401947d7b3"
+          ],
+          "dataset_id": "00866376-c7ba-997e-44d3-819c1c33d67c",
+          "consent_group": ["GRU"],
+          "data_use_permission": ["GRU"],
+          "owner": [null],
+          "principal_investigator": [null],
+          "registered_identifier": ["phs001489"],
+          "title": "ANVIL_CCDG_Broad_NP_Epilepsy_LEBABM_GRU_GSA_MD",
+          "data_modality": [null],
+          "description": "[Description currently not available]",
+          "duos_id": "DUOS-000710",
+          "accessible": false
+        }
+      ],
+      "activities": [
+        {
+          "activity_type": ["Unknown"],
+          "assay_type": [null],
+          "data_modality": [null]
+        }
+      ],
+      "biosamples": [
+        {
+          "anatomical_site": [null],
+          "biosample_type": [null],
+          "disease": [null],
+          "donor_age_at_collection_unit": [null],
+          "donor_age_at_collection": [{ "gte": null, "lte": null }]
+        }
+      ],
+      "diagnoses": [],
+      "donors": [],
+      "files": [
+        {
+          "data_modality": [null],
+          "file_format": [".vcf.gz"],
+          "file_size": 117027877144,
+          "reference_assembly": [null],
+          "is_supplementary": [false, true],
+          "count": 849
+        },
+        {
+          "data_modality": [null],
+          "file_format": [".idat"],
+          "file_size": 15633649608,
+          "reference_assembly": [null],
+          "is_supplementary": [false],
+          "count": 1692
+        }
+      ]
+    }
+  ],
+  "termFacets": {
+    "studies.registered_identifier": {
+      "terms": [
+        { "term": "phs001489", "count": 149 },
+        { "term": "phs000920", "count": 20 }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "studies.study_name": {
+      "terms": [
+        {
+          "term": "Center for Common Disease Genomics [CCDG] - Neuropsychiatric: Epilepsy: Epi25 Consortium (phs001489)",
+          "count": 149
+        }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "studies.consortia": {
+      "terms": [
+        { "term": "CCDG", "count": 283 },
+        { "term": "CMG", "count": 20 },
+        { "term": "CSER", "count": 8 },
+        { "term": "GREGoR", "count": 7 }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "studies.study_design": {
+      "terms": [
+        { "term": "Case-Control", "count": "..." },
+        { "term": "Cohort", "count": "..." }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "studies.phenotype_indication": {
+      "terms": [
+        { "term": "Epilepsy", "count": "..." },
+        { "term": "Inflammatory Bowel Disease", "count": "..." }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "studies.data_types": {
+      "terms": [
+        { "term": "WES", "count": "..." },
+        { "term": "WGS", "count": "..." },
+        { "term": "GSA-MD", "count": "..." }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "studies.principal_investigator": {
+      "terms": [
+        { "term": "Ben Neale", "count": 149 },
+        { "term": "Daniel MacArthur", "count": "..." }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "datasets.consent_group": {
+      "terms": [
+        { "term": "GRU", "count": 107 },
+        { "term": "HMB", "count": 27 },
+        { "term": "HMB-MDS", "count": 27 },
+        { "term": "HMB-NPU-MDS", "count": 18 }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "datasets.data_use_permission": {
+      "terms": [
+        { "term": "GRU", "count": 107 },
+        { "term": "HMB", "count": 27 },
+        { "term": "HMB-MDS", "count": 27 }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "datasets.title": {
+      "terms": [
+        {
+          "term": "ANVIL_CCDG_Broad_NP_Epilepsy_LEBABM_GRU_GSA_MD",
+          "count": 1
+        }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "biosamples.disease": {
+      "terms": [{ "term": null, "count": 382 }],
+      "total": 382,
+      "type": "terms"
+    },
+    "biosamples.anatomical_site": {
+      "terms": [
+        { "term": null, "count": 262 },
+        { "term": "Unknown", "count": 137 }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "biosamples.biosample_type": {
+      "terms": [
+        { "term": null, "count": 259 },
+        { "term": "Blood", "count": 125 }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "diagnoses.disease": {
+      "terms": [
+        { "term": "Autism spectrum disorder", "count": 37 },
+        { "term": "Inflammatory bowel disease", "count": 15 }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "diagnoses.phenotype": {
+      "terms": [
+        { "term": null, "count": 370 },
+        { "term": "Agenesis of the Corpus Callosum", "count": 2 }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "diagnoses.phenopacket": {
+      "terms": [{ "term": null, "count": 382 }],
+      "total": 382,
+      "type": "terms"
+    },
+    "files.data_modality": {
+      "terms": [
+        { "term": null, "count": 377 },
+        { "term": "single-cell RNA sequencing assay", "count": 4 }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "files.file_format": {
+      "terms": [
+        { "term": ".vcf.gz", "count": 288 },
+        { "term": ".tbi", "count": 277 },
+        { "term": ".cram", "count": 233 }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "files.is_supplementary": {
+      "terms": [
+        { "term": "true", "count": 347 },
+        { "term": "false", "count": 344 }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "activities.activity_type": {
+      "terms": [
+        { "term": "Indexing", "count": 283 },
+        { "term": "Unknown", "count": 210 },
+        { "term": "Sequencing", "count": 130 }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "activities.assay_type": {
+      "terms": [
+        { "term": null, "count": 382 },
+        { "term": "WGS", "count": 1 }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "activities.data_modality": {
+      "terms": [
+        { "term": null, "count": 382 },
+        { "term": "Genomic", "count": 7 }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "donors.organism_type": {
+      "terms": [
+        { "term": "Human", "count": 199 },
+        { "term": null, "count": 180 }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "donors.phenotypic_sex": {
+      "terms": [
+        { "term": "Female", "count": 190 },
+        { "term": "Male", "count": 190 }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "donors.reported_ethnicity": {
+      "terms": [
+        { "term": null, "count": 334 },
+        { "term": "Black or African American", "count": 54 }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "datasets.registered_identifier": {
+      "terms": [
+        { "term": "phs001489", "count": 149 },
+        { "term": "phs000920", "count": 20 }
+      ],
+      "total": 382,
+      "type": "terms"
+    },
+    "files.reference_assembly": {
+      "terms": [{ "term": "...", "count": "..." }],
+      "total": 382,
+      "type": "terms"
+    },
+    "accessible": {
+      "terms": [
+        { "term": "true", "count": "..." },
+        { "term": "false", "count": "..." }
+      ],
+      "total": 382,
+      "type": "terms"
+    }
+  }
+}

--- a/prds/study-entity/example-duos-response.json
+++ b/prds/study-entity/example-duos-response.json
@@ -1,0 +1,50 @@
+{
+  "datasetId": 727,
+  "datasetIdentifier": "DUOS-000667",
+  "datasetName": "ANVIL_CCDG_Broad_NP_Epilepsy_AUSALF_HMB_IRB_GSA_MD (HMB-IRB-MDS)",
+  "name": "ANVIL_CCDG_Broad_NP_Epilepsy_AUSALF_HMB_IRB_GSA_MD (HMB-IRB-MDS)",
+  "alias": 667,
+  "dacApproval": true,
+  "dacId": 2,
+  "studyId": 111,
+  "dataUse": "...",
+  "properties": "...",
+  "study": {
+    "studyId": 111,
+    "name": "Center for Common Disease Genomics [CCDG] - Neuropsychiatric: Epilepsy: Epi25 Consortium (phs001489)",
+    "description": "Epilepsy genetics research is at an exciting stage where it is now feasible, with the power of a large cohort, to understand the more complex genetic components of epilepsy...",
+    "piName": "Ben Neale",
+    "dataTypes": ["GSA-MD", "WES"],
+    "datasetIds": [768, 512, 769, "...149 total"],
+    "properties": [
+      {
+        "key": "collaboratingSites",
+        "type": "Json",
+        "value": ["CCDG"]
+      },
+      {
+        "key": "dbGaPPhsID",
+        "type": "String",
+        "value": "phs001489"
+      },
+      {
+        "key": "phenotypeIndication",
+        "type": "String",
+        "value": "Epilepsy"
+      },
+      {
+        "key": "data",
+        "type": "Json",
+        "value": {
+          "tags": [
+            "Platform: AnVIL",
+            "Platform: NCPI",
+            "dbGaP_phs_id: phs001489",
+            "dbGaP_accession: phs001489.v4.p2",
+            "dbGaP_study_design: Case-Control"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/prds/study-entity/example-studies-response.json
+++ b/prds/study-entity/example-studies-response.json
@@ -1,0 +1,278 @@
+{
+  "hits": [
+    {
+      "entryId": "7658b452-7e09-478e-b49d-44611ce6b691",
+      "sources": [
+        {
+          "source_prefix": "/0",
+          "source_spec": "tdr:bigquery:gcp:datarepo-afe52c93:ANVIL_CCDG_Broad_NP_Epilepsy_AUSALF_HMB_IRB_GSA_MD_20250718_ANV5_202508070436",
+          "source_id": "e358ba7e-dd04-4bc9-8ac0-50caf137c17d"
+        }
+      ],
+      "bundles": [
+        {
+          "bundle_uuid": "2424203d-c29b-a3d9-9591-92187a9fe875",
+          "bundle_version": "2022-06-01T00:00:00.000000Z"
+        }
+      ],
+      "studies": [
+        {
+          "study_name": "Center for Common Disease Genomics [CCDG] - Neuropsychiatric: Epilepsy: Epi25 Consortium (phs001489)",
+          "registered_identifier": "phs001489",
+          "consortia": ["CCDG"],
+          "description": "Epilepsy genetics research is at an exciting stage...",
+          "study_design": ["Case-Control"],
+          "data_types": ["GSA-MD", "WES"],
+          "principal_investigator": "Ben Neale",
+          "phenotype_indication": "Epilepsy"
+        }
+      ],
+      "datasets": [
+        {
+          "document_id": "7658b452-7e09-478e-b49d-44611ce6b691",
+          "source_datarepo_row_ids": [
+            "workspace_attributes:fccb9378-c83c-43da-9f9d-6a0b5bd518b9"
+          ],
+          "dataset_id": "765586ca-b050-cad7-2968-0adc139b46af",
+          "consent_group": ["HMB-IRB-MDS"],
+          "data_use_permission": ["HMB-IRB-MDS"],
+          "owner": [null],
+          "principal_investigator": [null],
+          "registered_identifier": ["phs001489"],
+          "title": "ANVIL_CCDG_Broad_NP_Epilepsy_AUSALF_HMB_IRB_GSA_MD",
+          "data_modality": [null],
+          "description": "[Description currently not available]",
+          "duos_id": "DUOS-000667",
+          "accessible": false
+        }
+      ],
+      "activities": [
+        {
+          "activity_type": ["Indexing", "Unknown"],
+          "assay_type": [null],
+          "data_modality": [null]
+        }
+      ],
+      "biosamples": [
+        {
+          "anatomical_site": [null],
+          "biosample_type": [null],
+          "disease": [null],
+          "donor_age_at_collection_unit": [null],
+          "donor_age_at_collection": [{ "gte": null, "lte": null }]
+        }
+      ],
+      "diagnoses": [],
+      "donors": [],
+      "files": [
+        {
+          "data_modality": [null],
+          "file_format": [".vcf.gz"],
+          "file_size": 2351439457,
+          "reference_assembly": [null],
+          "is_supplementary": [false, true],
+          "count": 17
+        },
+        {
+          "data_modality": [null],
+          "file_format": [".idat"],
+          "file_size": 295669520,
+          "reference_assembly": [null],
+          "is_supplementary": [false],
+          "count": 32
+        }
+      ]
+    }
+  ],
+  "termFacets": {
+    "studies.registered_identifier": {
+      "terms": [
+        { "term": "phs001489", "count": 1 },
+        { "term": "phs000920", "count": 1 }
+      ],
+      "total": 73,
+      "type": "terms"
+    },
+    "studies.study_name": {
+      "terms": [
+        {
+          "term": "Center for Common Disease Genomics [CCDG] - Neuropsychiatric: Epilepsy: Epi25 Consortium (phs001489)",
+          "count": 1
+        }
+      ],
+      "total": 73,
+      "type": "terms"
+    },
+    "studies.consortia": {
+      "terms": [
+        { "term": "CCDG", "count": "..." },
+        { "term": "CMG", "count": "..." },
+        { "term": "CSER", "count": "..." },
+        { "term": "GREGoR", "count": "..." }
+      ],
+      "total": 73,
+      "type": "terms"
+    },
+    "studies.study_design": {
+      "terms": [
+        { "term": "Case-Control", "count": "..." },
+        { "term": "Cohort", "count": "..." }
+      ],
+      "total": 73,
+      "type": "terms"
+    },
+    "studies.phenotype_indication": {
+      "terms": [
+        { "term": "Epilepsy", "count": "..." },
+        { "term": "Inflammatory Bowel Disease", "count": "..." }
+      ],
+      "total": 73,
+      "type": "terms"
+    },
+    "studies.data_types": {
+      "terms": [
+        { "term": "WES", "count": "..." },
+        { "term": "WGS", "count": "..." },
+        { "term": "GSA-MD", "count": "..." }
+      ],
+      "total": 73,
+      "type": "terms"
+    },
+    "studies.principal_investigator": {
+      "terms": [
+        { "term": "Ben Neale", "count": 1 },
+        { "term": "Daniel MacArthur", "count": "..." }
+      ],
+      "total": 73,
+      "type": "terms"
+    },
+    "datasets.consent_group": {
+      "terms": [
+        { "term": "HMB-IRB-MDS", "count": "..." },
+        { "term": "GRU", "count": "..." }
+      ],
+      "total": 73,
+      "type": "terms"
+    },
+    "datasets.data_use_permission": {
+      "terms": [
+        { "term": "HMB-IRB-MDS", "count": "..." },
+        { "term": "GRU", "count": "..." }
+      ],
+      "total": 73,
+      "type": "terms"
+    },
+    "datasets.title": {
+      "terms": [
+        {
+          "term": "ANVIL_CCDG_Broad_NP_Epilepsy_AUSALF_HMB_IRB_GSA_MD",
+          "count": 1
+        }
+      ],
+      "total": 73,
+      "type": "terms"
+    },
+    "biosamples.disease": {
+      "terms": [{ "term": "...", "count": "..." }],
+      "total": 73,
+      "type": "terms"
+    },
+    "biosamples.anatomical_site": {
+      "terms": [{ "term": "...", "count": "..." }],
+      "total": 73,
+      "type": "terms"
+    },
+    "biosamples.biosample_type": {
+      "terms": [{ "term": "...", "count": "..." }],
+      "total": 73,
+      "type": "terms"
+    },
+    "diagnoses.disease": {
+      "terms": [{ "term": "...", "count": "..." }],
+      "total": 73,
+      "type": "terms"
+    },
+    "diagnoses.phenotype": {
+      "terms": [{ "term": "...", "count": "..." }],
+      "total": 73,
+      "type": "terms"
+    },
+    "diagnoses.phenopacket": {
+      "terms": [{ "term": "...", "count": "..." }],
+      "total": 73,
+      "type": "terms"
+    },
+    "files.data_modality": {
+      "terms": [{ "term": "...", "count": "..." }],
+      "total": 73,
+      "type": "terms"
+    },
+    "files.file_format": {
+      "terms": [
+        { "term": ".vcf.gz", "count": "..." },
+        { "term": ".idat", "count": "..." }
+      ],
+      "total": 73,
+      "type": "terms"
+    },
+    "files.is_supplementary": {
+      "terms": [
+        { "term": "false", "count": "..." },
+        { "term": "true", "count": "..." }
+      ],
+      "total": 73,
+      "type": "terms"
+    },
+    "activities.activity_type": {
+      "terms": [{ "term": "Indexing", "count": "..." }],
+      "total": 73,
+      "type": "terms"
+    },
+    "activities.assay_type": {
+      "terms": [{ "term": "...", "count": "..." }],
+      "total": 73,
+      "type": "terms"
+    },
+    "activities.data_modality": {
+      "terms": [{ "term": "...", "count": "..." }],
+      "total": 73,
+      "type": "terms"
+    },
+    "donors.organism_type": {
+      "terms": [{ "term": "...", "count": "..." }],
+      "total": 73,
+      "type": "terms"
+    },
+    "donors.phenotypic_sex": {
+      "terms": [{ "term": "...", "count": "..." }],
+      "total": 73,
+      "type": "terms"
+    },
+    "donors.reported_ethnicity": {
+      "terms": [{ "term": "...", "count": "..." }],
+      "total": 73,
+      "type": "terms"
+    },
+    "datasets.registered_identifier": {
+      "terms": [
+        { "term": "phs001489", "count": "..." },
+        { "term": "phs000920", "count": "..." }
+      ],
+      "total": 73,
+      "type": "terms"
+    },
+    "files.reference_assembly": {
+      "terms": [{ "term": "...", "count": "..." }],
+      "total": 73,
+      "type": "terms"
+    },
+    "accessible": {
+      "terms": [
+        { "term": "true", "count": "..." },
+        { "term": "false", "count": "..." }
+      ],
+      "total": 73,
+      "type": "terms"
+    }
+  }
+}

--- a/prds/study-entity/prd-study-entity.md
+++ b/prds/study-entity/prd-study-entity.md
@@ -1,0 +1,232 @@
+# PRD: Study Entity and Filters
+
+## Background
+
+On the AnVIL Data Explorer, multiple datasets share the same parent study (`registered_identifier` / phsId). Currently there is no study-level entity in the API — partial study-level info is only available as repeated fields across dataset hits. A study entity collapses these into a single browsable entry with aggregated statistics.
+
+It is also difficult for consortia to link directly to their collection of studies — they can only link to a list of datasets, which may span multiple studies.
+
+As of 2026-03-12: 382 datasets map to **73 unique studies** in DUOS. 4 datasets have no `registered_identifier`.
+
+## Goals
+
+1. Add a `studies` entity to the Azul index with study-level fields and aggregations.
+2. Enable studies and their child entities (datasets, biosamples, donors, activities, files) to be filterable by the key study-level properties including a consortia filter enabling consortia to share direct links to the collection of their datasets in the explorer.
+
+## Studies Data Source
+
+Study info can be sourced from the DUOS API (`GET /api/tdr/{DUOS-ID}` → `response.study`). In the DUOS API, study info is embedded in the dataset response — there is no "list all studies" endpoint, so studies must be deduped from dataset responses.
+
+## API Changes
+
+> This document aims to follow existing Azul API patterns for how entities, inner objects, and facets are structured. If any pattern is described incorrectly, or if we want to introduce optimizations that deviate from the current patterns, the spec should be adjusted accordingly.
+
+### New endpoint: `/index/studies`
+
+The new `/index/studies` endpoint returns study entities with the same filtering and facet structure as the other entity endpoints. Hits and termFacets are updated as outlined below.
+
+### Hits
+
+#### New hit fields
+
+These new study-level fields are sourced from DUOS and appear in full on the `/index/studies` hit response. On other entity endpoints (`/index/datasets`, `/index/files`, etc.), a `studies` object is included in hits but abbreviated to just `study_name`, `registered_identifier`, and `consortia`, following the existing practice of including summary parent objects on child entity hits.
+
+| Field                  | Azul Key                         | DUOS Path                                                               | Notes                                                                                |
+| ---------------------- | -------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Registered Identifier  | `studies.registered_identifier`  | `study.properties[key=dbGaPPhsID].value`                                | 66/73 studies (90% coverage). See open question below for studies missing this field |
+| Study Name             | `studies.study_name`             | `study.name`                                                            | 73 unique values, 100% coverage                                                      |
+| Consortia              | `studies.consortia`              | `study.properties[key=collaboratingSites].value`                        | 19 unique values, 65/73 studies (89%), 365/382 datasets (95.5%)                      |
+| Study Design           | `studies.study_design`           | `study.properties[key=data].value.tags` (prefix `dbGaP_study_design: `) | 11 unique values, 90% coverage                                                       |
+| Description            | `studies.description`            | `study.description`                                                     | 100% coverage                                                                        |
+| Phenotype Indication   | `studies.phenotype_indication`   | `study.properties[key=phenotypeIndication].value`                       | 72/73 studies (99% coverage). String type in DUOS (single value, not array)          |
+| Data Types             | `studies.data_types`             | `study.dataTypes`                                                       | 100% coverage                                                                        |
+| Principal Investigator | `studies.principal_investigator` | `study.piName`                                                          | 100% coverage                                                                        |
+
+#### Existing hit fields rolled up from children to study
+
+These fields already exist on dataset entity responses. On `/index/studies`, they are aggregated up from datasets sharing the same `registered_identifier` as the study's `dbGaPPhsID`.
+
+| Field                      | Source field                         | Roll-up rule             |
+| -------------------------- | ------------------------------------ | ------------------------ |
+| Accessible                 | `datasets.accessible`                | Union of unique values   |
+| Consent Group              | `datasets.consent_group`             | Union of unique values   |
+| Data Use Permission        | `datasets.data_use_permission`       | Union of unique values   |
+| Title                      | `datasets.title`                     | Union of unique values   |
+|                            |                                      |                          |
+| Anatomical Site            | `biosamples.anatomical_site`         | Union of unique values   |
+| Biosample Type             | `biosamples.biosample_type`          | Union of unique values   |
+| Disease (Biosamples)       | `biosamples.disease`                 | Union of unique values   |
+| Donor Age at Collection    | `biosamples.donor_age_at_collection` | Union of unique ranges   |
+|                            |                                      |                          |
+| Disease (Diagnoses)        | `diagnoses.disease`                  | Union of unique values   |
+| Phenopacket                | `diagnoses.phenopacket`              | Union of unique values   |
+| Phenotype                  | `diagnoses.phenotype`                | Union of unique values   |
+|                            |                                      |                          |
+| Genetic Ancestry           | `donors.genetic_ancestry`            | Union of unique values   |
+| Organism Type              | `donors.organism_type`               | Union of unique values   |
+| Participant Count          | `donors`                             | Count of unique donors\* |
+| Phenotypic Sex             | `donors.phenotypic_sex`              | Union of unique values   |
+| Reported Ethnicity         | `donors.reported_ethnicity`          | Union of unique values   |
+|                            |                                      |                          |
+| Activity Type              | `activities.activity_type`           | Union of unique values   |
+| Assay Type                 | `activities.assay_type`              | Union of unique values   |
+| Data Modality (Activities) | `activities.data_modality`           | Union of unique values   |
+|                            |                                      |                          |
+| Data Modality (Files)      | `files.data_modality`                | Union of unique values   |
+| File Count                 | `files.count`                        | Sum                      |
+| File Format                | `files.file_format`                  | Union of unique values   |
+| File Size                  | `files.file_size`                    | Sum                      |
+| Is Supplementary           | `files.is_supplementary`             | Union of unique values   |
+| Reference Assembly         | `files.reference_assembly`           | Union of unique values   |
+
+\*Some investigation may be needed to determine the unique donor count, as donors may belong to multiple datasets within a study.
+
+### TermFacets
+
+> **Note:** Hit abbreviation and facet propagation are independent. On child entity endpoints, the `studies` hit object is abbreviated to 3 fields (`study_name`, `registered_identifier`, `consortia`), but _all_ 7 `studies.*` facets are available for filtering. This matches the existing pattern: e.g., `/index/files` hits abbreviate `datasets` to just `dataset_id` and `title`, yet all dataset-level facets (`datasets.consent_group`, `datasets.data_use_permission`, etc.) appear as termFacets on `/index/files`.
+
+#### New facets
+
+The following new facets are sourced from the DUOS study entity. Study-level values are propagated down to child entities for filtering, following the existing pattern where all parent facets appear on child endpoints.
+
+For array-valued fields (`consortia`, `study_design`, `data_types`), the full array is propagated to every child entity — the `studies.*` prefix makes the semantics clear (e.g., `studies.data_types: WES` means "belongs to a study tagged with WES," not that the child entity itself is WES).
+
+Facets are propagated to all entity endpoints, following the current practice of propagating all parent facets to children (`/index/studies`, `/index/datasets`, `/index/biosamples`, `/index/donors`, `/index/activities`, `/index/files`):
+
+| Facet                            | Source                                                                  |
+| -------------------------------- | ----------------------------------------------------------------------- |
+| `studies.registered_identifier`  | `study.properties[key=dbGaPPhsID].value`                                |
+| `studies.study_name`             | `study.name`                                                            |
+| `studies.consortia`              | `study.properties[key=collaboratingSites].value`                        |
+| `studies.study_design`           | `study.properties[key=data].value.tags` (prefix `dbGaP_study_design: `) |
+| `studies.phenotype_indication`   | `study.properties[key=phenotypeIndication].value`                       |
+| `studies.data_types`             | `study.dataTypes`                                                       |
+| `studies.principal_investigator` | `study.piName`                                                          |
+
+#### Existing facets
+
+All existing termFacets from current entity endpoints are also available on `/index/studies`, aggregated from child entities using the same roll-up rules as the hit fields above. All entity endpoints share the same set of existing facets.
+
+| Facet                            | Source field                     |
+| -------------------------------- | -------------------------------- |
+| `datasets.consent_group`         | `datasets.consent_group`         |
+| `datasets.data_use_permission`   | `datasets.data_use_permission`   |
+| `datasets.registered_identifier` | `datasets.registered_identifier` |
+| `datasets.title`                 | `datasets.title`                 |
+|                                  |                                  |
+| `biosamples.anatomical_site`     | `biosamples.anatomical_site`     |
+| `biosamples.biosample_type`      | `biosamples.biosample_type`      |
+| `biosamples.disease`             | `biosamples.disease`             |
+|                                  |                                  |
+| `diagnoses.disease`              | `diagnoses.disease`              |
+| `diagnoses.phenopacket`          | `diagnoses.phenopacket`          |
+| `diagnoses.phenotype`            | `diagnoses.phenotype`            |
+|                                  |                                  |
+| `donors.organism_type`           | `donors.organism_type`           |
+| `donors.phenotypic_sex`          | `donors.phenotypic_sex`          |
+| `donors.reported_ethnicity`      | `donors.reported_ethnicity`      |
+|                                  |                                  |
+| `activities.activity_type`       | `activities.activity_type`       |
+| `activities.assay_type`          | `activities.assay_type`          |
+| `activities.data_modality`       | `activities.data_modality`       |
+|                                  |                                  |
+| `files.data_modality`            | `files.data_modality`            |
+| `files.file_format`              | `files.file_format`              |
+| `files.is_supplementary`         | `files.is_supplementary`         |
+| `files.reference_assembly`       | `files.reference_assembly`       |
+|                                  |                                  |
+| `accessible`                     | `accessible`                     |
+
+### Example responses
+
+- [example-duos-response.json](example-duos-response.json) — DUOS API response for `GET /api/tdr/DUOS-000667` showing the dataset wrapper and its embedded `study` object with properties. Abbreviated for brevity; only study-relevant properties are included.
+- [example-studies-response.json](example-studies-response.json) — `/index/studies` response with the new `studies` inner entity and all child entities. Based on real data from DUOS study 111 (phs001489) and dataset DUOS-000667.
+- [example-datasets-response.json](example-datasets-response.json) — `/index/datasets` response showing the abbreviated `studies` inner entity (`study_name`, `registered_identifier`, `consortia`) and the new study-level termFacets. Based on real data with termFacet counts from the live API.
+
+### Study detail: `/index/studies/{studyId}`
+
+Returns a single study entity. Modeled after the dataset detail response (`/index/datasets/{datasetId}`) but with study-specific fields added. The response shape is the same as a single hit from `/index/studies` above.
+
+## Open Questions
+
+1. **4 datasets with no `registered_identifier`** (ANVIL_1000G_high_coverage_2019, ANVIL_GTEx_public_data, ANVIL_T2T, ANVIL_T2T_CHRY): Some options:
+   - Treat as standalone single-dataset studies
+   - Exclude from the studies endpoint
+   - Group under an "Unregistered" study
+2. **7 studies with no `dbGaPPhsID` in DUOS** (10% of studies): How should studies without a registered identifier be keyed and linked to their datasets?
+3. **Dataset-specific descriptions:** All datasets in a study share the same DUOS description. How to differentiate them on a study detail view?
+
+## Coverage (as of 2026-03-12)
+
+### Study field coverage (across 73 studies)
+
+| Field               | Coverage     |
+| ------------------- | ------------ |
+| name                | 73/73 (100%) |
+| description         | 73/73 (100%) |
+| piName              | 73/73 (100%) |
+| dataTypes           | 73/73 (100%) |
+| phenotypeIndication | 72/73 (99%)  |
+| dbGaPPhsID          | 66/73 (90%)  |
+| collaboratingSites  | 65/73 (89%)  |
+
+### Consortia coverage (across 382 datasets)
+
+| Metric                              | Count             |
+| ----------------------------------- | ----------------- |
+| With `collaboratingSites` populated | 365 (95.5%)       |
+| Without DUOS ID                     | 8 (all CMG Broad) |
+| Empty `collaboratingSites`          | 9                 |
+| Unique consortium values            | 19                |
+
+| Consortium              | Datasets |     | Consortium  | Datasets |
+| ----------------------- | -------- | --- | ----------- | -------- |
+| CCDG                    | 283      |     | CARD        | 3        |
+| CMG                     | 20       |     | PAGE        | 3        |
+| CSER                    | 8        |     | 1000G       | 2        |
+| GREGoR                  | 7        |     | ALS-Compute | 2        |
+| GTEx                    | 7        |     | ALS-FTD     | 2        |
+| IGVF                    | 6        |     | T2T         | 2        |
+| Convergent Neuroscience | 5        |     | ADOPT       | 2        |
+| WGSPD1                  | 5        |     | ENCORE      | 2        |
+| DepMap                  | 4        |     | HPRC        | 1        |
+|                         |          |     | CMH         | 1        |
+
+## References
+
+- GitHub issue: https://github.com/DataBiosphere/data-browser/issues/4376
+- Azul issue: https://github.com/DataBiosphere/azul/issues/7813
+- DUOS endpoint: `GET /api/tdr/{DUOS-ID}` on `consent.dsde-prod.broadinstitute.org`
+- Current datasets API: `https://service.explore.anvilproject.org/index/datasets?catalog=anvil13`
+
+---
+
+## Addendum: Data Source
+
+There may be other ways to query the DUOS API; these are examples.
+
+Fetch consortia for a dataset:
+
+```bash
+TOKEN=$(gcloud auth print-access-token)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://consent.dsde-prod.broadinstitute.org/api/tdr/DUOS-000667" \
+  | jq '.study.properties[] | select(.key == "collaboratingSites") | .value'
+# => ["CCDG"]
+```
+
+Fetch study fields for a dataset:
+
+```bash
+TOKEN=$(gcloud auth print-access-token)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://consent.dsde-prod.broadinstitute.org/api/tdr/DUOS-000667" \
+  | jq '.study | {name, description, dataTypes, properties: [.properties[] | {(.key): .value}]}'
+```
+
+## Addendum: Coverage Scripts
+
+Scripts used to generate the coverage data above. Requires `gcloud auth login` and `pip install requests`.
+
+- [scripts/study_coverage.py](scripts/study_coverage.py) — Study field coverage across unique DUOS studies
+- [scripts/consortia_coverage.py](scripts/consortia_coverage.py) — Consortia field coverage across datasets

--- a/prds/study-entity/scripts/consortia_coverage.py
+++ b/prds/study-entity/scripts/consortia_coverage.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Fetch all AnVIL datasets, look up consortia from DUOS, and report coverage.
+
+Supporting script for the study entity PRD. Review only needed if changes
+affect PRD claims (e.g. coverage numbers, field availability).
+
+Requires: gcloud auth login, pip install requests
+"""
+
+import subprocess
+import sys
+from collections import Counter
+
+import requests
+
+token = (
+    subprocess.check_output(["gcloud", "auth", "print-access-token"])
+    .decode()
+    .strip()
+)
+
+# Fetch all AnVIL datasets
+print("Fetching AnVIL datasets...")
+all_hits = []
+url = (
+    "https://service.explore.anvilproject.org/index/datasets"
+    "?size=100&sort=datasets.title&catalog=anvil13&order=asc&filters=%7B%7D"
+)
+while url:
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    all_hits.extend(data["hits"])
+    url = data.get("pagination", {}).get("next")
+
+datasets = []
+for h in all_hits:
+    for ds in h.get("datasets", []):
+        datasets.append(
+            {
+                "title": ds.get("title"),
+                "duos_id": ds.get("duos_id"),
+            }
+        )
+
+print(f"Total datasets: {len(datasets)}")
+with_duos = [d for d in datasets if d["duos_id"]]
+without_duos = [d for d in datasets if not d["duos_id"]]
+print(f"With DUOS ID: {len(with_duos)}")
+print(f"Without DUOS ID: {len(without_duos)}")
+for d in without_duos:
+    print(f"  - {d['title']}")
+
+# Hit DUOS API for each unique duos_id
+print("\nFetching consortia from DUOS...")
+headers = {"Authorization": f"Bearer {token}"}
+consortia_map = {}
+errors = []
+unique_duos_ids = list(set(d["duos_id"] for d in with_duos))
+for i, duos_id in enumerate(unique_duos_ids):
+    if i % 50 == 0:
+        print(f"  Progress: {i}/{len(unique_duos_ids)}", file=sys.stderr)
+    try:
+        r = requests.get(
+            f"https://consent.dsde-prod.broadinstitute.org/api/tdr/{duos_id}",
+            headers=headers,
+            timeout=30,
+        )
+        r.raise_for_status()
+        data = r.json()
+        study = data.get("study", {})
+        props = {p["key"]: p.get("value") for p in study.get("properties", [])}
+        consortia_map[duos_id] = props.get("collaboratingSites", [])
+    except Exception as e:
+        errors.append((duos_id, str(e)))
+        consortia_map[duos_id] = None
+
+# Analyze coverage
+populated = 0
+empty = 0
+null_or_missing = 0
+consortium_counter = Counter()
+
+for d in with_duos:
+    val = consortia_map.get(d["duos_id"])
+    if val is None:
+        null_or_missing += 1
+    elif not val or val == "":
+        empty += 1
+    else:
+        populated += 1
+        for v in val if isinstance(val, list) else [val]:
+            consortium_counter[v] += 1
+
+print(f"\n=== COVERAGE (across {len(datasets)} total datasets) ===")
+print(f"Populated collaboratingSites: {populated}")
+print(f"Empty collaboratingSites: {empty}")
+print(f"Null/missing/error: {null_or_missing}")
+print(f"Total with DUOS ID: {len(with_duos)}")
+print(f"Coverage: {populated}/{len(datasets)} ({100 * populated / len(datasets):.1f}%)")
+
+print(f"\n=== CONSORTIUM VALUES (by dataset count) ===")
+for name, count in consortium_counter.most_common():
+    print(f"  {name}: {count}")
+
+if errors:
+    print(f"\n=== ERRORS ({len(errors)}) ===")
+    for duos_id, err in errors:
+        print(f"  {duos_id}: {err}")
+
+print(f"\n=== DATASETS WITH EMPTY collaboratingSites ===")
+for d in with_duos:
+    val = consortia_map.get(d["duos_id"])
+    if val is not None and (not val or val == ""):
+        print(f"  - {d['title']} ({d['duos_id']})")

--- a/prds/study-entity/scripts/study_coverage.py
+++ b/prds/study-entity/scripts/study_coverage.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Fetch all AnVIL datasets, extract unique studies from DUOS, and report coverage.
+
+Supporting script for the study entity PRD. Review only needed if changes
+affect PRD claims (e.g. coverage numbers, field availability).
+
+Requires: gcloud auth login, pip install requests
+"""
+
+import subprocess
+import sys
+
+import requests
+
+token = (
+    subprocess.check_output(["gcloud", "auth", "print-access-token"])
+    .decode()
+    .strip()
+)
+
+# Fetch all AnVIL datasets
+print("Fetching AnVIL datasets...")
+all_hits = []
+url = (
+    "https://service.explore.anvilproject.org/index/datasets"
+    "?size=100&sort=datasets.title&catalog=anvil13&order=asc&filters=%7B%7D"
+)
+while url:
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    all_hits.extend(data["hits"])
+    url = data.get("pagination", {}).get("next")
+
+datasets = []
+for h in all_hits:
+    for ds in h.get("datasets", []):
+        datasets.append(
+            {
+                "title": ds.get("title"),
+                "duos_id": ds.get("duos_id"),
+                "registered_identifier": ds.get("registered_identifier", []),
+            }
+        )
+
+with_duos = [d for d in datasets if d["duos_id"]]
+print(f"Total datasets: {len(datasets)}, with DUOS ID: {len(with_duos)}")
+
+# Fetch study info from DUOS, dedupe by study name
+print("Fetching study info from DUOS...")
+headers = {"Authorization": f"Bearer {token}"}
+studies = {}
+unique_duos_ids = list(set(d["duos_id"] for d in with_duos))
+for i, duos_id in enumerate(unique_duos_ids):
+    if i % 50 == 0:
+        print(f"  Progress: {i}/{len(unique_duos_ids)}", file=sys.stderr)
+    try:
+        r = requests.get(
+            f"https://consent.dsde-prod.broadinstitute.org/api/tdr/{duos_id}",
+            headers=headers,
+            timeout=30,
+        )
+        r.raise_for_status()
+        data = r.json()
+        study = data.get("study", {})
+        name = study.get("name")
+        if name and name not in studies:
+            props = {
+                p["key"]: p.get("value") for p in study.get("properties", [])
+            }
+            studies[name] = {
+                "name": name,
+                "studyId": study.get("studyId"),
+                "description": study.get("description"),
+                "piName": study.get("piName"),
+                "dataTypes": study.get("dataTypes"),
+                "collaboratingSites": props.get("collaboratingSites"),
+                "dbGaPPhsID": props.get("dbGaPPhsID"),
+                "phenotypeIndication": props.get("phenotypeIndication"),
+                "datasetCount": len(study.get("datasetIds", [])),
+            }
+    except Exception as e:
+        print(f"  Error on {duos_id}: {e}", file=sys.stderr)
+
+print(f"\nUnique studies: {len(studies)}")
+
+# Field coverage
+print(f"\n=== FIELD COVERAGE (across {len(studies)} studies) ===")
+for field in [
+    "name",
+    "description",
+    "piName",
+    "dataTypes",
+    "phenotypeIndication",
+    "dbGaPPhsID",
+    "collaboratingSites",
+]:
+    n = sum(1 for s in studies.values() if s.get(field))
+    print(f"  {field}: {n}/{len(studies)} ({100 * n / len(studies):.0f}%)")
+
+# Dataset count distribution
+print(f"\n=== DATASETS PER STUDY ===")
+sizes = sorted([s["datasetCount"] for s in studies.values()], reverse=True)
+print(f"  Max: {sizes[0]}, Median: {sizes[len(sizes) // 2]}, Min: {sizes[-1]}")
+print(f"  Studies with 1 dataset: {sum(1 for s in sizes if s == 1)}")
+print(f"  Top 10:")
+for s in sorted(studies.values(), key=lambda x: x["datasetCount"], reverse=True)[:10]:
+    print(f"    {s['name'][:70]}: {s['datasetCount']} datasets")
+
+# Datasets with no registered_identifier
+no_reg = [
+    d
+    for d in datasets
+    if not d["registered_identifier"] or d["registered_identifier"] == ["none"]
+]
+print(f"\n=== DATASETS WITH NO registered_identifier: {len(no_reg)} ===")
+for d in no_reg:
+    print(f"  - {d['title']}")


### PR DESCRIPTION
## Summary

- Add [PRD](https://github.com/DataBiosphere/data-browser/blob/d152ee3aff466ff66a1be65a47efbbb38c6e81f3/prds/study-entity/prd-study-entity.md) for the new `/index/studies` entity endpoint in Azul, specifying new hit fields (from DUOS), roll-up aggregation rules from child entities, and termFacet propagation
- Define how study-level data flows to child entity endpoints following existing Azul patterns (summary hit objects + full facet propagation)
- Include example API responses and coverage analysis scripts verified against live DUOS/Azul data

## Test plan

- [ ] Review PRD for completeness against existing Azul entity patterns
- [ ] Verify DUOS field paths using the included coverage scripts
- [ ] Confirm example JSON responses match expected API shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)