### PR TITLE
chore: update HCA catalog to dcp58

### DIFF
--- a/site-config/hca-dcp/dev/config.ts
+++ b/site-config/hca-dcp/dev/config.ts
@@ -18,7 +18,7 @@ import { FILTER_SORT } from "@databiosphere/findable-ui/lib/common/filters/sort/
 
 // Template constants
 const APP_TITLE = "HCA Data Explorer";
-const CATALOG = "dcp57";
+const CATALOG = "dcp58";
 const BROWSER_URL = "https://explore.data.humancellatlas.dev.clevercanary.com";
 const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const EXPORT_TO_TERRA_URL = "https://app.terra.bio";

--- a/site-config/hca-dcp/ma-prod/config.ts
+++ b/site-config/hca-dcp/ma-prod/config.ts
@@ -6,7 +6,7 @@ import { getAuthenticationConfig } from "./authentication/authentication";
 
 // Template constants
 const BROWSER_URL = "https://explore.data.humancellatlas.org";
-const CATALOG = "dcp57";
+const CATALOG = "dcp58";
 const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const PORTAL_URL = "https://data.humancellatlas.org";
 


### PR DESCRIPTION
## Ticket
Closes #4724

## Summary
- Update HCA default catalog from dcp57 to dcp58

## Test plan
- [ ] Verify HCA Data Explorer loads with dcp58 catalog

🤖 Generated with [Claude Code](https://claude.ai/code)