### PR TITLE
feat: update curl download export text (#4735)

### DIFF
--- a/__tests__/site-config/export-constants.test.ts
+++ b/__tests__/site-config/export-constants.test.ts
@@ -144,12 +144,7 @@ describe("EXPORTS constants", () => {
 });
 
 describe("EXPORT_METHODS constants", () => {
-  const REQUIRED_METHOD_KEYS = [
-    "buttonLabel",
-    "description",
-    "route",
-    "title",
-  ] as const;
+  const REQUIRED_METHOD_KEYS = ["description", "route", "title"] as const;
 
   describe("structure validation", () => {
     it("has all three platform methods defined", () => {
@@ -208,12 +203,6 @@ describe("EXPORT_METHODS constants", () => {
   });
 
   describe("BioData Catalyst method config", () => {
-    it("has correct buttonLabel", () => {
-      expect(EXPORT_METHODS.BIO_DATA_CATALYST.buttonLabel).toBe(
-        "Analyze in NHLBI BioData Catalyst"
-      );
-    });
-
     it("has correct title mentioning Seven Bridges", () => {
       expect(EXPORT_METHODS.BIO_DATA_CATALYST.title).toContain("Seven Bridges");
       expect(EXPORT_METHODS.BIO_DATA_CATALYST.title).toContain("BDC-SB");
@@ -221,22 +210,12 @@ describe("EXPORT_METHODS constants", () => {
   });
 
   describe("CAVATICA method config", () => {
-    it("has correct buttonLabel", () => {
-      expect(EXPORT_METHODS.CAVATICA.buttonLabel).toBe("Analyze in CAVATICA");
-    });
-
     it("has correct title", () => {
       expect(EXPORT_METHODS.CAVATICA.title).toBe("Export to CAVATICA");
     });
   });
 
   describe("Cancer Genomics Cloud method config", () => {
-    it("has correct buttonLabel", () => {
-      expect(EXPORT_METHODS.CANCER_GENOMICS_CLOUD.buttonLabel).toBe(
-        "Analyze in Cancer Genomics Cloud"
-      );
-    });
-
     it("has correct title mentioning CGC", () => {
       expect(EXPORT_METHODS.CANCER_GENOMICS_CLOUD.title).toContain("CGC");
     });

--- a/__tests__/viewModelBuilders/dataset-export.test.ts
+++ b/__tests__/viewModelBuilders/dataset-export.test.ts
@@ -2,12 +2,12 @@ import { Breadcrumb } from "@databiosphere/findable-ui/lib/components/common/Bre
 import { ViewContext } from "@databiosphere/findable-ui/lib/config/entities";
 import { FileFacet } from "@databiosphere/findable-ui/lib/hooks/useFileManifest/common/entities";
 import { FileManifestState } from "@databiosphere/findable-ui/lib/providers/fileManifestState";
+import { DatasetsResponse } from "../../app/apis/azul/anvil-cmg/common/responses";
 import {
   buildDatasetExportToPlatform,
   buildDatasetExportToPlatformHero,
   buildDatasetExportToPlatformMethod,
 } from "../../app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders";
-import { DatasetsResponse } from "../../app/apis/azul/anvil-cmg/common/responses";
 import { ANVIL_CMG_CATEGORY_KEY } from "../../site-config/anvil-cmg/category";
 import {
   EXPORTS,
@@ -284,17 +284,6 @@ describe("buildDatasetExportToPlatformMethod", () => {
     );
   });
 
-  it("returns buttonLabel from props", () => {
-    const props = EXPORT_METHODS.CAVATICA;
-    const builder = buildDatasetExportToPlatformMethod(props);
-    const response = createMockDatasetsResponse();
-    const viewContext = createMockViewContext();
-
-    const result = builder(response, viewContext);
-
-    expect(result.buttonLabel).toBe(props.buttonLabel);
-  });
-
   it("returns description from props", () => {
     const props = EXPORT_METHODS.CANCER_GENOMICS_CLOUD;
     const builder = buildDatasetExportToPlatformMethod(props);
@@ -359,7 +348,6 @@ describe("buildDatasetExportToPlatformMethod", () => {
 
       const result = builder(response, viewContext);
 
-      expect(result.buttonLabel).toBe("Analyze in NHLBI BioData Catalyst");
       expect(result.route).toBe(
         "/datasets/test-dataset-id/export/biodata-catalyst"
       );
@@ -374,7 +362,6 @@ describe("buildDatasetExportToPlatformMethod", () => {
 
       const result = builder(response, viewContext);
 
-      expect(result.buttonLabel).toBe("Analyze in CAVATICA");
       expect(result.route).toBe("/datasets/test-dataset-id/export/cavatica");
     });
 
@@ -387,7 +374,6 @@ describe("buildDatasetExportToPlatformMethod", () => {
 
       const result = builder(response, viewContext);
 
-      expect(result.buttonLabel).toBe("Analyze in Cancer Genomics Cloud");
       expect(result.route).toBe(
         "/datasets/test-dataset-id/export/cancer-genomics-cloud"
       );

--- a/__tests__/viewModelBuilders/export.test.ts
+++ b/__tests__/viewModelBuilders/export.test.ts
@@ -239,16 +239,6 @@ describe("buildExportToPlatformMethod", () => {
     expect(result.route).toBe(props.route);
   });
 
-  it("returns buttonLabel from props", () => {
-    const props = EXPORT_METHODS.CAVATICA;
-    const builder = buildExportToPlatformMethod(props);
-    const viewContext = createMockViewContext();
-
-    const result = builder(undefined, viewContext);
-
-    expect(result.buttonLabel).toBe(props.buttonLabel);
-  });
-
   it("returns description from props", () => {
     const props = EXPORT_METHODS.CANCER_GENOMICS_CLOUD;
     const builder = buildExportToPlatformMethod(props);
@@ -325,7 +315,6 @@ describe("buildExportToPlatformMethod", () => {
 
       const result = builder(undefined, viewContext);
 
-      expect(result.buttonLabel).toBe("Analyze in NHLBI BioData Catalyst");
       expect(result.route).toBe("/export/biodata-catalyst");
     });
 
@@ -335,7 +324,6 @@ describe("buildExportToPlatformMethod", () => {
 
       const result = builder(undefined, viewContext);
 
-      expect(result.buttonLabel).toBe("Analyze in CAVATICA");
       expect(result.route).toBe("/export/cavatica");
     });
 
@@ -347,7 +335,6 @@ describe("buildExportToPlatformMethod", () => {
 
       const result = builder(undefined, viewContext);
 
-      expect(result.buttonLabel).toBe("Analyze in Cancer Genomics Cloud");
       expect(result.route).toBe("/export/cancer-genomics-cloud");
     });
   });

--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx
@@ -15,6 +15,7 @@ import {
   FileSummaryTerm,
   FormFacet,
 } from "@databiosphere/findable-ui/lib/components/Export/common/entities";
+import { ExportMethod } from "@databiosphere/findable-ui/lib/components/Export/components/ExportMethod/exportMethod";
 import { CurrentQuery } from "@databiosphere/findable-ui/lib/components/Export/components/ExportSummary/components/ExportCurrentQuery/exportCurrentQuery";
 import { Summary } from "@databiosphere/findable-ui/lib/components/Export/components/ExportSummary/components/ExportSelectedDataSummary/exportSelectedDataSummary";
 import { ANCHOR_TARGET } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
@@ -36,6 +37,7 @@ import {
   ChipProps as MChipProps,
   FadeProps as MFadeProps,
 } from "@mui/material";
+import { ExportEntity } from "app/components/Export/components/AnVILExplorer/components/ExportEntity/exportEntity";
 import React, { ComponentProps, ReactNode } from "react";
 import {
   ANVIL_CMG_CATEGORY_KEY,
@@ -97,14 +99,12 @@ import {
 } from "../../../../apis/azul/common/utils";
 import * as C from "../../../../components";
 import * as MDX from "../../../../components/common/MDXContent/anvil-cmg";
+import { RequestAccess } from "../../../../components/Detail/components/AnVILCMG/components/RequestAccess/requestAccess";
 import { Description } from "../../../../components/Detail/components/MDX/components/Description/description";
-import { ExportMethod } from "@databiosphere/findable-ui/lib/components/Export/components/ExportMethod/exportMethod";
 import { METADATA_KEY } from "../../../../components/Index/common/entities";
 import { getPluralizedMetadataLabel } from "../../../../components/Index/common/indexTransformer";
 import { SUMMARY_DISPLAY_TEXT } from "./summaryMapper/constants";
 import { mapExportSummary } from "./summaryMapper/summaryMapper";
-import { ExportEntity } from "app/components/Export/components/AnVILExplorer/components/ExportEntity/exportEntity";
-import { RequestAccess } from "../../../../components/Detail/components/AnVILCMG/components/RequestAccess/requestAccess";
 
 /**
  * Build props for activity type BasicCell component from the given activities response.
@@ -443,7 +443,6 @@ export const buildDatasetExportMethodManifestDownload = (
 ): React.ComponentProps<typeof C.ExportMethod> => {
   const datasetPath = buildDatasetPath(datasetsResponse);
   return {
-    buttonLabel: "Request File Manifest",
     description:
       "Request a file manifest suitable for downloading this dataset to your HPC cluster or local machine.",
     route: `${datasetPath}${ROUTES.MANIFEST_DOWNLOAD}`,
@@ -477,7 +476,6 @@ export const buildDatasetExportMethodTerra = (
 ): React.ComponentProps<typeof ExportMethod> => {
   const datasetPath = buildDatasetPath(datasetsResponse);
   return {
-    buttonLabel: "Analyze in Terra",
     description:
       "Terra is a biomedical research platform to analyze data using workflows, Jupyter Notebooks, RStudio, and Galaxy.",
     route: `${datasetPath}${ROUTES.TERRA}`,
@@ -507,10 +505,15 @@ export const buildDatasetExportMethodCurlCommand = (
 ): React.ComponentProps<typeof C.ExportMethod> => {
   const datasetPath = buildDatasetPath(datasetsResponse);
   return {
-    buttonLabel: "Request curl Command",
-    description: "Obtain a curl command for downloading the dataset.",
+    description: (
+      <div>
+        Generate a <code>curl</code> command to download this dataset. This
+        open-access dataset is hosted through the AWS Open Data Sponsorship
+        Program, which covers storage and data transfer costs.
+      </div>
+    ),
     route: `${datasetPath}${ROUTES.CURL_DOWNLOAD}`,
-    title: "Download Open-Access Data and Metadata (curl Command)",
+    title: "Download Open-Access Data and Metadata (No Egress Fees)",
   };
 };
 
@@ -595,7 +598,7 @@ export const buildDatasetExportToPlatformMethod = ({
   ...props
 }: Pick<
   ComponentProps<typeof ExportMethod>,
-  "buttonLabel" | "description" | "route" | "title"
+  "description" | "route" | "title"
 >): ((
   response: DatasetsResponse,
   viewContext: ViewContext<unknown>
@@ -860,7 +863,6 @@ export const buildExportMethodManifestDownload = (
 ): React.ComponentProps<typeof C.ExportMethod> => {
   return {
     ...getExportMethodAccessibility(viewContext),
-    buttonLabel: "Request File Manifest",
     description:
       "Request a file manifest for the current query containing the full list of selected files and the metadata for each file.",
     route: ROUTES.MANIFEST_DOWNLOAD,
@@ -880,7 +882,6 @@ export const buildExportMethodTerra = (
 ): React.ComponentProps<typeof ExportMethod> => {
   return {
     ...getExportMethodAccessibility(viewContext),
-    buttonLabel: "Analyze in Terra",
     description:
       "Terra is a biomedical research platform to analyze data using workflows, Jupyter Notebooks, RStudio, and Galaxy.",
     route: ROUTES.TERRA,
@@ -927,9 +928,8 @@ export const buildExportMethodBulkDownload = (
 ): React.ComponentProps<typeof C.ExportMethod> => {
   return {
     ...getExportMethodAccessibility(viewContext),
-    buttonLabel: "Request curl Command",
     description:
-      "Obtain a curl command for downloading the open-access portion of the selected data.",
+      "Generate a curl command for downloading the open-access portion of the selected data. Open-access datasets are hosted through the AWS Open Data Sponsorship Program, which covers storage and data transfer costs.",
     route: ROUTES.CURL_DOWNLOAD,
     title: "Download Open-Access Data and Metadata (curl Command)",
   };
@@ -1033,7 +1033,7 @@ export const buildExportToPlatformHero = (
 export const buildExportToPlatformMethod = (
   props: Pick<
     ComponentProps<typeof ExportMethod>,
-    "buttonLabel" | "description" | "route" | "title"
+    "description" | "route" | "title"
   >
 ): ((
   _: unknown,

--- a/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
@@ -36,6 +36,7 @@ import {
 } from "@databiosphere/findable-ui/lib/hooks/useFileManifest/common/utils";
 import { FileManifestState } from "@databiosphere/findable-ui/lib/providers/fileManifestState";
 import { SIZE } from "@databiosphere/findable-ui/lib/styles/common/constants/size";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { formatCountSize } from "@databiosphere/findable-ui/lib/utils/formatCountSize";
 import { CategoryKeyLabel } from "@databiosphere/findable-ui/lib/viewModelBuilders/common/entities";
 import {
@@ -114,7 +115,6 @@ import {
   bindFileSummaryResponse,
   mapExportSummary,
 } from "./summaryMapper/summaryMapper";
-import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 
 /**
  * Build props for the KeyValuePairs component for displaying the project accessions.
@@ -958,7 +958,6 @@ export const buildExportMethodBulkDownload = (
 ): React.ComponentProps<typeof C.ExportMethod> => {
   return {
     ...getExportMethodAccessibility(viewContext),
-    buttonLabel: "Request curl Command",
     description: "Obtain a curl command for downloading the selected data.",
     route: ROUTE_BULK_DOWNLOAD,
     title: "Download Study Data and Metadata (Curl Command)",
@@ -1029,7 +1028,6 @@ export const buildExportMethodManifestDownload = (
 ): React.ComponentProps<typeof C.ExportMethod> => {
   return {
     ...getExportMethodAccessibility(viewContext),
-    buttonLabel: "Request File Manifest",
     description:
       "Request a file manifest for the current query containing the full list of selected files and the metadata for each file.",
     route: ROUTE_MANIFEST_DOWNLOAD,
@@ -1050,7 +1048,6 @@ export const buildExportMethodTerra = (
 ): React.ComponentProps<typeof C.ExportMethod> => {
   return {
     ...getExportMethodAccessibility(viewContext),
-    buttonLabel: "Analyze in Terra",
     description:
       "Terra is a biomedical research platform to analyze data using workflows, Jupyter Notebooks, RStudio, and Galaxy.",
     route: ROUTE_EXPORT_TO_TERRA,

--- a/e2e/anvil/anvil-dataset.spec.ts
+++ b/e2e/anvil/anvil-dataset.spec.ts
@@ -1,17 +1,17 @@
 import { expect, Locator, Page, Request, test } from "@playwright/test";
+import { ANVIL_CMG_CATEGORY_KEY } from "../../site-config/anvil-cmg/category";
+import { ROUTES } from "../../site-config/anvil-cmg/dev/export/routes";
+import { MUI_CLASSES } from "../features/common/constants";
 import {
-  BUTTON_TEXT_ANALYZE_IN_TERRA,
   BUTTON_TEXT_EXPORT,
   BUTTON_TEXT_REQUEST_ACCESS,
-  BUTTON_TEXT_REQUEST_FILE_MANIFEST,
   BUTTON_TEXT_REQUEST_LINK,
   CHIP_TEXT_ACCESS_GRANTED,
   CHIP_TEXT_ACCESS_REQUIRED,
   DatasetAccess,
+  TITLE_TEXT_ANALYZE_IN_TERRA,
+  TITLE_TEXT_REQUEST_FILE_MANIFEST,
 } from "./common/constants";
-import { MUI_CLASSES } from "../features/common/constants";
-import { ROUTES } from "../../site-config/anvil-cmg/dev/export/routes";
-import { ANVIL_CMG_CATEGORY_KEY } from "../../site-config/anvil-cmg/category";
 
 const { describe } = test;
 
@@ -61,10 +61,10 @@ describe("Dataset", () => {
 
     // Confim Terra and file manifest export methods are listed.
     await expect(
-      getLinkWithText(page, BUTTON_TEXT_ANALYZE_IN_TERRA)
+      getHeadingWithText(page, TITLE_TEXT_ANALYZE_IN_TERRA)
     ).toBeVisible();
     await expect(
-      getLinkWithText(page, BUTTON_TEXT_REQUEST_FILE_MANIFEST)
+      getHeadingWithText(page, TITLE_TEXT_REQUEST_FILE_MANIFEST)
     ).toBeVisible();
   });
 
@@ -105,7 +105,7 @@ describe("Dataset", () => {
     await clickLink(page, BUTTON_TEXT_EXPORT);
 
     // Confirm file manifest export method is visible and click it.
-    await clickLink(page, BUTTON_TEXT_REQUEST_FILE_MANIFEST);
+    await clickCard(page, TITLE_TEXT_REQUEST_FILE_MANIFEST);
 
     // Confirm the file manifest page is loaded: check there is one button to request the manifest.
     const buttons = page.locator(`${MUI_CLASSES.BUTTON}`, {
@@ -130,7 +130,7 @@ describe("Dataset", () => {
       page.waitForRequest((request) =>
         request.url().includes(API_ENDPOINT_SUMMARY)
       ),
-      clickLink(page, BUTTON_TEXT_REQUEST_FILE_MANIFEST),
+      clickCard(page, TITLE_TEXT_REQUEST_FILE_MANIFEST),
     ]);
 
     // Confirm summary request has dataset ID request param.
@@ -144,7 +144,7 @@ describe("Dataset", () => {
     await clickLink(page, BUTTON_TEXT_EXPORT);
 
     // Confirm Terra export method is visible and click it.
-    await clickLink(page, BUTTON_TEXT_ANALYZE_IN_TERRA);
+    await clickCard(page, TITLE_TEXT_ANALYZE_IN_TERRA);
 
     // Confirm the analyze in Terra page is loaded: check for form elements.
     await expect(page.locator(MUI_CLASSES.FORM_CONTROL).first()).toBeVisible();
@@ -161,7 +161,7 @@ describe("Dataset", () => {
       page.waitForRequest((request) =>
         request.url().includes(API_ENDPOINT_SUMMARY)
       ),
-      clickLink(page, BUTTON_TEXT_ANALYZE_IN_TERRA),
+      clickCard(page, TITLE_TEXT_ANALYZE_IN_TERRA),
     ]);
 
     // Confirm summary request has dataset ID request param.
@@ -170,12 +170,33 @@ describe("Dataset", () => {
 });
 
 /**
- * Click the link wit the given text.
+ * Click the card with the given heading text.
+ * @param page - Playwright page object.
+ * @param headingText - Heading text.
+ */
+async function clickCard(page: Page, headingText: string): Promise<void> {
+  await getHeadingWithText(page, headingText)
+    .locator("xpath=ancestor::a")
+    .click();
+}
+
+/**
+ * Click the link with the given text.
  * @param page - Playwright page object.
  * @param buttonText - The text of the button to click.
  */
 async function clickLink(page: Page, buttonText: string): Promise<void> {
   await getLinkWithText(page, buttonText).click();
+}
+
+/**
+ * Return the heading with the given text.
+ * @param page - Playwright page object.
+ * @param headingText - Heading text.
+ * @returns - Playwright locator object for the dataset export method.
+ */
+function getHeadingWithText(page: Page, headingText: string): Locator {
+  return page.locator(`h3:has-text("${headingText}")`);
 }
 
 /**

--- a/e2e/anvil/anvil-index-export-button.spec.ts
+++ b/e2e/anvil/anvil-index-export-button.spec.ts
@@ -1,18 +1,13 @@
-import test, { ElementHandle, Response, Page } from "@playwright/test";
-import { expect } from "@playwright/test";
-import { testBulkDownloadIndexExportWorkflow } from "../testFunctions";
-import { ANVIL_TABS } from "./anvil-tabs";
+import test, { ElementHandle, expect, Page, Response } from "@playwright/test";
 import { MUI_CLASSES, TEST_IDS } from "../features/common/constants";
+import { testBulkDownloadFileManifestWorkflow } from "../testFunctions";
 
 test.describe("AnVIL Data Explorer Export", () => {
   test("Smoke test File Manifest Request index export workflow on the Files tab", async ({
     page,
   }) => {
     test.setTimeout(120000);
-    const testResult = await testBulkDownloadIndexExportWorkflow(
-      page,
-      ANVIL_TABS.FILES
-    );
+    const testResult = await testBulkDownloadFileManifestWorkflow(page);
     if (!testResult) {
       test.fail();
     }

--- a/e2e/anvil/anvil-tabs.ts
+++ b/e2e/anvil/anvil-tabs.ts
@@ -1,7 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string  -- ignoring duplicate strings here */
 import {
   AnvilCMGTabCollection,
-  IndexExportButtons,
   TabCollectionKeys,
   TabDescription,
 } from "../testInterfaces";
@@ -48,22 +47,9 @@ export const REPORTED_ETHNICITY_INDEX = 12;
 
 const ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT = "Search all filters...";
 
-export const ANVIL_INDEX_EXPORT_BUTTONS: IndexExportButtons = {
-  actionLandingMessage: "Confirm Organism Type and Manifest File Formats",
-  detailsName: "Selected Data Summary",
-  detailsToCheck: ["BioSamples", "Donors", "Files"],
-  exportActionButtonText: "Download Manifest",
-  exportOptionButtonText: "Request File Manifest",
-  exportRequestButtonText: "Prepare Manifest",
-  indexExportButtonText: "Export",
-  requestLandingMessage:
-    "Download a File Manifest with Metadata for the Selected Data",
-};
-
 export const ANVIL_TABS: AnvilCMGTabCollection = {
   ACTIVITIES: {
     emptyFirstColumn: false,
-    indexExportPage: ANVIL_INDEX_EXPORT_BUTTONS,
     maxPages: 25,
     preselectedColumns: ANVIL_ACTIVITIES_PRESELECTED_COLUMNS_BY_NAME,
     searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
@@ -73,7 +59,6 @@ export const ANVIL_TABS: AnvilCMGTabCollection = {
   },
   BIOSAMPLES: {
     emptyFirstColumn: false,
-    indexExportPage: ANVIL_INDEX_EXPORT_BUTTONS,
     maxPages: 25,
     preselectedColumns: ANVIL_BIOSAMPLES_PRESELECTED_COLUMNS_BY_NAME,
     searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
@@ -143,7 +128,6 @@ export const ANVIL_TABS: AnvilCMGTabCollection = {
       },
     ],
     emptyFirstColumn: false,
-    indexExportPage: ANVIL_INDEX_EXPORT_BUTTONS,
     maxPages: 25,
     preselectedColumns: ANVIL_DATASETS_PRESELECTED_COLUMNS_BY_NAME,
     searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
@@ -153,7 +137,6 @@ export const ANVIL_TABS: AnvilCMGTabCollection = {
   },
   DONORS: {
     emptyFirstColumn: false,
-    indexExportPage: ANVIL_INDEX_EXPORT_BUTTONS,
     maxPages: 25,
     preselectedColumns: ANVIL_DONORS_PRESELECTED_COLUMNS_BY_NAME,
     searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,
@@ -163,7 +146,6 @@ export const ANVIL_TABS: AnvilCMGTabCollection = {
   },
   FILES: {
     emptyFirstColumn: true,
-    indexExportPage: ANVIL_INDEX_EXPORT_BUTTONS,
     maxPages: 25,
     preselectedColumns: ANVIL_FILES_PRESELECTED_COLUMNS_BY_NAME,
     searchFiltersPlaceholderText: ANVIL_CMG_SEARCH_FILTERS_PLACEHOLDER_TEXT,

--- a/e2e/anvil/common/constants.tsx
+++ b/e2e/anvil/common/constants.tsx
@@ -5,6 +5,10 @@ export const BUTTON_TEXT_EXPORT = "Export";
 export const BUTTON_TEXT_REQUEST_ACCESS = "Request Access";
 export const BUTTON_TEXT_REQUEST_LINK = "Request Link";
 export const BUTTON_TEXT_REQUEST_FILE_MANIFEST = "Request File Manifest";
+export const TITLE_TEXT_ANALYZE_IN_TERRA =
+  "Export Dataset Data and Metadata to Terra Workspace";
+export const TITLE_TEXT_REQUEST_FILE_MANIFEST =
+  "Download a File Manifest with Metadata";
 
 export type DatasetAccess =
   | typeof CHIP_TEXT_ACCESS_GRANTED

--- a/e2e/testFunctions.ts
+++ b/e2e/testFunctions.ts
@@ -1,10 +1,12 @@
 import { expect, Locator, Page } from "@playwright/test";
-import { ColumnDescription, TabDescription } from "./testInterfaces";
+import { ANVIL_TABS } from "./anvil/anvil-tabs";
+import { TITLE_TEXT_REQUEST_FILE_MANIFEST } from "./anvil/common/constants";
 import {
   KEYBOARD_KEYS,
   MUI_CLASSES,
   TEST_IDS,
 } from "./features/common/constants";
+import { ColumnDescription, TabDescription } from "./testInterfaces";
 
 /* eslint-disable sonarjs/no-duplicate-string  -- ignoring duplicate strings here */
 
@@ -891,47 +893,44 @@ const hoverAndGetText = async (
 };
 
 /**
- * Test that the Bulk Download index export workflow can be initiated and results in a download on the specified tab
+ *  Tests bulk download of a file manifest from the files tab.
  * @param page - a Playwright page object
- * @param tab - the tab to run the test on
- * @returns - true if the test passes, false if the test fails but does not fail an assertion
+ * @returns - True if the test passes, false if the test fails.
  */
-export async function testBulkDownloadIndexExportWorkflow(
-  page: Page,
-  tab: TabDescription
+export async function testBulkDownloadFileManifestWorkflow(
+  page: Page
 ): Promise<boolean> {
-  if (tab?.indexExportPage === undefined) {
-    console.log(
-      "testBulkIndexExportWorkflow Error: indexExportPage not specified for given tab, so test cannot run"
-    );
-    return false;
-  }
-  await page.goto(tab.url);
-  const exportButtonLocator = page.getByRole("link", {
-    name: tab.indexExportPage.indexExportButtonText,
-  });
-  await expect(exportButtonLocator).toBeVisible();
-  await exportButtonLocator.click();
-  await expect(
-    page.getByText(tab.indexExportPage.requestLandingMessage)
-  ).toBeVisible();
-  await expect(
-    page.getByRole("link", {
-      name: tab.indexExportPage.exportOptionButtonText,
-    })
-  ).toBeEnabled();
-  await page
-    .getByRole("link", { name: tab.indexExportPage.exportOptionButtonText })
-    .click();
+  await page.goto(ANVIL_TABS.FILES.url);
+
+  const buttonLocator = page.getByRole("link", { name: "Export" });
+  await expect(buttonLocator).toBeVisible();
+  await buttonLocator.click();
+
+  // Select the file manifest export method.
+  const cardLocator = getCard(page, TITLE_TEXT_REQUEST_FILE_MANIFEST);
+
+  // Check that the card link is not disabled.
+  await expect(cardLocator).not.toHaveClass(/Mui-disabled/);
+
+  // Click the card to go to the export request form.
+  await cardLocator.click();
+
+  await page.waitForURL("**/export/download-manifest");
+
   const exportRequestButtonLocator = page.getByRole("button", {
-    name: tab.indexExportPage.exportRequestButtonText,
+    name: "Prepare Manifest",
   });
+
+  await expect(exportRequestButtonLocator).toBeVisible();
+
   // Complete the export request form
   await makeMinimalExportRequest(page, exportRequestButtonLocator);
+
   // Click the Export Action button and check that a download occurs
   const exportActionButtonLocator = page.getByRole("link", {
-    name: tab.indexExportPage?.exportActionButtonText,
+    name: "Download Manifest",
   });
+
   await expect(exportActionButtonLocator).toBeEnabled({
     timeout: TIMEOUT_EXPORT_REQUEST,
   });
@@ -1189,6 +1188,26 @@ export async function testPaginationContent(
     // Expect page entry to be consistent with forward pagination
     await expect(firstElementTextLocator).toHaveText(OldFirstTableEntry);
   }
+}
+
+/**
+ * Return the card with the given heading text.
+ * @param page - Playwright page object.
+ * @param headingText - Heading text.
+ * @returns - Playwright locator object for the card with the given heading text.
+ */
+function getCard(page: Page, headingText: string): Locator {
+  return getHeadingWithText(page, headingText).locator("xpath=ancestor::a");
+}
+
+/**
+ * Return the heading with the given text.
+ * @param page - Playwright page object.
+ * @param headingText - Heading text.
+ * @returns - Playwright locator object for the dataset export method.
+ */
+function getHeadingWithText(page: Page, headingText: string): Locator {
+  return page.locator(`h3:has-text("${headingText}")`);
 }
 
 /**

--- a/e2e/testInterfaces.ts
+++ b/e2e/testInterfaces.ts
@@ -7,7 +7,6 @@ export interface TabDescription {
   backpageExportButtons?: BackpageExportButtons;
   backpageHeaders?: BackpageHeader[];
   emptyFirstColumn: boolean;
-  indexExportPage?: IndexExportButtons;
   maxPages?: number;
   preselectedColumns: StringToColumnDescription;
   searchFiltersPlaceholderText: string;
@@ -63,12 +62,4 @@ export interface BackpageExportButtons extends ExportButtonInfo {
   exportTabName: string;
   exportUrlRegExp: RegExp;
   newTabMessage: string;
-}
-
-//TODO: might need to make it so that there's an interface with indexExportButtonText
-// and a list of other objects that go to different export pages for this to work with HCA
-export interface IndexExportButtons extends ExportButtonInfo {
-  detailsToCheck: string[];
-  exportOptionButtonText: string;
-  indexExportButtonText: string;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "2.30.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^50.1.1",
+        "@databiosphere/findable-ui": "^50.4.0",
         "@emotion/react": "^11",
         "@emotion/styled": "^11",
         "@mdx-js/loader": "^3",
@@ -1052,9 +1052,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "50.1.1",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-50.1.1.tgz",
-      "integrity": "sha512-hrke1c6yfgRWDjEFLz62OAanlfLEEdCcrWBrMbVDORdwlvDbrERIKWERvgXqarX5w07iOPrGPFgo+yQSOj7VQg==",
+      "version": "50.4.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-50.4.0.tgz",
+      "integrity": "sha512-mCcfpekFvYDITqy6FMQk+lVyMWVIUz/kTGEH7i2Bx0OZd+T4AWseuYE+OZal/mYp7NQCCQoV4HO481sFKKcNzw==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "check-system-status:anvil-cmg": "esrun e2e/anvil/anvil-check-system-status.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^50.1.1",
+    "@databiosphere/findable-ui": "^50.4.0",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@mdx-js/loader": "^3",

--- a/site-config/anvil-cmg/dev/export/constants.ts
+++ b/site-config/anvil-cmg/dev/export/constants.ts
@@ -1,7 +1,7 @@
-import { ROUTES } from "./routes";
-import { ComponentProps } from "react";
 import { ExportMethod } from "@databiosphere/findable-ui/lib/components/Export/components/ExportMethod/exportMethod";
+import { ComponentProps } from "react";
 import { ExportToPlatform } from "../../../../app/components";
+import { ROUTES } from "./routes";
 
 export const EXPORTS: Record<
   string,
@@ -35,25 +35,19 @@ export const EXPORTS: Record<
 
 export const EXPORT_METHODS: Record<
   string,
-  Pick<
-    ComponentProps<typeof ExportMethod>,
-    "buttonLabel" | "description" | "route" | "title"
-  >
+  Pick<ComponentProps<typeof ExportMethod>, "description" | "route" | "title">
 > = {
   BIO_DATA_CATALYST: {
-    buttonLabel: "Analyze in NHLBI BioData Catalyst",
     description: EXPORTS.BIO_DATA_CATALYST.description,
     route: ROUTES.BIO_DATA_CATALYST,
     title: "Export to BioData Catalyst Powered by Seven Bridges (BDC-SB)",
   },
   CANCER_GENOMICS_CLOUD: {
-    buttonLabel: "Analyze in Cancer Genomics Cloud",
     description: EXPORTS.CANCER_GENOMICS_CLOUD.description,
     route: ROUTES.CANCER_GENOMICS_CLOUD,
     title: "Export to Cancer Genomics Cloud (CGC)",
   },
   CAVATICA: {
-    buttonLabel: "Analyze in CAVATICA",
     description: EXPORTS.CAVATICA.description,
     route: ROUTES.CAVATICA,
     title: "Export to CAVATICA",

--- a/site-config/anvil-cmg/dev/export/export.ts
+++ b/site-config/anvil-cmg/dev/export/export.ts
@@ -3,12 +3,12 @@ import {
   ExportConfig,
 } from "@databiosphere/findable-ui/lib/config/entities";
 import * as C from "../../../../app/components";
+import { ExportMethod } from "../../../../app/components/Export/components/AnVILExplorer/platform/ExportMethod/exportMethod";
 import * as V from "../../../../app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders";
-import { ROUTES } from "./routes";
+import { EXPORT_METHODS, EXPORTS } from "./constants";
 import { mainColumn as exportMainColumn } from "./exportMainColumn";
 import { sideColumn as exportSideColumn } from "./exportSideColumn";
-import { ExportMethod } from "../../../../app/components/Export/components/AnVILExplorer/platform/ExportMethod/exportMethod";
-import { EXPORT_METHODS, EXPORTS } from "./constants";
+import { ROUTES } from "./routes";
 
 export const exportConfig: ExportConfig = {
   exportMethods: [


### PR DESCRIPTION
Closes #4735.

This pull request removes the use of the `buttonLabel` property from export method configurations and their related view model builders, focusing instead on using `description`, `route`, and `title` for export actions. It also updates test cases accordingly and improves export descriptions, especially for open-access datasets. Additionally, the pull request upgrades the `@databiosphere/findable-ui` dependency and makes some minor import cleanups.

**Removal of `buttonLabel` from export methods and view model builders:**

- Removed the `buttonLabel` property from the parameters and return values of all export method builder functions in `app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx` and `app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts` to standardize export method configurations. [[1]](diffhunk://#diff-3c3d68abd4141a02b123c02e81e2fcad3050ba989147a269c9bd08b4a2ab6973L446) [[2]](diffhunk://#diff-3c3d68abd4141a02b123c02e81e2fcad3050ba989147a269c9bd08b4a2ab6973L480) [[3]](diffhunk://#diff-3c3d68abd4141a02b123c02e81e2fcad3050ba989147a269c9bd08b4a2ab6973L510-R516) [[4]](diffhunk://#diff-3c3d68abd4141a02b123c02e81e2fcad3050ba989147a269c9bd08b4a2ab6973L598-R601) [[5]](diffhunk://#diff-3c3d68abd4141a02b123c02e81e2fcad3050ba989147a269c9bd08b4a2ab6973L863) [[6]](diffhunk://#diff-3c3d68abd4141a02b123c02e81e2fcad3050ba989147a269c9bd08b4a2ab6973L883) [[7]](diffhunk://#diff-3c3d68abd4141a02b123c02e81e2fcad3050ba989147a269c9bd08b4a2ab6973L930-R932) [[8]](diffhunk://#diff-3c3d68abd4141a02b123c02e81e2fcad3050ba989147a269c9bd08b4a2ab6973L1036-R1036) [[9]](diffhunk://#diff-178d98a1be1f94d92cf0053329d9566eae61c65847d66472221a5323f832c4d1L961) [[10]](diffhunk://#diff-178d98a1be1f94d92cf0053329d9566eae61c65847d66472221a5323f832c4d1L1032) [[11]](diffhunk://#diff-178d98a1be1f94d92cf0053329d9566eae61c65847d66472221a5323f832c4d1L1053)

- Updated all related test files by removing tests that checked for the existence or correctness of `buttonLabel`, and adjusted required keys and assertions to reflect the removal. [[1]](diffhunk://#diff-fa8c2fa8889a2348db2f22a674a1d27cf6f80d8ccacfcb83700593495cc34171L147-R147) [[2]](diffhunk://#diff-fa8c2fa8889a2348db2f22a674a1d27cf6f80d8ccacfcb83700593495cc34171L211-L239) [[3]](diffhunk://#diff-2ce384e4c7502d0ad9690c41841805f22bb982f641b8cf80fe48ec2ec074802aL287-L297) [[4]](diffhunk://#diff-2ce384e4c7502d0ad9690c41841805f22bb982f641b8cf80fe48ec2ec074802aL362) [[5]](diffhunk://#diff-2ce384e4c7502d0ad9690c41841805f22bb982f641b8cf80fe48ec2ec074802aL377) [[6]](diffhunk://#diff-2ce384e4c7502d0ad9690c41841805f22bb982f641b8cf80fe48ec2ec074802aL390) [[7]](diffhunk://#diff-0139f93f1c87bf3fa51490ddfec90e3ae60751c14e7c54305ad7aa976afbb2b5L242-L251) [[8]](diffhunk://#diff-0139f93f1c87bf3fa51490ddfec90e3ae60751c14e7c54305ad7aa976afbb2b5L328) [[9]](diffhunk://#diff-0139f93f1c87bf3fa51490ddfec90e3ae60751c14e7c54305ad7aa976afbb2b5L338) [[10]](diffhunk://#diff-0139f93f1c87bf3fa51490ddfec90e3ae60751c14e7c54305ad7aa976afbb2b5L350)

**Improvements to export descriptions:**

- Enhanced the `description` and `title` fields for open-access dataset export options, clarifying that data transfer/storage costs are covered by the AWS Open Data Sponsorship Program and improving user guidance. [[1]](diffhunk://#diff-3c3d68abd4141a02b123c02e81e2fcad3050ba989147a269c9bd08b4a2ab6973L510-R516) [[2]](diffhunk://#diff-3c3d68abd4141a02b123c02e81e2fcad3050ba989147a269c9bd08b4a2ab6973L930-R932)

**Dependency and import updates:**

- Upgraded the `@databiosphere/findable-ui` package to version `^50.4.0` in `package.json`.
- Cleaned up and reordered imports in view model builder files for clarity and consistency. [[1]](diffhunk://#diff-2ce384e4c7502d0ad9690c41841805f22bb982f641b8cf80fe48ec2ec074802aR5-L10) [[2]](diffhunk://#diff-3c3d68abd4141a02b123c02e81e2fcad3050ba989147a269c9bd08b4a2ab6973R18) [[3]](diffhunk://#diff-3c3d68abd4141a02b123c02e81e2fcad3050ba989147a269c9bd08b4a2ab6973R40) [[4]](diffhunk://#diff-3c3d68abd4141a02b123c02e81e2fcad3050ba989147a269c9bd08b4a2ab6973R102-L107) [[5]](diffhunk://#diff-178d98a1be1f94d92cf0053329d9566eae61c65847d66472221a5323f832c4d1R39) [[6]](diffhunk://#diff-178d98a1be1f94d92cf0053329d9566eae61c65847d66472221a5323f832c4d1L117)

These changes simplify the export method configuration, improve the clarity of export options for users, and keep dependencies up to date.

<img width="1672" height="982" alt="image" src="https://github.com/user-attachments/assets/1089db80-a3a2-4d63-a27b-573302cb6dfc" />

<img width="1671" height="1034" alt="image" src="https://github.com/user-attachments/assets/29c658cd-836a-4cb6-b034-0ff3d6932b2c" />
