### PR TITLE
feat: enable curl download for anvil-cmg datasets

### DIFF
--- a/app/components/Export/components/AnVILExplorer/CurlDownload/curlDownloadExportMethod.tsx
+++ b/app/components/Export/components/AnVILExplorer/CurlDownload/curlDownloadExportMethod.tsx
@@ -1,0 +1,21 @@
+import { JSX } from "react";
+import { ComponentProps } from "react";
+import { ExportMethod as DXExportMethod } from "@databiosphere/findable-ui/lib/components/Export/components/ExportMethod/exportMethod";
+import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
+import { FEATURES } from "app/shared/entities";
+
+/**
+ * Export method component for curl download.
+ * Hidden if the curl download feature is not enabled.
+ * @param props - Export method component props.
+ * @returns Export method component.
+ */
+export const CurlDownloadExportMethod = (
+  props: ComponentProps<typeof DXExportMethod>
+): JSX.Element | null => {
+  const isEnabled = useFeatureFlag(FEATURES.CURL_DOWNLOAD);
+
+  if (!isEnabled) return null;
+
+  return <DXExportMethod {...props} />;
+};

--- a/app/components/common/MDXContent/anvil-cmg/downloadCurlCommandStart.mdx
+++ b/app/components/common/MDXContent/anvil-cmg/downloadCurlCommandStart.mdx
@@ -1,1 +1,5 @@
 ### Download via curl
+
+<TagWarning>Please note</TagWarning> This download includes only files available
+through the AWS Open Data Program. Files hosted exclusively on Google Cloud are
+not included in this command.

--- a/app/components/common/MDXContent/anvil-cmg/downloadCurlCommandStart.mdx
+++ b/app/components/common/MDXContent/anvil-cmg/downloadCurlCommandStart.mdx
@@ -1,0 +1,1 @@
+### Download via curl

--- a/app/components/common/MDXContent/anvil-cmg/downloadCurlCommandSuccess.mdx
+++ b/app/components/common/MDXContent/anvil-cmg/downloadCurlCommandSuccess.mdx
@@ -1,0 +1,3 @@
+### Your curl Command is Ready
+
+Execute the curl command below in your terminal to download the selected data.

--- a/app/components/common/MDXContent/anvil-cmg/index.tsx
+++ b/app/components/common/MDXContent/anvil-cmg/index.tsx
@@ -7,6 +7,8 @@ export { default as AlertExportWarning } from "./alertExportWarning.mdx";
 export { default as AlertExportWarningContent } from "./alertExportWarningContent.mdx";
 export { default as AlertLoginReminder } from "./alertLoginReminder.mdx";
 export { default as DataReleasePolicy } from "./dataReleasePolicy.mdx";
+export { default as DownloadCurlCommandStart } from "./downloadCurlCommandStart.mdx";
+export { default as DownloadCurlCommandSuccess } from "./downloadCurlCommandSuccess.mdx";
 export { default as LoginTermsOfService } from "./loginTermsOfService.mdx";
 export { default as LoginText } from "./loginText.mdx";
 export { default as LoginWarning } from "./loginWarning.mdx";

--- a/app/shared/entities.ts
+++ b/app/shared/entities.ts
@@ -3,5 +3,6 @@
  */
 export enum FEATURES {
   AZUL_DOWNLOAD = "azuldownload",
+  CURL_DOWNLOAD = "curldownload",
   NCPI_EXPORT = "ncpiexport",
 }

--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
@@ -486,6 +486,62 @@ export const buildDatasetExportMethodTerra = (
 };
 
 /**
+ * Build props for dataset curl download BackPageHero component.
+ * @param datasetsResponse - Response model return from datasets API.
+ * @returns model to be used as props for the BackPageHero component.
+ */
+export const buildDatasetExportMethodHeroCurlCommand = (
+  datasetsResponse: DatasetsResponse
+): React.ComponentProps<typeof C.BackPageHero> => {
+  const title = 'Download Selected Data Using "curl"';
+  return getDatasetExportMethodHero(datasetsResponse, title);
+};
+
+/**
+ * Build props for ExportMethod component for display of the dataset curl download section.
+ * @param datasetsResponse - Response model return from datasets API.
+ * @returns model to be used as props for the dataset curl download export method component.
+ */
+export const buildDatasetExportMethodCurlCommand = (
+  datasetsResponse: DatasetsResponse
+): React.ComponentProps<typeof C.ExportMethod> => {
+  const datasetPath = buildDatasetPath(datasetsResponse);
+  return {
+    buttonLabel: "Request curl Command",
+    description: "Obtain a curl command for downloading the selected data.",
+    route: `${datasetPath}${ROUTES.CURL_DOWNLOAD}`,
+    title: "Download Study Data and Metadata (curl Command)",
+  };
+};
+
+/**
+ * Build props for DownloadCurlCommand component from the given datasets response.
+ * @param datasetsResponse - Response model return from datasets API.
+ * @param viewContext - View context.
+ * @returns model to be used as props for the DownloadCurlCommand component.
+ */
+export const buildDatasetDownloadCurlCommand = (
+  datasetsResponse: DatasetsResponse,
+  viewContext: ViewContext<DatasetsResponse>
+): React.ComponentProps<typeof C.DownloadCurlCommand> => {
+  const { fileManifestState } = viewContext;
+  // Get the initial filters.
+  const filters = getExportEntityFilters(datasetsResponse);
+  // Get the form facets.
+  const formFacet = getFormFacets(fileManifestState);
+  return {
+    DownloadCurlForm: C.DownloadCurlCommandForm,
+    DownloadCurlStart: MDX.DownloadCurlCommandStart,
+    DownloadCurlSuccess: MDX.DownloadCurlCommandSuccess,
+    fileManifestState,
+    fileSummaryFacetName: ANVIL_CMG_CATEGORY_KEY.FILE_FILE_FORMAT,
+    filters,
+    formFacet,
+    speciesFacetName: ANVIL_CMG_CATEGORY_KEY.DONOR_ORGANISM_TYPE,
+  };
+};
+
+/**
  * Build props for the dataset ExportToPlatform component.
  * @param props - Props to pass to the ExportToPlatform component.
  * @returns model to be used as props for the ExportToPlatform component.

--- a/pages/[entityListType]/[...params].tsx
+++ b/pages/[entityListType]/[...params].tsx
@@ -42,6 +42,8 @@ const NCPI_EXPORT_PATHS = [
   ROUTES.CAVATICA,
 ];
 
+const CURL_DOWNLOAD_PATH = ROUTES.CURL_DOWNLOAD;
+
 interface StaticPath {
   params: PageUrl;
 }
@@ -64,10 +66,13 @@ export interface EntityDetailPageProps extends AzulEntityStaticResponse {
  */
 const EntityDetailPage = (props: EntityDetailPageProps): JSX.Element => {
   const isNCPIExportEnabled = useFeatureFlag(FEATURES.NCPI_EXPORT);
+  const isCurlDownloadEnabled = useFeatureFlag(FEATURES.CURL_DOWNLOAD);
   const { query } = useRouter();
   if (!props.entityListType) return <></>;
   if (props.override) return <EntityGuard override={props.override} />;
   if (!isNCPIExportEnabled && isNCPIExportRoute(query))
+    return <NextError statusCode={404} />;
+  if (!isCurlDownloadEnabled && isCurlDownloadRoute(query))
     return <NextError statusCode={404} />;
   if (isChooseExportView(query)) return <EntityExportView {...props} />;
   if (isExportMethodView(query)) return <EntityExportMethodView {...props} />;
@@ -101,6 +106,17 @@ function isNCPIExportRoute(query: ParsedUrlQuery): boolean {
   return NCPI_EXPORT_PATHS.map((path) => path.replace("/export/", "")).includes(
     lastParam
   );
+}
+
+/**
+ * Returns true if the current route is a curl download route.
+ * @param query - Parsed URL query.
+ * @returns True if the route matches the curl download path.
+ */
+function isCurlDownloadRoute(query: ParsedUrlQuery): boolean {
+  const params = query.params as string[] | undefined;
+  const lastParam = params?.[params.length - 1] || "";
+  return lastParam === CURL_DOWNLOAD_PATH.replace("/export/", "");
 }
 
 /**

--- a/site-config/anvil-cmg/dev/detail/dataset/export/export.ts
+++ b/site-config/anvil-cmg/dev/detail/dataset/export/export.ts
@@ -8,6 +8,7 @@ import * as C from "../../../../../../app/components";
 import { DatasetsResponse } from "app/apis/azul/anvil-cmg/common/responses";
 import { ROUTES } from "../../../export/routes";
 import * as MDX from "../../../../../../app/components/common/MDXContent/anvil-cmg";
+import { CurlDownloadExportMethod } from "../../../../../../app/components/Export/components/AnVILExplorer/CurlDownload/curlDownloadExportMethod";
 import { ExportMethod } from "../../../../../../app/components/Export/components/AnVILExplorer/platform/ExportMethod/exportMethod";
 import { EXPORT_METHODS, EXPORTS } from "../../../export/constants";
 import { ExportToPlatform } from "../../../../../../app/components/Export/components/AnVILExplorer/platform/ExportToPlatform/exportToPlatform";
@@ -25,6 +26,59 @@ const DATASET_ACCESSIBILITY_BADGE = {
  */
 export const exportConfig: ExportConfig = {
   exportMethods: [
+    {
+      mainColumn: [
+        /* --------- */
+        /* Dataset is not accessible; render warning */
+        /* --------- */
+        {
+          children: [
+            {
+              children: [
+                {
+                  component: MDX.Alert,
+                  viewBuilder: V.buildAlertDatasetExportWarning,
+                } as ComponentConfig<typeof MDX.Alert, DatasetsResponse>,
+              ],
+              component: C.BackPageContentSingleColumn,
+            } as ComponentConfig<typeof C.BackPageContentSingleColumn>,
+          ],
+          component: C.ConditionalComponent,
+          viewBuilder: V.renderDatasetExportWarning,
+        } as ComponentConfig<typeof C.ConditionalComponent, DatasetsResponse>,
+        /* ------ */
+        /* Dataset is accessible; render curl download method */
+        /* ------ */
+        {
+          children: [
+            {
+              children: [
+                {
+                  component: C.DownloadCurlCommand,
+                  viewBuilder: V.buildDatasetDownloadCurlCommand,
+                } as ComponentConfig<
+                  typeof C.DownloadCurlCommand,
+                  DatasetsResponse
+                >,
+              ],
+              component: C.BackPageContentMainColumn,
+            } as ComponentConfig<typeof C.BackPageContentMainColumn>,
+            /* sideColumn */
+            ...exportSideColumn,
+          ],
+          component: C.ConditionalComponent,
+          viewBuilder: V.renderDatasetExport,
+        } as ComponentConfig<typeof C.ConditionalComponent, DatasetsResponse>,
+      ],
+      route: ROUTES.CURL_DOWNLOAD,
+      top: [
+        {
+          children: [DATASET_ACCESSIBILITY_BADGE],
+          component: C.BackPageHero,
+          viewBuilder: V.buildDatasetExportMethodHeroCurlCommand,
+        } as ComponentConfig<typeof C.BackPageHero>,
+      ],
+    },
     {
       mainColumn: [
         /* --------- */
@@ -324,6 +378,10 @@ export const exportConfig: ExportConfig = {
                   component: C.AnVILExportEntity,
                   viewBuilder: V.buildDatasetExportPropsWithFilter,
                 } as ComponentConfig<typeof C.AnVILExportEntity>,
+                {
+                  component: CurlDownloadExportMethod,
+                  viewBuilder: V.buildDatasetExportMethodCurlCommand,
+                } as ComponentConfig<typeof CurlDownloadExportMethod>,
                 {
                   component: C.ExportMethod,
                   viewBuilder: V.buildDatasetExportMethodTerra,

--- a/site-config/anvil-cmg/dev/export/routes.ts
+++ b/site-config/anvil-cmg/dev/export/routes.ts
@@ -2,6 +2,7 @@ export const ROUTES = {
   BIO_DATA_CATALYST: "/export/biodata-catalyst",
   CANCER_GENOMICS_CLOUD: "/export/cancer-genomics-cloud",
   CAVATICA: "/export/cavatica",
+  CURL_DOWNLOAD: "/export/get-curl-command",
   MANIFEST_DOWNLOAD: "/export/download-manifest",
   TERRA: "/export/export-to-terra",
 } as const;


### PR DESCRIPTION
## Ticket
Closes #4692

## Summary
- Add curl download export method for anvil-cmg datasets (behind `curldownload` feature flag)
- Only available for open access datasets (uses existing accessibility check)
- Curl download appears first in the export methods list

## Changes
- Add `CURL_DOWNLOAD` feature flag to `app/shared/entities.ts`
- Add curl download route to `site-config/anvil-cmg/dev/export/routes.ts`
- Create MDX content for curl download start/success messages
- Add view builders for curl download in anvil-cmg viewModelBuilders
- Create feature-flagged `CurlDownloadExportMethod` component
- Update dataset export config to include curl download

## Test plan
- [ ] Enable feature flag by adding `?curldownload` to URL
- [ ] Navigate to an open access dataset export page
- [ ] Verify curl download appears as first export option
- [ ] Verify curl command generation works correctly
- [ ] Verify tracking event `bulk_download_requested` fires on request

🤖 Generated with [Claude Code](https://claude.com/claude-code)