### PR TITLE
feat: enable curl download for anvil-cmg cohort export

### DIFF
--- a/app/components/common/MDXContent/anvil-cmg/downloadCurlCommandDatasetStart.mdx
+++ b/app/components/common/MDXContent/anvil-cmg/downloadCurlCommandDatasetStart.mdx
@@ -1,0 +1,1 @@
+### Download via curl

--- a/app/components/common/MDXContent/anvil-cmg/downloadCurlCommandStart.mdx
+++ b/app/components/common/MDXContent/anvil-cmg/downloadCurlCommandStart.mdx
@@ -1,5 +1,4 @@
 ### Download via curl
 
-<TagWarning>Please note</TagWarning> This download includes only files available
-through the AWS Open Data Program. Files hosted exclusively on Google Cloud are
-not included in this command.
+<TagWarning>Please note</TagWarning> Only the open-access portion (consent group
+NRES) of the selected data will be included in the download.

--- a/app/components/common/MDXContent/anvil-cmg/index.tsx
+++ b/app/components/common/MDXContent/anvil-cmg/index.tsx
@@ -7,6 +7,7 @@ export { default as AlertExportWarning } from "./alertExportWarning.mdx";
 export { default as AlertExportWarningContent } from "./alertExportWarningContent.mdx";
 export { default as AlertLoginReminder } from "./alertLoginReminder.mdx";
 export { default as DataReleasePolicy } from "./dataReleasePolicy.mdx";
+export { default as DownloadCurlCommandDatasetStart } from "./downloadCurlCommandDatasetStart.mdx";
 export { default as DownloadCurlCommandStart } from "./downloadCurlCommandStart.mdx";
 export { default as DownloadCurlCommandSuccess } from "./downloadCurlCommandSuccess.mdx";
 export { default as LoginTermsOfService } from "./loginTermsOfService.mdx";

--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
@@ -1787,6 +1787,22 @@ export const renderWhenUnAuthenticated = (
 };
 
 /**
+ * Renders dataset curl download components when the given dataset is accessible
+ * and has NRES consent group.
+ * @param datasetsResponse - Response model return from datasets API.
+ * @returns model to be used as props for the ConditionalComponent component.
+ */
+export const renderDatasetCurlDownload = (
+  datasetsResponse: DatasetsResponse
+): React.ComponentProps<typeof C.ConditionalComponent> => {
+  const consentGroups = getConsentGroup(datasetsResponse);
+  const isNRES = consentGroups.includes("NRES");
+  return {
+    isIn: isDatasetAccessible(datasetsResponse) && isNRES,
+  };
+};
+
+/**
  * Renders dataset export-related components (either the choose export method component,
  * or specific export components) when the given dataset is accessble.
  * @param datasetsResponse - Response model return from datasets API.

--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
@@ -508,9 +508,9 @@ export const buildDatasetExportMethodCurlCommand = (
   const datasetPath = buildDatasetPath(datasetsResponse);
   return {
     buttonLabel: "Request curl Command",
-    description: "Obtain a curl command for downloading the selected data.",
+    description: "Obtain a curl command for downloading the dataset.",
     route: `${datasetPath}${ROUTES.CURL_DOWNLOAD}`,
-    title: "Download Study Data and Metadata (curl Command)",
+    title: "Download Open-Access Data and Metadata (curl Command)",
   };
 };
 
@@ -531,7 +531,7 @@ export const buildDatasetDownloadCurlCommand = (
   const formFacet = getFormFacets(fileManifestState);
   return {
     DownloadCurlForm: C.DownloadCurlCommandForm,
-    DownloadCurlStart: MDX.DownloadCurlCommandStart,
+    DownloadCurlStart: MDX.DownloadCurlCommandDatasetStart,
     DownloadCurlSuccess: MDX.DownloadCurlCommandSuccess,
     fileManifestState,
     fileSummaryFacetName: ANVIL_CMG_CATEGORY_KEY.FILE_FILE_FORMAT,
@@ -928,9 +928,10 @@ export const buildExportMethodBulkDownload = (
   return {
     ...getExportMethodAccessibility(viewContext),
     buttonLabel: "Request curl Command",
-    description: "Obtain a curl command for downloading the selected data.",
+    description:
+      "Obtain a curl command for downloading the open-access portion of the selected data.",
     route: ROUTES.CURL_DOWNLOAD,
-    title: "Download Study Data and Metadata (curl Command)",
+    title: "Download Open-Access Data and Metadata (curl Command)",
   };
 };
 

--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.ts
@@ -889,6 +889,69 @@ export const buildExportMethodTerra = (
 };
 
 /**
+ * Build props for DownloadCurlCommand component.
+ * @param _ - Unused.
+ * @param viewContext - View context.
+ * @returns model to be used as props for the DownloadCurlCommand component.
+ */
+export const buildDownloadCurlCommand = (
+  _: unknown,
+  viewContext: ViewContext<unknown>
+): React.ComponentProps<typeof C.DownloadCurlCommand> => {
+  const {
+    exploreState: { filterState },
+    fileManifestState,
+  } = viewContext;
+  const formFacet = getFormFacets(fileManifestState);
+  return {
+    DownloadCurlForm: C.DownloadCurlCommandForm,
+    DownloadCurlStart: MDX.DownloadCurlCommandStart,
+    DownloadCurlSuccess: MDX.DownloadCurlCommandSuccess,
+    fileManifestState,
+    fileSummaryFacetName: ANVIL_CMG_CATEGORY_KEY.FILE_FILE_FORMAT,
+    filters: filterState,
+    formFacet,
+    speciesFacetName: ANVIL_CMG_CATEGORY_KEY.DONOR_ORGANISM_TYPE,
+  };
+};
+
+/**
+ * Build props for ExportMethod component for display of the bulk download section.
+ * @param _ - Unused.
+ * @param viewContext - View context.
+ * @returns model to be used as props for the ExportMethod component.
+ */
+export const buildExportMethodBulkDownload = (
+  _: unknown,
+  viewContext: ViewContext<unknown>
+): React.ComponentProps<typeof C.ExportMethod> => {
+  return {
+    ...getExportMethodAccessibility(viewContext),
+    buttonLabel: "Request curl Command",
+    description: "Obtain a curl command for downloading the selected data.",
+    route: ROUTES.CURL_DOWNLOAD,
+    title: "Download Study Data and Metadata (curl Command)",
+  };
+};
+
+/**
+ * Build props for download curl command BackPageHero component.
+ * @param _ - Unused.
+ * @param viewContext - View context.
+ * @returns model to be used as props for the BackPageHero component.
+ */
+export const buildExportMethodHeroCurlCommand = (
+  _: unknown,
+  viewContext: ViewContext<unknown>
+): React.ComponentProps<typeof C.BackPageHero> => {
+  const title = 'Download Selected Data Using "curl"';
+  const {
+    exploreState: { tabValue },
+  } = viewContext;
+  return getExportMethodHero(tabValue, title);
+};
+
+/**
  * Build props for ExportSelectedDataSummary component.
  * @param _ - Unused.
  * @param viewContext - View context.

--- a/pages/[entityListType]/[...params].tsx
+++ b/pages/[entityListType]/[...params].tsx
@@ -29,6 +29,7 @@ import { ParsedUrlQuery } from "querystring";
 import { EntityGuard } from "../../app/components/Detail/components/EntityGuard/entityGuard";
 import { readFile } from "../../app/utils/tsvParser";
 import { useRouter } from "next/router";
+import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
 import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 import { FEATURES } from "../../app/shared/entities";
 import NextError from "next/error";
@@ -65,6 +66,8 @@ export interface EntityDetailPageProps extends AzulEntityStaticResponse {
  * @returns Entity detail view component.
  */
 const EntityDetailPage = (props: EntityDetailPageProps): JSX.Element => {
+  const { config } = useConfig();
+  const isAnVIL = config.appTitle?.includes("AnVIL");
   const isNCPIExportEnabled = useFeatureFlag(FEATURES.NCPI_EXPORT);
   const isCurlDownloadEnabled = useFeatureFlag(FEATURES.CURL_DOWNLOAD);
   const { query } = useRouter();
@@ -72,7 +75,8 @@ const EntityDetailPage = (props: EntityDetailPageProps): JSX.Element => {
   if (props.override) return <EntityGuard override={props.override} />;
   if (!isNCPIExportEnabled && isNCPIExportRoute(query))
     return <NextError statusCode={404} />;
-  if (!isCurlDownloadEnabled && isCurlDownloadRoute(query))
+  // Feature flag only applies to AnVIL sites
+  if (isAnVIL && !isCurlDownloadEnabled && isCurlDownloadRoute(query))
     return <NextError statusCode={404} />;
   if (isChooseExportView(query)) return <EntityExportView {...props} />;
   if (isExportMethodView(query)) return <EntityExportMethodView {...props} />;

--- a/pages/[entityListType]/[...params].tsx
+++ b/pages/[entityListType]/[...params].tsx
@@ -34,6 +34,8 @@ import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureF
 import { FEATURES } from "../../app/shared/entities";
 import NextError from "next/error";
 import { ROUTES } from "../../site-config/anvil-cmg/dev/export/routes";
+import { getConsentGroup } from "../../app/apis/azul/anvil-cmg/common/transformers";
+import { DatasetsResponse } from "../../app/apis/azul/anvil-cmg/common/responses";
 
 const setOfProcessedIds = new Set<string>();
 
@@ -75,9 +77,12 @@ const EntityDetailPage = (props: EntityDetailPageProps): JSX.Element => {
   if (props.override) return <EntityGuard override={props.override} />;
   if (!isNCPIExportEnabled && isNCPIExportRoute(query))
     return <NextError statusCode={404} />;
-  // Feature flag only applies to AnVIL sites
-  if (isAnVIL && !isCurlDownloadEnabled && isCurlDownloadRoute(query))
-    return <NextError statusCode={404} />;
+  // Curl download requires feature flag AND NRES consent group (AnVIL only)
+  if (isAnVIL && isCurlDownloadRoute(query)) {
+    if (!isCurlDownloadEnabled || !isNRESDataset(props.data)) {
+      return <NextError statusCode={404} />;
+    }
+  }
   if (isChooseExportView(query)) return <EntityExportView {...props} />;
   if (isExportMethodView(query)) return <EntityExportMethodView {...props} />;
   return <EntityDetailView {...props} />;
@@ -121,6 +126,17 @@ function isCurlDownloadRoute(query: ParsedUrlQuery): boolean {
   const params = query.params as string[] | undefined;
   const lastParam = params?.[params.length - 1] || "";
   return lastParam === CURL_DOWNLOAD_PATH.replace("/export/", "");
+}
+
+/**
+ * Returns true if the dataset has NRES consent group.
+ * @param data - Entity response data.
+ * @returns True if the dataset has NRES consent group.
+ */
+function isNRESDataset(data: AzulEntityStaticResponse | undefined): boolean {
+  if (!data) return false;
+  const consentGroups = getConsentGroup(data as DatasetsResponse);
+  return consentGroups.includes("NRES");
 }
 
 /**
@@ -260,6 +276,7 @@ export const getStaticProps: GetStaticProps<AzulEntityStaticResponse> = async ({
   const slug = (params as PageUrl).params;
   const entityConfig = getEntityConfig(entities, entityListType);
   const entityTab = getSlugPath(slug, PARAMS_INDEX_TAB);
+  const entityExportMethod = getSlugPath(slug, PARAMS_INDEX_EXPORT_METHOD);
   const entityId = getSlugPath(slug, PARAMS_INDEX_UUID);
 
   if (!entityConfig || !entityId) return { notFound: true };
@@ -272,7 +289,13 @@ export const getStaticProps: GetStaticProps<AzulEntityStaticResponse> = async ({
   if (props.override) return { props };
 
   // Process entity props.
-  await processEntityProps(entityConfig, entityTab, entityId, props);
+  await processEntityProps(
+    entityConfig,
+    entityTab,
+    entityExportMethod,
+    entityId,
+    props
+  );
 
   return {
     props,
@@ -476,12 +499,14 @@ function processEntityPaths(
  * Processes the entity props for the given entity page.
  * @param entityConfig - Entity config.
  * @param entityTab - Entity tab.
+ * @param entityExportMethod - Entity export method.
  * @param entityId - Entity ID.
  * @param props - Entity detail page props.
  */
 async function processEntityProps(
   entityConfig: EntityConfig,
   entityTab = "",
+  entityExportMethod = "",
   entityId: string,
   props: EntityDetailPageProps
 ): Promise<void> {
@@ -491,8 +516,15 @@ async function processEntityProps(
   } = entityConfig;
   // Early exit; return if the entity is not to be statically loaded.
   if (!staticLoad) return;
-  // When the entity detail is to be fetched from API, we only do so for the first tab.
-  if (exploreMode === EXPLORE_MODE.SS_FETCH_SS_FILTERING && entityTab) return;
+  // When the entity detail is to be fetched from API, we only do so for the first tab,
+  // unless it's the curl download route which needs data for NRES check.
+  const isCurlDownload = entityExportMethod === "get-curl-command";
+  if (
+    exploreMode === EXPLORE_MODE.SS_FETCH_SS_FILTERING &&
+    entityTab &&
+    !isCurlDownload
+  )
+    return;
   if (exploreMode === EXPLORE_MODE.CS_FETCH_CS_FILTERING) {
     // Seed database.
     await seedDatabase(entityConfig.route, entityConfig);

--- a/pages/[entityListType]/[...params].tsx
+++ b/pages/[entityListType]/[...params].tsx
@@ -68,8 +68,8 @@ export interface EntityDetailPageProps extends AzulEntityStaticResponse {
  * @returns Entity detail view component.
  */
 const EntityDetailPage = (props: EntityDetailPageProps): JSX.Element => {
-  const { config } = useConfig();
-  const isAnVIL = config.appTitle?.includes("AnVIL");
+  const { config: siteConfig } = useConfig();
+  const isAnVIL = siteConfig.appTitle?.includes("AnVIL");
   const isNCPIExportEnabled = useFeatureFlag(FEATURES.NCPI_EXPORT);
   const isCurlDownloadEnabled = useFeatureFlag(FEATURES.CURL_DOWNLOAD);
   const { query } = useRouter();
@@ -518,7 +518,8 @@ async function processEntityProps(
   if (!staticLoad) return;
   // When the entity detail is to be fetched from API, we only do so for the first tab,
   // unless it's the curl download route which needs data for NRES check.
-  const isCurlDownload = entityExportMethod === "get-curl-command";
+  const isCurlDownload =
+    entityExportMethod === CURL_DOWNLOAD_PATH.replace("/export/", "");
   if (
     exploreMode === EXPLORE_MODE.SS_FETCH_SS_FILTERING &&
     entityTab &&

--- a/pages/export/get-curl-command.tsx
+++ b/pages/export/get-curl-command.tsx
@@ -1,6 +1,10 @@
 import { JSX } from "react";
 import { ExportMethodView } from "@databiosphere/findable-ui/lib/views/ExportMethodView/exportMethodView";
+import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
+import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 import { GetStaticProps } from "next";
+import NextError from "next/error";
+import { FEATURES } from "../../app/shared/entities";
 
 export const getStaticProps: GetStaticProps = async () => {
   return {
@@ -15,6 +19,11 @@ export const getStaticProps: GetStaticProps = async () => {
  * @returns download curl command view component.
  */
 const GetCurlCommandPage = (): JSX.Element => {
+  const { config } = useConfig();
+  const isAnVIL = config.appTitle?.includes("AnVIL");
+  const isEnabled = useFeatureFlag(FEATURES.CURL_DOWNLOAD);
+  // Feature flag only applies to AnVIL sites
+  if (isAnVIL && !isEnabled) return <NextError statusCode={404} />;
   return <ExportMethodView />;
 };
 

--- a/site-config/anvil-cmg/dev/detail/dataset/export/export.ts
+++ b/site-config/anvil-cmg/dev/detail/dataset/export/export.ts
@@ -47,7 +47,7 @@ export const exportConfig: ExportConfig = {
           viewBuilder: V.renderDatasetExportWarning,
         } as ComponentConfig<typeof C.ConditionalComponent, DatasetsResponse>,
         /* ------ */
-        /* Dataset is accessible; render curl download method */
+        /* Dataset is accessible and NRES; render curl download method */
         /* ------ */
         {
           children: [
@@ -67,7 +67,7 @@ export const exportConfig: ExportConfig = {
             ...exportSideColumn,
           ],
           component: C.ConditionalComponent,
-          viewBuilder: V.renderDatasetExport,
+          viewBuilder: V.renderDatasetCurlDownload,
         } as ComponentConfig<typeof C.ConditionalComponent, DatasetsResponse>,
       ],
       route: ROUTES.CURL_DOWNLOAD,
@@ -379,9 +379,18 @@ export const exportConfig: ExportConfig = {
                   viewBuilder: V.buildDatasetExportPropsWithFilter,
                 } as ComponentConfig<typeof C.AnVILExportEntity>,
                 {
-                  component: CurlDownloadExportMethod,
-                  viewBuilder: V.buildDatasetExportMethodCurlCommand,
-                } as ComponentConfig<typeof CurlDownloadExportMethod>,
+                  children: [
+                    {
+                      component: CurlDownloadExportMethod,
+                      viewBuilder: V.buildDatasetExportMethodCurlCommand,
+                    } as ComponentConfig<typeof CurlDownloadExportMethod>,
+                  ],
+                  component: C.ConditionalComponent,
+                  viewBuilder: V.renderDatasetCurlDownload,
+                } as ComponentConfig<
+                  typeof C.ConditionalComponent,
+                  DatasetsResponse
+                >,
                 {
                   component: C.ExportMethod,
                   viewBuilder: V.buildDatasetExportMethodTerra,

--- a/site-config/anvil-cmg/dev/export/export.ts
+++ b/site-config/anvil-cmg/dev/export/export.ts
@@ -8,10 +8,36 @@ import { ROUTES } from "./routes";
 import { mainColumn as exportMainColumn } from "./exportMainColumn";
 import { sideColumn as exportSideColumn } from "./exportSideColumn";
 import { ExportMethod } from "../../../../app/components/Export/components/AnVILExplorer/platform/ExportMethod/exportMethod";
+import { CurlDownloadExportMethod } from "../../../../app/components/Export/components/AnVILExplorer/CurlDownload/curlDownloadExportMethod";
 import { EXPORT_METHODS, EXPORTS } from "./constants";
 
 export const exportConfig: ExportConfig = {
   exportMethods: [
+    {
+      mainColumn: [
+        /* mainColumn - top section - warning - some datasets are not available */
+        ...exportMainColumn,
+        /* mainColumn */
+        {
+          children: [
+            {
+              component: C.DownloadCurlCommand,
+              viewBuilder: V.buildDownloadCurlCommand,
+            } as ComponentConfig<typeof C.DownloadCurlCommand>,
+          ],
+          component: C.BackPageContentMainColumn,
+        } as ComponentConfig<typeof C.BackPageContentMainColumn>,
+        /* sideColumn */
+        ...exportSideColumn,
+      ],
+      route: ROUTES.CURL_DOWNLOAD,
+      top: [
+        {
+          component: C.BackPageHero,
+          viewBuilder: V.buildExportMethodHeroCurlCommand,
+        } as ComponentConfig<typeof C.BackPageHero>,
+      ],
+    },
     {
       mainColumn: [
         /* mainColumn - top section - warning - some datasets are not available */
@@ -154,6 +180,10 @@ export const exportConfig: ExportConfig = {
         /* mainColumn */
         {
           children: [
+            {
+              component: CurlDownloadExportMethod,
+              viewBuilder: V.buildExportMethodBulkDownload,
+            } as ComponentConfig<typeof CurlDownloadExportMethod>,
             {
               component: C.ExportMethod,
               viewBuilder: V.buildExportMethodTerra,


### PR DESCRIPTION
## Ticket
Closes #4692

## Summary
- Add curl download export method for cohort export in anvil-cmg
- Add view builders: `buildDownloadCurlCommand`, `buildExportMethodBulkDownload`, `buildExportMethodHeroCurlCommand`
- Gate `/export/get-curl-command` route behind `curldownload` feature flag

## Note
This PR depends on #4725 (dataset curl download) being merged first.

## Test plan
- [ ] Enable feature flag with `?feature=curldownload`
- [ ] Navigate to cohort export and verify curl download appears as first export method
- [ ] Verify curl download method works and shows AWS ODP disclaimer
- [ ] Verify `/export/get-curl-command` returns 404 when feature flag is disabled

🤖 Generated with [Claude Code](https://claude.ai/code)