### PR TITLE
Add total file size to export selected data summary

### DIFF
--- a/app/viewModelBuilders/azul/anvil-cmg/common/summaryMapper/constants.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/summaryMapper/constants.ts
@@ -6,7 +6,7 @@ export const DEFAULT_SUMMARY: FileSummary = {
   donorCount: 0,
   fileCount: 0,
   fileFormats: [LABEL.UNSPECIFIED],
-  fileSize: 0,
+  totalFileSize: 0,
 };
 
 /**
@@ -17,6 +17,6 @@ export const SUMMARY_DISPLAY_TEXT: Record<SUMMARY, string> = {
   [SUMMARY.DONOR_COUNT]: "Donors",
   [SUMMARY.FILE_COUNT]: "Files",
   [SUMMARY.FILE_FORMATS]: "File Formats",
-  [SUMMARY.FILE_SIZE]: "File Size",
   [SUMMARY.ORGANISM_TYPE]: "Organism Type",
+  [SUMMARY.TOTAL_FILE_SIZE]: "Total File Size",
 };

--- a/app/viewModelBuilders/azul/anvil-cmg/common/summaryMapper/constants.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/summaryMapper/constants.ts
@@ -6,6 +6,7 @@ export const DEFAULT_SUMMARY: FileSummary = {
   donorCount: 0,
   fileCount: 0,
   fileFormats: [LABEL.UNSPECIFIED],
+  fileSize: 0,
 };
 
 /**
@@ -16,5 +17,6 @@ export const SUMMARY_DISPLAY_TEXT: Record<SUMMARY, string> = {
   [SUMMARY.DONOR_COUNT]: "Donors",
   [SUMMARY.FILE_COUNT]: "Files",
   [SUMMARY.FILE_FORMATS]: "File Formats",
+  [SUMMARY.FILE_SIZE]: "File Size",
   [SUMMARY.ORGANISM_TYPE]: "Organism Type",
 };

--- a/app/viewModelBuilders/azul/anvil-cmg/common/summaryMapper/entities.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/summaryMapper/entities.ts
@@ -6,7 +6,7 @@ export interface FileSummary {
   donorCount: number;
   fileCount: number;
   fileFormats: string[];
-  fileSize: number;
+  totalFileSize: number;
 }
 
 /**
@@ -17,6 +17,6 @@ export const enum SUMMARY {
   DONOR_COUNT = "DONOR_COUNT",
   FILE_COUNT = "FILE_COUNT",
   FILE_FORMATS = "FILE_FORMATS",
-  FILE_SIZE = "FILE_SIZE",
   ORGANISM_TYPE = "ORGANISM_TYPE",
+  TOTAL_FILE_SIZE = "TOTAL_FILE_SIZE",
 }

--- a/app/viewModelBuilders/azul/anvil-cmg/common/summaryMapper/entities.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/summaryMapper/entities.ts
@@ -6,6 +6,7 @@ export interface FileSummary {
   donorCount: number;
   fileCount: number;
   fileFormats: string[];
+  fileSize: number;
 }
 
 /**
@@ -16,5 +17,6 @@ export const enum SUMMARY {
   DONOR_COUNT = "DONOR_COUNT",
   FILE_COUNT = "FILE_COUNT",
   FILE_FORMATS = "FILE_FORMATS",
+  FILE_SIZE = "FILE_SIZE",
   ORGANISM_TYPE = "ORGANISM_TYPE",
 }

--- a/app/viewModelBuilders/azul/anvil-cmg/common/summaryMapper/summaryMapper.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/summaryMapper/summaryMapper.ts
@@ -7,6 +7,7 @@ import {
   Term,
 } from "@databiosphere/findable-ui/lib/hooks/useFileManifest/common/entities";
 import { formatCountSize } from "@databiosphere/findable-ui/lib/utils/formatCountSize";
+import { formatFileSize } from "@databiosphere/findable-ui/lib/utils/formatFileSize";
 import { ANVIL_CMG_CATEGORY_KEY } from "../../../../../../site-config/anvil-cmg/category";
 import { SummaryResponse } from "../../../../../apis/azul/anvil-cmg/common/responses";
 import { METADATA_KEY } from "../../../../../components/Index/common/entities";
@@ -44,6 +45,7 @@ export function bindFileSummaryResponse(
     donorCount: summaryResponse.donorCount,
     fileCount: summaryResponse.fileCount,
     fileFormats: bindFileFormatSummaryResponse(summaryResponse),
+    fileSize: summaryResponse.totalFileSize,
   };
 }
 
@@ -63,6 +65,7 @@ export function mapExportSummary(
   const donorCount = fileSummary.donorCount;
   const fileCount = fileSummary.fileCount;
   const fileFormats = fileSummary.fileFormats;
+  const fileSize = fileSummary.fileSize;
   const organismType = listSelectedTermsOfFacet(
     filesFacets,
     ANVIL_CMG_CATEGORY_KEY.DONOR_ORGANISM_TYPE
@@ -89,6 +92,7 @@ export function mapExportSummary(
       values: fileFormats,
     })
   ); // Formats
+  summaryBySummaryKey.set(SUMMARY.FILE_SIZE, formatFileSize(fileSize)); // File Size
   return summaryBySummaryKey;
 }
 

--- a/app/viewModelBuilders/azul/anvil-cmg/common/summaryMapper/summaryMapper.ts
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/summaryMapper/summaryMapper.ts
@@ -45,7 +45,7 @@ export function bindFileSummaryResponse(
     donorCount: summaryResponse.donorCount,
     fileCount: summaryResponse.fileCount,
     fileFormats: bindFileFormatSummaryResponse(summaryResponse),
-    fileSize: summaryResponse.totalFileSize,
+    totalFileSize: summaryResponse.totalFileSize,
   };
 }
 
@@ -65,7 +65,7 @@ export function mapExportSummary(
   const donorCount = fileSummary.donorCount;
   const fileCount = fileSummary.fileCount;
   const fileFormats = fileSummary.fileFormats;
-  const fileSize = fileSummary.fileSize;
+  const totalFileSize = fileSummary.totalFileSize;
   const organismType = listSelectedTermsOfFacet(
     filesFacets,
     ANVIL_CMG_CATEGORY_KEY.DONOR_ORGANISM_TYPE
@@ -92,7 +92,10 @@ export function mapExportSummary(
       values: fileFormats,
     })
   ); // Formats
-  summaryBySummaryKey.set(SUMMARY.FILE_SIZE, formatFileSize(fileSize)); // File Size
+  summaryBySummaryKey.set(
+    SUMMARY.TOTAL_FILE_SIZE,
+    formatFileSize(totalFileSize)
+  ); // Total file Size
   return summaryBySummaryKey;
 }
 


### PR DESCRIPTION
## Summary
- Add total file size to the selected data summary on the AnVIL export page
- Binds `totalFileSize` from the summary API response and formats it using `formatFileSize`

Closes #4738

## Test plan
- [x] Verify file size appears in the selected data summary on the cohort export page
- [x] Verify file size is formatted in human-readable units (e.g., GB, TB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1728" height="959" alt="image" src="https://github.com/user-attachments/assets/68d6cec4-4d38-49a6-888d-20dc71909814" />

<img width="1728" height="961" alt="image" src="https://github.com/user-attachments/assets/407adc1d-37c3-4d31-9350-1bfcb7293a55" />
