### PR TITLE
feat: add tooltip to direct file download (#4742)

### DIFF
--- a/__tests__/viewModelBuilders/buildFileDownload.test.ts
+++ b/__tests__/viewModelBuilders/buildFileDownload.test.ts
@@ -1,5 +1,7 @@
-import { buildFileDownload } from "../../app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders";
+import { AzulFileDownloadProps } from "@databiosphere/findable-ui/lib/components/Index/components/AzulFileDownload/azulFileDownload";
+import { ReactElement } from "react";
 import { FilesResponse } from "../../app/apis/azul/anvil-cmg/common/responses";
+import { buildFileDownloadWithTooltip } from "../../app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders";
 
 /**
  * Creates a mock FilesResponse with configurable file and dataset values.
@@ -70,9 +72,11 @@ describe("buildFileDownload", () => {
         azul_url: "https://service.azul.data/repository/files/file-123",
       });
 
-      const result = buildFileDownload(response);
+      const result = buildFileDownloadWithTooltip(response);
 
-      expect(result.url).toBeUndefined();
+      expect(
+        (result.children as ReactElement<AzulFileDownloadProps>).props.url
+      ).toBeUndefined();
     });
 
     it("returns undefined url when azul_mirror_uri is empty string", () => {
@@ -81,9 +85,11 @@ describe("buildFileDownload", () => {
         azul_url: "https://service.azul.data/repository/files/file-123",
       });
 
-      const result = buildFileDownload(response);
+      const result = buildFileDownloadWithTooltip(response);
 
-      expect(result.url).toBeUndefined();
+      expect(
+        (result.children as ReactElement<AzulFileDownloadProps>).props.url
+      ).toBeUndefined();
     });
 
     it("returns azul_url when azul_mirror_uri has a value", () => {
@@ -93,9 +99,11 @@ describe("buildFileDownload", () => {
         azul_url: azulUrl,
       });
 
-      const result = buildFileDownload(response);
+      const result = buildFileDownloadWithTooltip(response);
 
-      expect(result.url).toBe(azulUrl);
+      expect(
+        (result.children as ReactElement<AzulFileDownloadProps>).props.url
+      ).toBe(azulUrl);
     });
 
     it("returns azul_url value exactly as provided when mirror uri exists", () => {
@@ -106,9 +114,11 @@ describe("buildFileDownload", () => {
         azul_url: azulUrl,
       });
 
-      const result = buildFileDownload(response);
+      const result = buildFileDownloadWithTooltip(response);
 
-      expect(result.url).toBe(azulUrl);
+      expect(
+        (result.children as ReactElement<AzulFileDownloadProps>).props.url
+      ).toBe(azulUrl);
     });
   });
 
@@ -118,9 +128,12 @@ describe("buildFileDownload", () => {
         file_name: "my-sample-file.bam",
       });
 
-      const result = buildFileDownload(response);
+      const result = buildFileDownloadWithTooltip(response);
 
-      expect(result.entityName).toBe("my-sample-file.bam");
+      expect(
+        (result.children as ReactElement<AzulFileDownloadProps>).props
+          .entityName
+      ).toBe("my-sample-file.bam");
     });
 
     it("returns correct relatedEntityId from dataset_id", () => {
@@ -129,9 +142,12 @@ describe("buildFileDownload", () => {
         { dataset_id: ["my-dataset-id-123"] }
       );
 
-      const result = buildFileDownload(response);
+      const result = buildFileDownloadWithTooltip(response);
 
-      expect(result.relatedEntityId).toBe("my-dataset-id-123");
+      expect(
+        (result.children as ReactElement<AzulFileDownloadProps>).props
+          .relatedEntityId
+      ).toBe("my-dataset-id-123");
     });
 
     it("returns correct relatedEntityName from dataset title", () => {
@@ -140,9 +156,39 @@ describe("buildFileDownload", () => {
         { title: ["My Research Dataset"] }
       );
 
-      const result = buildFileDownload(response);
+      const result = buildFileDownloadWithTooltip(response);
 
-      expect(result.relatedEntityName).toBe("My Research Dataset");
+      expect(
+        (result.children as ReactElement<AzulFileDownloadProps>).props
+          .relatedEntityName
+      ).toBe("My Research Dataset");
+    });
+  });
+
+  describe("tooltip title", () => {
+    it("returns tooltip message when download is disabled", () => {
+      const response = createMockFilesResponse({
+        azul_mirror_uri: null,
+      });
+
+      const result = buildFileDownloadWithTooltip(response);
+
+      expect(result.title).toBe(
+        "Direct file downloads are currently only available for open-access files."
+      );
+    });
+
+    it("returns enabled tooltip message when download is available", () => {
+      const response = createMockFilesResponse({
+        azul_mirror_uri: "s3://bucket/path/to/file.bam",
+        azul_url: "https://service.azul.data/repository/files/file-123",
+      });
+
+      const result = buildFileDownloadWithTooltip(response);
+
+      expect(result.title).toBe(
+        "This open-access file is freely downloadable from AWS Open Data, with no data transfer fees."
+      );
     });
   });
 
@@ -160,9 +206,11 @@ describe("buildFileDownload", () => {
         }
       );
 
-      const result = buildFileDownload(response);
+      const result = buildFileDownloadWithTooltip(response);
 
-      expect(result).toEqual({
+      expect(
+        (result.children as ReactElement<AzulFileDownloadProps>).props
+      ).toEqual({
         entityName: "research-data.bam",
         relatedEntityId: "dataset-abc",
         relatedEntityName: "Genomics Research Project",
@@ -183,9 +231,11 @@ describe("buildFileDownload", () => {
         }
       );
 
-      const result = buildFileDownload(response);
+      const result = buildFileDownloadWithTooltip(response);
 
-      expect(result).toEqual({
+      expect(
+        (result.children as ReactElement<AzulFileDownloadProps>).props
+      ).toEqual({
         entityName: "research-data.bam",
         relatedEntityId: "dataset-abc",
         relatedEntityName: "Genomics Research Project",

--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx
@@ -36,6 +36,7 @@ import {
 import {
   ChipProps as MChipProps,
   FadeProps as MFadeProps,
+  Tooltip,
 } from "@mui/material";
 import { ExportEntity } from "app/components/Export/components/AnVILExplorer/components/ExportEntity/exportEntity";
 import React, { ComponentProps, ReactNode } from "react";
@@ -1115,6 +1116,28 @@ export const buildFileDownload = (
     relatedEntityId: dataset.dataset_id[0],
     relatedEntityName: dataset.title[0],
     url,
+  };
+};
+
+/**
+ * Build props for file download tooltip. If there is no mirror URI, the tooltip will display a message indicating that the file is not available for download.
+ * @param response - Response model returned from index/files API endpoint.
+ * @returns model to be used as props for the Tooltip component.
+ */
+export const buildFileDownloadTooltip = (
+  response: FilesResponse
+): Omit<ComponentProps<typeof Tooltip>, "children"> => {
+  // Render tooltip with message, if there is no URL to download (i.e. mirror URI is not present).
+  const url = processEntityValue(response.files, "azul_mirror_uri", LABEL.EMPTY)
+    ? processEntityValue(response.files, "azul_url", LABEL.EMPTY)
+    : undefined;
+
+  if (url) return { title: null };
+
+  return {
+    arrow: true,
+    title:
+      "Direct file downloads are currently only available for open-access files.",
   };
 };
 

--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx
@@ -18,6 +18,7 @@ import {
 import { ExportMethod } from "@databiosphere/findable-ui/lib/components/Export/components/ExportMethod/exportMethod";
 import { CurrentQuery } from "@databiosphere/findable-ui/lib/components/Export/components/ExportSummary/components/ExportCurrentQuery/exportCurrentQuery";
 import { Summary } from "@databiosphere/findable-ui/lib/components/Export/components/ExportSummary/components/ExportSelectedDataSummary/exportSelectedDataSummary";
+import { AzulFileDownload } from "@databiosphere/findable-ui/lib/components/Index/components/AzulFileDownload/azulFileDownload";
 import { ANCHOR_TARGET } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import { ViewContext } from "@databiosphere/findable-ui/lib/config/entities";
 import { FileFacet } from "@databiosphere/findable-ui/lib/hooks/useFileManifest/common/entities";
@@ -1093,14 +1094,14 @@ export const buildFileDataModality = (
 };
 
 /**
- * Build props for file download AzulFileDownload component.
+ * Build props for file download AzulFileDownload component, with a tooltip component used to display a message when the file is not available for download.
  * Downloads use azul_url but are only enabled when azul_mirror_uri is present.
  * @param response - Response model returned from index/files API endpoint.
  * @returns model to be used as props for the AzulFileDownload component.
  */
-export const buildFileDownload = (
+export const buildFileDownloadWithTooltip = (
   response: FilesResponse
-): React.ComponentProps<typeof C.AzulFileDownload> => {
+): ComponentProps<typeof Tooltip> => {
   const dataset = response.datasets[0];
   const mirrorUri = processEntityValue(
     response.files,
@@ -1111,33 +1112,25 @@ export const buildFileDownload = (
   const url = mirrorUri
     ? processEntityValue(response.files, "azul_url", LABEL.EMPTY)
     : undefined;
-  return {
-    entityName: processEntityValue(response.files, "file_name"),
-    relatedEntityId: dataset.dataset_id[0],
-    relatedEntityName: dataset.title[0],
-    url,
-  };
-};
+  // Determine the entity name
+  const entityName = processEntityValue(response.files, "file_name");
+  // Determine the tooltip title based on whether the file is available for download or not.
+  const title = url
+    ? "This open-access file is freely downloadable from AWS Open Data, with no data transfer fees."
+    : "Direct file downloads are currently only available for open-access files.";
 
-/**
- * Build props for file download tooltip. If there is no mirror URI, the tooltip will display a message indicating that the file is not available for download.
- * @param response - Response model returned from index/files API endpoint.
- * @returns model to be used as props for the Tooltip component.
- */
-export const buildFileDownloadTooltip = (
-  response: FilesResponse
-): Omit<ComponentProps<typeof Tooltip>, "children"> => {
-  // Render tooltip with message, if there is no URL to download (i.e. mirror URI is not present).
-  const url = processEntityValue(response.files, "azul_mirror_uri", LABEL.EMPTY)
-    ? processEntityValue(response.files, "azul_url", LABEL.EMPTY)
-    : undefined;
-
-  if (url) return { title: null };
-
+  // Return the download component as a child component of the tooltip.
   return {
     arrow: true,
-    title:
-      "Direct file downloads are currently only available for open-access files.",
+    children: (
+      <AzulFileDownload
+        entityName={entityName}
+        relatedEntityId={dataset.dataset_id[0]}
+        relatedEntityName={dataset.title[0]}
+        url={url}
+      />
+    ),
+    title,
   };
 };
 

--- a/site-config/anvil-cmg/dev/index/filesEntityConfig.ts
+++ b/site-config/anvil-cmg/dev/index/filesEntityConfig.ts
@@ -6,6 +6,7 @@ import {
   SORT_DIRECTION,
 } from "@databiosphere/findable-ui/lib/config/entities";
 import { EXPLORE_MODE } from "@databiosphere/findable-ui/lib/hooks/useExploreMode/types";
+import { Tooltip } from "@mui/material";
 import { FilesResponse } from "../../../../app/apis/azul/anvil-cmg/common/responses";
 import * as C from "../../../../app/components";
 import * as V from "../../../../app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders";
@@ -18,9 +19,15 @@ import { filesEntityListSlot } from "../ui/filesEntityList";
 
 export const downloadColumn: ColumnConfig<FilesResponse> = {
   componentConfig: {
-    component: C.AzulFileDownload,
-    viewBuilder: V.buildFileDownload,
-  } as ComponentConfig<typeof C.AzulFileDownload>,
+    children: [
+      {
+        component: C.AzulFileDownload,
+        viewBuilder: V.buildFileDownload,
+      } as ComponentConfig<typeof C.AzulFileDownload>,
+    ],
+    component: Tooltip,
+    viewBuilder: V.buildFileDownloadTooltip,
+  },
   enableHiding: false,
   enableSorting: false,
   header: ANVIL_CMG_CATEGORY_LABEL.AZUL_FILE_DOWNLOAD,

--- a/site-config/anvil-cmg/dev/index/filesEntityConfig.ts
+++ b/site-config/anvil-cmg/dev/index/filesEntityConfig.ts
@@ -19,14 +19,8 @@ import { filesEntityListSlot } from "../ui/filesEntityList";
 
 export const downloadColumn: ColumnConfig<FilesResponse> = {
   componentConfig: {
-    children: [
-      {
-        component: C.AzulFileDownload,
-        viewBuilder: V.buildFileDownload,
-      } as ComponentConfig<typeof C.AzulFileDownload>,
-    ],
     component: Tooltip,
-    viewBuilder: V.buildFileDownloadTooltip,
+    viewBuilder: V.buildFileDownloadWithTooltip,
   },
   enableHiding: false,
   enableSorting: false,


### PR DESCRIPTION
Closes #4742.

This pull request introduces a tooltip to the file download column in the AnVIL CMG file explorer. The tooltip provides users with contextual information about file download availability, specifically indicating when direct downloads are only available for open-access files. The main changes include importing the necessary `Tooltip` component, adding a new view model builder for tooltip props, and updating the column configuration to use the tooltip.

**Enhancements to file download UI:**

* Added import of the `Tooltip` component from `@mui/material` in both `viewModelBuilders.tsx` and `filesEntityConfig.ts` to enable tooltip functionality. [[1]](diffhunk://#diff-3c3d68abd4141a02b123c02e81e2fcad3050ba989147a269c9bd08b4a2ab6973R39) [[2]](diffhunk://#diff-37a2a93932f63e3e6c21179b07ea0e672c43ba248a50e938cf23771b521f3c7aR9)
* Implemented the `buildFileDownloadTooltip` function in `viewModelBuilders.tsx` to generate props for the `Tooltip` component, displaying a message when a file is not available for direct download.
* Updated the `downloadColumn` configuration in `filesEntityConfig.ts` to wrap the file download button with the `Tooltip` component and use the new view builder for tooltip props.

<img width="2255" height="1061" alt="image" src="https://github.com/user-attachments/assets/6a894dc1-5fe6-4962-a145-48b881dbd03e" />

<img width="2560" height="786" alt="image" src="https://github.com/user-attachments/assets/290656c6-a184-4558-b60d-3042f2756fd0" />
