### PR TITLE
feat: track dataset exports for anvil-cmg and hca-dcp

### DIFF
--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
@@ -617,6 +617,7 @@ export const buildDatasetTerraExport = (
     fileSummaryFacetName: ANVIL_CMG_CATEGORY_KEY.FILE_FILE_FORMAT,
     filters,
     formFacet,
+    isDatasetExport: true,
     manifestDownloadFormat: MANIFEST_DOWNLOAD_FORMAT.VERBATIM_PFB,
     manifestDownloadFormats: [MANIFEST_DOWNLOAD_FORMAT.VERBATIM_PFB],
     speciesFacetName: ANVIL_CMG_CATEGORY_KEY.DONOR_ORGANISM_TYPE,

--- a/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
@@ -918,6 +918,7 @@ export const buildExportEntityToTerra = (
     fileSummaryFacetName: HCA_DCP_CATEGORY_KEY.FILE_FORMAT,
     filters,
     formFacet,
+    isDatasetExport: true,
     manifestDownloadFormat: MANIFEST_DOWNLOAD_FORMAT.TERRA_PFB,
     manifestDownloadFormats: [MANIFEST_DOWNLOAD_FORMAT.TERRA_PFB],
     speciesFacetName: HCA_DCP_CATEGORY_KEY.GENUS_SPECIES,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "2.28.1",
       "dependencies": {
-        "@databiosphere/findable-ui": "^50.0.0",
+        "@databiosphere/findable-ui": "^50.1.0",
         "@emotion/react": "^11",
         "@emotion/styled": "^11",
         "@mdx-js/loader": "^3",
@@ -1052,9 +1052,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "50.0.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-50.0.0.tgz",
-      "integrity": "sha512-3fEYvDbnhrRBc6MkOmd3Ap5Kz+Wi3b+av6qpn757O7OhPJH8UohjrUA3HJAMgs+OLec5H5vP6I/InoEFjc0DAg==",
+      "version": "50.1.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-50.1.0.tgz",
+      "integrity": "sha512-05SxpVQFq6rPngC3WWPD4M16NviqzG0sfdOCOqOvTM+lJDGsvdzuKQMiz8gRy5Dirpty3MTgvRG0dZDL9ihfpw==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "check-system-status:anvil-cmg": "esrun e2e/anvil/anvil-check-system-status.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^50.0.0",
+    "@databiosphere/findable-ui": "^50.1.0",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@mdx-js/loader": "^3",


### PR DESCRIPTION
## Ticket
Closes #4711

## Summary
- Add `isDatasetExport: true` to Terra export props for anvil-cmg and hca-dcp entity exports
- Update findable-ui from ^49.6.0 to ^50.1.0

## Test plan
- [ ] Verify Terra export functionality works correctly for anvil-cmg datasets
- [ ] Verify Terra export functionality works correctly for hca-dcp projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)