### PR TITLE
feat: update ordering and wording of cohort and dataset export options (#4744)

### DIFF
--- a/app/components/Export/components/AnVILExplorer/components/ExportCohort/components/DownloadSection/downloadSection.tsx
+++ b/app/components/Export/components/AnVILExplorer/components/ExportCohort/components/DownloadSection/downloadSection.tsx
@@ -22,7 +22,7 @@ export const DownloadSection = ({ viewContext }: Props): JSX.Element => {
       </Typography>
       <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_LARGE_400}>
         {isNRES ? (
-          <div>
+          <span>
             First, download the open-access data files in the current selection
             using a <code>curl</code> command. Then download a TSV manifest
             containing metadata for all data files in the current selection,
@@ -30,12 +30,12 @@ export const DownloadSection = ({ viewContext }: Props): JSX.Element => {
             and does not include file data. Open-access data files are hosted
             through AWS Open Data, with storage and data transfer costs covered
             by the AWS Open Data Sponsorship Program.
-          </div>
+          </span>
         ) : (
-          <div>
+          <span>
             Download a TSV manifest containing metadata for all selected files.
             The manifest contains metadata only and does not include file data.
-          </div>
+          </span>
         )}
       </Typography>
     </Stack>

--- a/app/components/Export/components/AnVILExplorer/components/ExportCohort/components/DownloadSection/downloadSection.tsx
+++ b/app/components/Export/components/AnVILExplorer/components/ExportCohort/components/DownloadSection/downloadSection.tsx
@@ -23,13 +23,14 @@ export const DownloadSection = ({ viewContext }: Props): JSX.Element => {
       <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_LARGE_400}>
         {isNRES ? (
           <span>
-            First, download the open-access data files in the current selection
-            using a <code>curl</code> command. Then download a TSV manifest
-            containing metadata for all data files in the current selection,
-            including managed-access files. The manifest contains metadata only
-            and does not include file data. Open-access data files are hosted
-            through AWS Open Data, with storage and data transfer costs covered
-            by the AWS Open Data Sponsorship Program.
+            To download the open-access data in the current selection, first use
+            the <code>curl</code> command option to download the open-access
+            data files. Then download a TSV manifest containing metadata for all
+            data files in the current selection, including managed-access files.
+            The manifest contains metadata only and does not include file data.
+            Open-access data files are hosted through AWS Open Data, with
+            storage and data transfer costs covered by the AWS Open Data
+            Sponsorship Program.
           </span>
         ) : (
           <span>

--- a/app/components/Export/components/AnVILExplorer/components/ExportCohort/components/DownloadSection/downloadSection.tsx
+++ b/app/components/Export/components/AnVILExplorer/components/ExportCohort/components/DownloadSection/downloadSection.tsx
@@ -1,0 +1,43 @@
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Stack, Typography } from "@mui/material";
+import type { JSX } from "react";
+import { isNRESConsentGroup } from "../../../../../../../../viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders";
+import { Props } from "./types";
+
+/**
+ * Returns section title and description for downloading cohort files and metadata.
+ * @param props - Component props.
+ * @param props.viewContext - View context.
+ * @returns Download section title and description.
+ */
+export const DownloadSection = ({ viewContext }: Props): JSX.Element => {
+  const isNRES = isNRESConsentGroup(viewContext);
+  return (
+    <Stack gap={1}>
+      <Typography
+        component="h2"
+        variant={TYPOGRAPHY_PROPS.VARIANT.HEADING_SMALL}
+      >
+        Download
+      </Typography>
+      <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_LARGE_400}>
+        {isNRES ? (
+          <div>
+            First, download the open-access data files in the current selection
+            using a <code>curl</code> command. Then download a TSV manifest
+            containing metadata for all data files in the current selection,
+            including managed-access files. The manifest contains metadata only
+            and does not include file data. Open-access data files are hosted
+            through AWS Open Data, with storage and data transfer costs covered
+            by the AWS Open Data Sponsorship Program.
+          </div>
+        ) : (
+          <div>
+            Download a TSV manifest containing metadata for all selected files.
+            The manifest contains metadata only and does not include file data.
+          </div>
+        )}
+      </Typography>
+    </Stack>
+  );
+};

--- a/app/components/Export/components/AnVILExplorer/components/ExportCohort/components/DownloadSection/types.ts
+++ b/app/components/Export/components/AnVILExplorer/components/ExportCohort/components/DownloadSection/types.ts
@@ -1,0 +1,6 @@
+import { ViewContext } from "@databiosphere/findable-ui/lib/config/entities";
+import { DatasetsResponse } from "../../../../../../../../apis/azul/anvil-cmg/common/responses";
+
+export interface Props {
+  viewContext: ViewContext<DatasetsResponse>;
+}

--- a/app/components/Export/components/AnVILExplorer/components/ExportCohort/components/ExportSection/exportSection.tsx
+++ b/app/components/Export/components/AnVILExplorer/components/ExportCohort/components/ExportSection/exportSection.tsx
@@ -1,0 +1,24 @@
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Stack, Typography } from "@mui/material";
+import type { JSX } from "react";
+
+/**
+ * Returns section title and description for exporting cohort files and metadata.
+ * @returns Export section title and description.
+ */
+export const ExportSection = (): JSX.Element => {
+  return (
+    <Stack gap={1}>
+      <Typography
+        component="h2"
+        variant={TYPOGRAPHY_PROPS.VARIANT.HEADING_SMALL}
+      >
+        Export
+      </Typography>
+      <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_LARGE_400}>
+        Send selected files and metadata to a supported cloud workspace for
+        analysis.
+      </Typography>
+    </Stack>
+  );
+};

--- a/app/components/Export/components/AnVILExplorer/components/ExportEntity/components/DownloadSection/downloadSection.tsx
+++ b/app/components/Export/components/AnVILExplorer/components/ExportEntity/components/DownloadSection/downloadSection.tsx
@@ -1,0 +1,44 @@
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Stack, Typography } from "@mui/material";
+import { isDatasetNRESConsentGroup } from "app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders";
+import type { JSX } from "react";
+import type { Props } from "./types";
+
+/**
+ * Returns section title and description for downloading dataset files and metadata.
+ * @param props - Component props.
+ * @param props.dataset - Dataset response.
+ * @returns Download section title and description.
+ */
+export const DownloadSection = ({ dataset }: Props): JSX.Element => {
+  const isNRES = isDatasetNRESConsentGroup(dataset);
+  return (
+    <Stack gap={1}>
+      <Typography
+        component="h2"
+        variant={TYPOGRAPHY_PROPS.VARIANT.HEADING_SMALL}
+      >
+        Download
+      </Typography>
+      <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_LARGE_400}>
+        {isNRES ? (
+          <div>
+            First, download the open-access data files in the current selection
+            using a <code>curl</code> command. Then download a TSV manifest
+            containing metadata for all data files in the current selection,
+            including managed-access files. The manifest contains metadata only
+            and does not include file data. Open-access data files are hosted
+            through AWS Open Data, with storage and data transfer costs covered
+            by the AWS Open Data Sponsorship Program.
+          </div>
+        ) : (
+          <div>
+            Download a TSV manifest containing metadata for all files in the
+            dataset. The manifest contains metadata only and does not include
+            file data.
+          </div>
+        )}
+      </Typography>
+    </Stack>
+  );
+};

--- a/app/components/Export/components/AnVILExplorer/components/ExportEntity/components/DownloadSection/downloadSection.tsx
+++ b/app/components/Export/components/AnVILExplorer/components/ExportEntity/components/DownloadSection/downloadSection.tsx
@@ -23,19 +23,16 @@ export const DownloadSection = ({ dataset }: Props): JSX.Element => {
       <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_LARGE_400}>
         {isNRES ? (
           <span>
-            First, download the open-access data files in the current selection
-            using a <code>curl</code> command. Then download a TSV manifest
-            containing metadata for all data files in the current selection,
-            including managed-access files. The manifest contains metadata only
-            and does not include file data. Open-access data files are hosted
-            through AWS Open Data, with storage and data transfer costs covered
-            by the AWS Open Data Sponsorship Program.
+            To download data from this dataset, first download the open-access
+            data files using the <code>curl</code> command option. Then download
+            the TSV metadata manifest for the dataset. Open-access data files
+            are hosted through AWS Open Data, with storage and data transfer
+            costs covered by the AWS Open Data Sponsorship Program.
           </span>
         ) : (
           <span>
-            Download a TSV manifest containing metadata for all files in the
-            dataset. The manifest contains metadata only and does not include
-            file data.
+            Download a TSV manifest with metadata for all files in the
+            managed-access dataset. No file data is included.
           </span>
         )}
       </Typography>

--- a/app/components/Export/components/AnVILExplorer/components/ExportEntity/components/DownloadSection/downloadSection.tsx
+++ b/app/components/Export/components/AnVILExplorer/components/ExportEntity/components/DownloadSection/downloadSection.tsx
@@ -22,7 +22,7 @@ export const DownloadSection = ({ dataset }: Props): JSX.Element => {
       </Typography>
       <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_LARGE_400}>
         {isNRES ? (
-          <div>
+          <span>
             First, download the open-access data files in the current selection
             using a <code>curl</code> command. Then download a TSV manifest
             containing metadata for all data files in the current selection,
@@ -30,13 +30,13 @@ export const DownloadSection = ({ dataset }: Props): JSX.Element => {
             and does not include file data. Open-access data files are hosted
             through AWS Open Data, with storage and data transfer costs covered
             by the AWS Open Data Sponsorship Program.
-          </div>
+          </span>
         ) : (
-          <div>
+          <span>
             Download a TSV manifest containing metadata for all files in the
             dataset. The manifest contains metadata only and does not include
             file data.
-          </div>
+          </span>
         )}
       </Typography>
     </Stack>

--- a/app/components/Export/components/AnVILExplorer/components/ExportEntity/components/DownloadSection/types.ts
+++ b/app/components/Export/components/AnVILExplorer/components/ExportEntity/components/DownloadSection/types.ts
@@ -1,0 +1,5 @@
+import { DatasetsResponse } from "../../../../../../../../apis/azul/anvil-cmg/common/responses";
+
+export interface Props {
+  dataset: DatasetsResponse;
+}

--- a/app/components/Export/components/AnVILExplorer/components/ExportEntity/components/ExportSection/exportSection.tsx
+++ b/app/components/Export/components/AnVILExplorer/components/ExportEntity/components/ExportSection/exportSection.tsx
@@ -1,0 +1,24 @@
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Stack, Typography } from "@mui/material";
+import type { JSX } from "react";
+
+/**
+ * Returns section title and description for exporting dataset files and metadata.
+ * @returns Export section title and description.
+ */
+export const ExportSection = (): JSX.Element => {
+  return (
+    <Stack gap={1}>
+      <Typography
+        component="h2"
+        variant={TYPOGRAPHY_PROPS.VARIANT.HEADING_SMALL}
+      >
+        Export
+      </Typography>
+      <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_LARGE_400}>
+        Send this dataset&apos;s files and metadata to a supported cloud
+        workspace for analysis.
+      </Typography>
+    </Stack>
+  );
+};

--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx
@@ -1865,12 +1865,12 @@ export const renderWhenUnAuthenticated = (
 };
 
 /**
- * Renders dataset export-related components when the given dataset has NRES consent group.
+ * Renders cohort curl download component when the current query includes NRES or Unrestricted access consent groups.
  * @param _ - Unused.
  * @param viewContext - View context.
  * @returns model to be used as props for the ConditionalComponent component.
  */
-export const renderCurlDownload = (
+export const renderCohortCurlDownload = (
   _: unknown,
   viewContext: ViewContext<DatasetsResponse>
 ): ComponentProps<typeof C.ConditionalComponent> => {

--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx
@@ -279,6 +279,19 @@ export const buildConsentGroup = (
 };
 
 /**
+ * Build props for the cohort DownloadSection component.
+ * @param _ - Unused.
+ * @param viewContext - View context.
+ * @returns model to be used as props for the DownloadSection component.
+ */
+export const buildCohortDownloadSectionProps = (
+  _: unknown,
+  viewContext: ViewContext<DatasetsResponse>
+): { viewContext: ViewContext<DatasetsResponse> } => {
+  return { viewContext };
+};
+
+/**
  * Build props for data modality NTagCell component from the given response.
  * @param response - Response model return from API.
  * @returns model to be used as props for the NTagCell component.
@@ -340,6 +353,17 @@ export const buildDatasetDescription = (
         LABEL.EMPTY
       ) || "To be provided.",
   };
+};
+
+/**
+ * Build props for the dataset detail DownloadSection component.
+ * @param datasetsResponse - Response model return from datasets API.
+ * @returns model to be used as props for the DownloadSection component.
+ */
+export const buildDatasetDownloadSectionProps = (
+  datasetsResponse: DatasetsResponse
+): { dataset: DatasetsResponse } => {
+  return { dataset: datasetsResponse };
 };
 
 /**
@@ -447,9 +471,9 @@ export const buildDatasetExportMethodManifestDownload = (
   const datasetPath = buildDatasetPath(datasetsResponse);
   return {
     description:
-      "Request a file manifest suitable for downloading this dataset to your HPC cluster or local machine.",
+      "Download a TSV manifest containing metadata for all data files in the dataset.",
     route: `${datasetPath}${ROUTES.MANIFEST_DOWNLOAD}`,
-    title: "Download a File Manifest with Metadata",
+    title: "Download TSV Manifest",
   };
 };
 
@@ -482,7 +506,7 @@ export const buildDatasetExportMethodTerra = (
     description:
       "Terra is a biomedical research platform to analyze data using workflows, Jupyter Notebooks, RStudio, and Galaxy.",
     route: `${datasetPath}${ROUTES.TERRA}`,
-    title: "Export Dataset Data and Metadata to Terra Workspace",
+    title: "Export to Terra",
   };
 };
 
@@ -508,15 +532,10 @@ export const buildDatasetExportMethodCurlCommand = (
 ): React.ComponentProps<typeof C.ExportMethod> => {
   const datasetPath = buildDatasetPath(datasetsResponse);
   return {
-    description: (
-      <div>
-        Generate a <code>curl</code> command to download this dataset. This
-        open-access dataset is hosted through the AWS Open Data Sponsorship
-        Program, which covers storage and data transfer costs.
-      </div>
-    ),
+    description:
+      "Generate a curl command to download all files in this open-access dataset.",
     route: `${datasetPath}${ROUTES.CURL_DOWNLOAD}`,
-    title: "Download Open-Access Data and Metadata (No Egress Fees)",
+    title: "Download Open-Access Data Files (No Data Transfer Fees)",
   };
 };
 
@@ -867,9 +886,9 @@ export const buildExportMethodManifestDownload = (
   return {
     ...getExportMethodAccessibility(viewContext),
     description:
-      "Request a file manifest for the current query containing the full list of selected files and the metadata for each file.",
+      "Download a TSV manifest containing metadata for all data files in the current selection, including managed-access files.",
     route: ROUTES.MANIFEST_DOWNLOAD,
-    title: "Download a File Manifest with Metadata for the Selected Data",
+    title: "Download TSV Manifest for All Selected Data Files",
   };
 };
 
@@ -888,7 +907,7 @@ export const buildExportMethodTerra = (
     description:
       "Terra is a biomedical research platform to analyze data using workflows, Jupyter Notebooks, RStudio, and Galaxy.",
     route: ROUTES.TERRA,
-    title: "Export Study Data and Metadata to Terra Workspace",
+    title: "Export to Terra",
   };
 };
 
@@ -931,10 +950,14 @@ export const buildExportMethodBulkDownload = (
 ): React.ComponentProps<typeof C.ExportMethod> => {
   return {
     ...getExportMethodAccessibility(viewContext),
-    description:
-      "Generate a curl command for downloading the open-access portion of the selected data. Open-access datasets are hosted through the AWS Open Data Sponsorship Program, which covers storage and data transfer costs.",
+    description: (
+      <div>
+        Generate a <code>curl</code> command to download the open-access data
+        files in the current selection.
+      </div>
+    ),
     route: ROUTES.CURL_DOWNLOAD,
-    title: "Download Open-Access Data and Metadata (curl Command)",
+    title: "Download Open-Access Data Files (No Data Transfer Fees)",
   };
 };
 
@@ -1712,6 +1735,21 @@ function isDatasetAccessible(datasetsResponse: DatasetsResponse): boolean {
 }
 
 /**
+ * Returns true if the dataset has NRES or Unrestricted access consent group.
+ * @param datasetsResponse - Response model return from datasets API.
+ * @returns true if the dataset has NRES or Unrestricted access consent group.
+ */
+export function isDatasetNRESConsentGroup(
+  datasetsResponse: DatasetsResponse
+): boolean {
+  const consentGroups = getConsentGroup(datasetsResponse);
+  return (
+    consentGroups.includes("NRES") ||
+    consentGroups.includes("Unrestricted access")
+  );
+}
+
+/**
  * Returns true if the "accessible" file facet has a term value of "true".
  * @param fileManifestState - File manifest state.
  * @returns true if the "accessible" file facet has a term value of "true".
@@ -1732,6 +1770,28 @@ function isFileManifestSummaryFileCountValid(
 ): boolean {
   const { summary: { fileCount } = {} } = fileManifestState;
   return fileCount > 0;
+}
+
+/**
+ * Returns true if the dataset has NRES or Unrestricted access consent group.
+ * @param viewContext - View context.
+ * @returns true if the dataset has NRES or Unrestricted access consent group.
+ */
+export function isNRESConsentGroup(
+  viewContext: ViewContext<DatasetsResponse>
+): boolean {
+  const { fileManifestState } = viewContext;
+
+  const facet = findFacet(
+    fileManifestState.filesFacets,
+    ANVIL_CMG_CATEGORY_KEY.DATASET_CONSENT_GROUP
+  );
+
+  if (!facet) return false;
+
+  const termsByName = facet.termsByName;
+
+  return termsByName.has("NRES") || termsByName.has("Unrestricted access");
 }
 
 /**
@@ -1805,18 +1865,28 @@ export const renderWhenUnAuthenticated = (
 };
 
 /**
- * Renders dataset curl download components when the given dataset is accessible
- * and has NRES consent group.
+ * Renders dataset export-related components when the given dataset has NRES consent group.
+ * @param _ - Unused.
+ * @param viewContext - View context.
+ * @returns model to be used as props for the ConditionalComponent component.
+ */
+export const renderCurlDownload = (
+  _: unknown,
+  viewContext: ViewContext<DatasetsResponse>
+): ComponentProps<typeof C.ConditionalComponent> => {
+  return { isIn: isNRESConsentGroup(viewContext) };
+};
+
+/**
+ * Renders dataset curl download components when the given dataset has NRES consent group.
  * @param datasetsResponse - Response model return from datasets API.
  * @returns model to be used as props for the ConditionalComponent component.
  */
 export const renderDatasetCurlDownload = (
   datasetsResponse: DatasetsResponse
 ): React.ComponentProps<typeof C.ConditionalComponent> => {
-  const consentGroups = getConsentGroup(datasetsResponse);
-  const isNRES = consentGroups.includes("NRES");
   return {
-    isIn: isDatasetAccessible(datasetsResponse) && isNRES,
+    isIn: isDatasetNRESConsentGroup(datasetsResponse),
   };
 };
 

--- a/e2e/anvil/common/constants.tsx
+++ b/e2e/anvil/common/constants.tsx
@@ -5,10 +5,8 @@ export const BUTTON_TEXT_EXPORT = "Export";
 export const BUTTON_TEXT_REQUEST_ACCESS = "Request Access";
 export const BUTTON_TEXT_REQUEST_LINK = "Request Link";
 export const BUTTON_TEXT_REQUEST_FILE_MANIFEST = "Request File Manifest";
-export const TITLE_TEXT_ANALYZE_IN_TERRA =
-  "Export Dataset Data and Metadata to Terra Workspace";
-export const TITLE_TEXT_REQUEST_FILE_MANIFEST =
-  "Download a File Manifest with Metadata";
+export const TITLE_TEXT_ANALYZE_IN_TERRA = "Export to Terra";
+export const TITLE_TEXT_REQUEST_FILE_MANIFEST = "Download TSV Manifest";
 
 export type DatasetAccess =
   | typeof CHIP_TEXT_ACCESS_GRANTED

--- a/site-config/anvil-cmg/dev/detail/dataset/export/export.ts
+++ b/site-config/anvil-cmg/dev/detail/dataset/export/export.ts
@@ -2,15 +2,17 @@ import {
   ComponentConfig,
   ExportConfig,
 } from "@databiosphere/findable-ui/lib/config/entities";
-import { sideColumn as exportSideColumn } from "../../../export/exportSideColumn";
-import * as V from "../../../../../../app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders";
+import { DatasetsResponse } from "../../../../../../app/apis/azul/anvil-cmg/common/responses";
 import * as C from "../../../../../../app/components";
-import { DatasetsResponse } from "app/apis/azul/anvil-cmg/common/responses";
-import { ROUTES } from "../../../export/routes";
 import * as MDX from "../../../../../../app/components/common/MDXContent/anvil-cmg";
+import { DownloadSection } from "../../../../../../app/components/Export/components/AnVILExplorer/components/ExportEntity/components/DownloadSection/downloadSection";
+import { ExportSection } from "../../../../../../app/components/Export/components/AnVILExplorer/components/ExportEntity/components/ExportSection/exportSection";
 import { ExportMethod } from "../../../../../../app/components/Export/components/AnVILExplorer/platform/ExportMethod/exportMethod";
-import { EXPORT_METHODS, EXPORTS } from "../../../export/constants";
 import { ExportToPlatform } from "../../../../../../app/components/Export/components/AnVILExplorer/platform/ExportToPlatform/exportToPlatform";
+import * as V from "../../../../../../app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders";
+import { EXPORT_METHODS, EXPORTS } from "../../../export/constants";
+import { sideColumn as exportSideColumn } from "../../../export/exportSideColumn";
+import { ROUTES } from "../../../export/routes";
 
 /**
  * Badge indicating dataset accessibility.
@@ -378,18 +380,8 @@ export const exportConfig: ExportConfig = {
                   viewBuilder: V.buildDatasetExportPropsWithFilter,
                 } as ComponentConfig<typeof C.AnVILExportEntity>,
                 {
-                  children: [
-                    {
-                      component: C.ExportMethod,
-                      viewBuilder: V.buildDatasetExportMethodCurlCommand,
-                    } as ComponentConfig<typeof C.ExportMethod>,
-                  ],
-                  component: C.ConditionalComponent,
-                  viewBuilder: V.renderDatasetCurlDownload,
-                } as ComponentConfig<
-                  typeof C.ConditionalComponent,
-                  DatasetsResponse
-                >,
+                  component: ExportSection,
+                },
                 {
                   component: C.ExportMethod,
                   viewBuilder: V.buildDatasetExportMethodTerra,
@@ -412,6 +404,23 @@ export const exportConfig: ExportConfig = {
                     EXPORT_METHODS.CANCER_GENOMICS_CLOUD
                   ),
                 } as ComponentConfig<typeof ExportMethod>,
+                {
+                  component: DownloadSection,
+                  viewBuilder: V.buildDatasetDownloadSectionProps,
+                },
+                {
+                  children: [
+                    {
+                      component: C.ExportMethod,
+                      viewBuilder: V.buildDatasetExportMethodCurlCommand,
+                    } as ComponentConfig<typeof C.ExportMethod>,
+                  ],
+                  component: C.ConditionalComponent,
+                  viewBuilder: V.renderDatasetCurlDownload,
+                } as ComponentConfig<
+                  typeof C.ConditionalComponent,
+                  DatasetsResponse
+                >,
                 {
                   component: C.ExportMethod,
                   viewBuilder: V.buildDatasetExportMethodManifestDownload,

--- a/site-config/anvil-cmg/dev/export/export.ts
+++ b/site-config/anvil-cmg/dev/export/export.ts
@@ -3,6 +3,8 @@ import {
   ExportConfig,
 } from "@databiosphere/findable-ui/lib/config/entities";
 import * as C from "../../../../app/components";
+import { DownloadSection } from "../../../../app/components/Export/components/AnVILExplorer/components/ExportCohort/components/DownloadSection/downloadSection";
+import { ExportSection } from "../../../../app/components/Export/components/AnVILExplorer/components/ExportCohort/components/ExportSection/exportSection";
 import { ExportMethod } from "../../../../app/components/Export/components/AnVILExplorer/platform/ExportMethod/exportMethod";
 import * as V from "../../../../app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders";
 import { EXPORT_METHODS, EXPORTS } from "./constants";
@@ -180,9 +182,8 @@ export const exportConfig: ExportConfig = {
         {
           children: [
             {
-              component: C.ExportMethod,
-              viewBuilder: V.buildExportMethodBulkDownload,
-            } as ComponentConfig<typeof C.ExportMethod>,
+              component: ExportSection,
+            },
             {
               component: C.ExportMethod,
               viewBuilder: V.buildExportMethodTerra,
@@ -205,6 +206,20 @@ export const exportConfig: ExportConfig = {
                 EXPORT_METHODS.CANCER_GENOMICS_CLOUD
               ),
             } as ComponentConfig<typeof ExportMethod>,
+            {
+              component: DownloadSection,
+              viewBuilder: V.buildCohortDownloadSectionProps,
+            },
+            {
+              children: [
+                {
+                  component: C.ExportMethod,
+                  viewBuilder: V.buildExportMethodBulkDownload,
+                } as ComponentConfig<typeof C.ExportMethod>,
+              ],
+              component: C.ConditionalComponent,
+              viewBuilder: V.renderCurlDownload,
+            },
             {
               component: C.ExportMethod,
               viewBuilder: V.buildExportMethodManifestDownload,

--- a/site-config/anvil-cmg/dev/export/export.ts
+++ b/site-config/anvil-cmg/dev/export/export.ts
@@ -218,7 +218,7 @@ export const exportConfig: ExportConfig = {
                 } as ComponentConfig<typeof C.ExportMethod>,
               ],
               component: C.ConditionalComponent,
-              viewBuilder: V.renderCurlDownload,
+              viewBuilder: V.renderCohortCurlDownload,
             },
             {
               component: C.ExportMethod,


### PR DESCRIPTION
## Summary
- Extract Export and Download section headings/descriptions into reusable components for both cohort and dataset export views
- Update export method titles and descriptions for clarity (e.g. "Download TSV Manifest", "Export to Terra")
- Add NRES consent group checks to conditionally show curl download and contextual download descriptions
- Add named viewBuilder functions for DownloadSection props

Closes #4744.

## Test plan
- [x] Verify cohort export page shows correct Export/Download section headings and descriptions
- [x] Verify dataset export page shows correct Export/Download section headings and descriptions
- [x] Verify curl download option only appears for NRES/Unrestricted access datasets
- [x] Verify non-NRES datasets show manifest-only download description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1728" height="1074" alt="image" src="https://github.com/user-attachments/assets/5566155d-c5c2-490e-b4b0-098c4cba0681" />

<img width="1728" height="926" alt="image" src="https://github.com/user-attachments/assets/8d064468-ef0e-41d3-8281-83f69e9cdfdf" />

<img width="1728" height="926" alt="image" src="https://github.com/user-attachments/assets/bcd09e5e-e6ec-48d4-99d2-fee0ae6d164d" />
