### PR TITLE
content: update guides content and export descriptions (#4760)

### DIFF
--- a/app/content/anvil-cmg/guides.mdx
+++ b/app/content/anvil-cmg/guides.mdx
@@ -27,6 +27,7 @@ Documentation for using the AnVIL Data Explorer can be found in a series of arti
 - [Part 1: Set up billing and access in Terra](https://support.terra.bio/hc/en-us/articles/34595554957723-Part-1-Set-up-billing-and-data-access-in-Terra)
 - [Part 2: Search and select data in the AnVIL Data Explorer](https://support.terra.bio/hc/en-us/articles/34596321862427-Part-2-Search-and-select-data-in-AnVIL-Data-Explorer)
 - [Part 3: Export data for analysis](https://support.terra.bio/hc/en-us/articles/34607573660827-Part-3-Export-AnVIL-data-to-Terra-for-analysis)
+- [Downloading open-access data files to AWS EC2, your HPC environment, or your local compute environment](/guides/data-download-options).
 
 ## Limitations of the Data Explorer
 

--- a/app/content/anvil-cmg/guides/data-download-options.mdx
+++ b/app/content/anvil-cmg/guides/data-download-options.mdx
@@ -16,13 +16,13 @@ Managed-access datasets can be downloaded from Google Cloud Platform on a reques
 
 The following options are available through the AnVIL Data Explorer:
 
-- **TSV File Manifest Downloads**
+- **[TSV File Manifest Downloads](/guides/tsv-file-manifest-download)**
   - Available for all datasets, including open and managed access datasets.
   - Manifest can include one or more datasets based on the search criteria used in the AnVIL Data Explorer.
 
-- **Data Download via curl**
+- **[Data Download via curl](/guides/data-download-via-curl)**
   - Available only for open-access datasets.
   - `curl` Command downloads can be full datasets or include select file types from one or more open-access datasets.
 
-- **Individual File Download**
+- **[Individual File Download](/guides/individual-file-download)**
   - Available only for files in open-access datasets.

--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx
@@ -464,15 +464,13 @@ export const buildDatasetExportMethodHeroTerraExport = (
 /**
  * Build props for ExportMethod component for display of the dataset manifest download section.
  * @param datasetsResponse - Response model return from datasets API.
- * @param viewContext - View context.
  * @returns model to be used as props for the dataset file manifest export method component.
  */
 export const buildDatasetExportMethodManifestDownload = (
-  datasetsResponse: DatasetsResponse,
-  viewContext: ViewContext<DatasetsResponse>
+  datasetsResponse: DatasetsResponse
 ): React.ComponentProps<typeof C.ExportMethod> => {
   const datasetPath = buildDatasetPath(datasetsResponse);
-  const isNRES = isNRESConsentGroup(viewContext);
+  const isNRES = isDatasetNRESConsentGroup(datasetsResponse);
   return {
     description: isNRES
       ? "Download a TSV manifest containing metadata for all data files in the dataset. For open-access data files, the manifest also includes S3 URIs."

--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx
@@ -464,15 +464,19 @@ export const buildDatasetExportMethodHeroTerraExport = (
 /**
  * Build props for ExportMethod component for display of the dataset manifest download section.
  * @param datasetsResponse - Response model return from datasets API.
+ * @param viewContext - View context.
  * @returns model to be used as props for the dataset file manifest export method component.
  */
 export const buildDatasetExportMethodManifestDownload = (
-  datasetsResponse: DatasetsResponse
+  datasetsResponse: DatasetsResponse,
+  viewContext: ViewContext<DatasetsResponse>
 ): React.ComponentProps<typeof C.ExportMethod> => {
   const datasetPath = buildDatasetPath(datasetsResponse);
+  const isNRES = isNRESConsentGroup(viewContext);
   return {
-    description:
-      "Download a TSV manifest containing metadata for all data files in the dataset.",
+    description: isNRES
+      ? "Download a TSV manifest containing metadata for all data files in the dataset. For open-access data files, the manifest also includes S3 URIs."
+      : "Download a TSV manifest containing metadata for all data files in the dataset.",
     icon: <ExportIcon alt="Manifest" src="/export/manifest.webp" width={24} />,
     route: `${datasetPath}${ROUTES.MANIFEST_DOWNLOAD}`,
     title: "Download TSV Manifest",
@@ -535,8 +539,13 @@ export const buildDatasetExportMethodCurlCommand = (
 ): React.ComponentProps<typeof C.ExportMethod> => {
   const datasetPath = buildDatasetPath(datasetsResponse);
   return {
-    description:
-      "Generate a curl command to download all files in this open-access dataset.",
+    description: (
+      <div>
+        Generate a <code>curl</code> command to download all files in this
+        open-access dataset for analysis in AWS EC2, your HPC, or your local
+        compute environment.
+      </div>
+    ),
     icon: <ExportIcon alt="curl" src="/export/curl.webp" width={24} />,
     route: `${datasetPath}${ROUTES.CURL_DOWNLOAD}`,
     title: "Download Open-Access Data Files (No Data Transfer Fees)",
@@ -891,7 +900,7 @@ export const buildExportMethodManifestDownload = (
   return {
     ...getExportMethodAccessibility(viewContext),
     description:
-      "Download a TSV manifest containing metadata for all data files in the current selection, including managed-access files.",
+      "Download a TSV manifest containing metadata for all data files in the current selection, including managed-access files. For open-access data files, the manifest also includes S3 URIs.",
     icon: <ExportIcon alt="Manifest" src="/export/manifest.webp" width={24} />,
     route: ROUTES.MANIFEST_DOWNLOAD,
     title: "Download TSV Manifest for All Selected Data Files",
@@ -960,7 +969,8 @@ export const buildExportMethodBulkDownload = (
     description: (
       <div>
         Generate a <code>curl</code> command to download the open-access data
-        files in the current selection.
+        files in the current selection for analysis in AWS EC2, your HPC, or
+        your local compute environment.
       </div>
     ),
     icon: <ExportIcon alt="curl" src="/export/curl.webp" width={24} />,

--- a/site-config/anvil-cmg/dev/config.ts
+++ b/site-config/anvil-cmg/dev/config.ts
@@ -2,7 +2,6 @@ import { APIEndpoints } from "@databiosphere/findable-ui/lib/apis/azul/common/en
 import { FILTER_SORT } from "@databiosphere/findable-ui/lib/common/filters/sort/config/types";
 import { SELECTED_MATCH } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/common/entities";
 import { SystemStatusBindResponseFn } from "@databiosphere/findable-ui/lib/config/entities";
-import { CATALOG_DEFAULT } from "../../../app/apis/azul/anvil-cmg/common/constants";
 import * as C from "../../../app/components/index";
 import { mapSelectCategoryValue } from "../../../app/config/utils";
 import { buildDataDictionary } from "../../../app/viewModelBuilders/azul/anvil-cmg/common/dataDictionaryMapper/dataDictionaryMapper";
@@ -26,7 +25,7 @@ import { floating } from "./layout/floating";
 
 // Template constants
 const APP_TITLE = "AnVIL Data Explorer";
-const DATA_URL = "https://service.anvil.gi.ucsc.edu";
+const DATA_URL = "https://service.explore.anvilproject.org";
 const BROWSER_URL = "https://explore.anvil.gi.ucsc.edu";
 const PORTAL_URL = "https://anvilproject.dev.clevercanary.com";
 
@@ -35,7 +34,7 @@ export function makeConfig(
   portalUrl: string,
   dataUrl: string,
   gitHubUrl: string,
-  catalog: string = CATALOG_DEFAULT
+  catalog: string = "anvil13"
 ): SiteConfig {
   return {
     analytics: {

--- a/site-config/anvil-cmg/dev/config.ts
+++ b/site-config/anvil-cmg/dev/config.ts
@@ -2,6 +2,7 @@ import { APIEndpoints } from "@databiosphere/findable-ui/lib/apis/azul/common/en
 import { FILTER_SORT } from "@databiosphere/findable-ui/lib/common/filters/sort/config/types";
 import { SELECTED_MATCH } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/common/entities";
 import { SystemStatusBindResponseFn } from "@databiosphere/findable-ui/lib/config/entities";
+import { CATALOG_DEFAULT } from "../../../app/apis/azul/anvil-cmg/common/constants";
 import * as C from "../../../app/components/index";
 import { mapSelectCategoryValue } from "../../../app/config/utils";
 import { buildDataDictionary } from "../../../app/viewModelBuilders/azul/anvil-cmg/common/dataDictionaryMapper/dataDictionaryMapper";
@@ -25,7 +26,7 @@ import { floating } from "./layout/floating";
 
 // Template constants
 const APP_TITLE = "AnVIL Data Explorer";
-const DATA_URL = "https://service.explore.anvilproject.org";
+const DATA_URL = "https://service.anvil.gi.ucsc.edu";
 const BROWSER_URL = "https://explore.anvil.gi.ucsc.edu";
 const PORTAL_URL = "https://anvilproject.dev.clevercanary.com";
 
@@ -34,7 +35,7 @@ export function makeConfig(
   portalUrl: string,
   dataUrl: string,
   gitHubUrl: string,
-  catalog: string = "anvil13"
+  catalog: string = CATALOG_DEFAULT
 ): SiteConfig {
   return {
     analytics: {


### PR DESCRIPTION
## Summary
- Add internal links from Data Download Options page to guide sub-pages (TSV manifest, curl, individual download)
- Add data download options link to the main guides overview page
- Update export method descriptions to mention S3 URIs for open-access manifests and compute environments for curl downloads
- Add NRES-specific manifest description
- Update data URL to service.explore.anvilproject.org and inline catalog default

## Test plan
- [x] Verify links on `/guides/data-download-options` navigate to correct sub-pages
- [x] Verify new link on `/guides` overview page works
- [x] Verify updated export descriptions render correctly on dataset detail and cohort export pages
- [x] Verify NRES datasets show updated manifest description

Closes #4760

🤖 Generated with [Claude Code](https://claude.com/claude-code)