### PR TITLE
chore: update findable-ui to latest version (#4704)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "2.27.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^49.4.1",
+        "@databiosphere/findable-ui": "^49.6.0",
         "@emotion/react": "^11",
         "@emotion/styled": "^11",
         "@mdx-js/loader": "^3",
@@ -1052,9 +1052,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "49.4.1",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-49.4.1.tgz",
-      "integrity": "sha512-IYwn9Gn5GZzCtNZwJ/VZz2bjDXFlsYsJNqnQDMW1cirMHayEas2ObbH5X6J4nLD5SMHrLSsLLwGV9M57nSyK4A==",
+      "version": "49.6.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-49.6.0.tgz",
+      "integrity": "sha512-/nNdJRzfNrNkXD0MTw1BSt3clOte8pBbr7T9Rm+9nAYxwcU/6E60u042VM8yjFp6ibl7YrkP/Z+iSK5cNLtH1Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "check-system-status:anvil-cmg": "esrun e2e/anvil/anvil-check-system-status.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^49.4.1",
+    "@databiosphere/findable-ui": "^49.6.0",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@mdx-js/loader": "^3",


### PR DESCRIPTION
Closes #4704.

This pull request makes a minor update to the `package.json` file, upgrading the `@databiosphere/findable-ui` dependency to version 49.6.0. This ensures the project uses the latest features and fixes from the UI library.