### PR TITLE
feat: always show curl export option in non-production environments

### DIFF
--- a/app/apis/azul/anvil-cmg/common/transformers.ts
+++ b/app/apis/azul/anvil-cmg/common/transformers.ts
@@ -72,6 +72,18 @@ export function getConsentGroup(response: DatasetsResponse): string[] {
 }
 
 /**
+ * Returns true if consent groups include NRES or Unrestricted access.
+ * @param consentGroups - Array of consent group strings.
+ * @returns true if NRES or Unrestricted access is present.
+ */
+export function isNRESOrUnrestrictedAccess(consentGroups: string[]): boolean {
+  return (
+    consentGroups.includes("NRES") ||
+    consentGroups.includes("Unrestricted access")
+  );
+}
+
+/**
  * Maps biosample type from an aggregated biosamples value returned from endpoints other than index/biosamples.
  * @param response - Response model return from Azul that includes aggregated biosamples.
  * @returns Set of aggregated biosample types.

--- a/app/components/Export/components/AnVILExplorer/components/ExportCohort/components/DownloadSection/downloadSection.tsx
+++ b/app/components/Export/components/AnVILExplorer/components/ExportCohort/components/DownloadSection/downloadSection.tsx
@@ -1,7 +1,7 @@
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { Stack, Typography } from "@mui/material";
 import type { JSX } from "react";
-import { isNRESConsentGroup } from "../../../../../../../../viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders";
+import { hasNRESConsentGroup } from "../../../../../../../../viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders";
 import { Props } from "./types";
 
 /**
@@ -11,7 +11,7 @@ import { Props } from "./types";
  * @returns Download section title and description.
  */
 export const DownloadSection = ({ viewContext }: Props): JSX.Element => {
-  const isNRES = isNRESConsentGroup(viewContext);
+  const isNRES = hasNRESConsentGroup(viewContext.fileManifestState);
   return (
     <Stack gap={1}>
       <Typography

--- a/app/config/utils.ts
+++ b/app/config/utils.ts
@@ -1,18 +1,6 @@
 import { SelectCategoryValue } from "@databiosphere/findable-ui/lib/common/entities";
 
 /**
- * Returns true if consent groups include NRES or Unrestricted access.
- * @param consentGroups - Array of consent group strings.
- * @returns true if NRES or Unrestricted access is present.
- */
-export function hasNRESOrUnrestrictedAccess(consentGroups: string[]): boolean {
-  return (
-    consentGroups.includes("NRES") ||
-    consentGroups.includes("Unrestricted access")
-  );
-}
-
-/**
  * Returns true if the current environment is production.
  * Determined by checking if NEXT_PUBLIC_SITE_CONFIG ends with "-prod".
  * @returns true if production environment.

--- a/app/config/utils.ts
+++ b/app/config/utils.ts
@@ -1,6 +1,16 @@
 import { SelectCategoryValue } from "@databiosphere/findable-ui/lib/common/entities";
 
 /**
+ * Returns true if the current environment is production.
+ * Determined by checking if NEXT_PUBLIC_SITE_CONFIG contains "prod".
+ * @returns true if production environment.
+ */
+export function isProductionEnvironment(): boolean {
+  const config = process.env.NEXT_PUBLIC_SITE_CONFIG ?? "";
+  return config.includes("prod");
+}
+
+/**
  * Returns select category value with formatted label.
  * @param formatLabel - Function to format label.
  * @returns select category value with formatted label.

--- a/app/config/utils.ts
+++ b/app/config/utils.ts
@@ -1,13 +1,25 @@
 import { SelectCategoryValue } from "@databiosphere/findable-ui/lib/common/entities";
 
 /**
+ * Returns true if consent groups include NRES or Unrestricted access.
+ * @param consentGroups - Array of consent group strings.
+ * @returns true if NRES or Unrestricted access is present.
+ */
+export function hasNRESOrUnrestrictedAccess(consentGroups: string[]): boolean {
+  return (
+    consentGroups.includes("NRES") ||
+    consentGroups.includes("Unrestricted access")
+  );
+}
+
+/**
  * Returns true if the current environment is production.
- * Determined by checking if NEXT_PUBLIC_SITE_CONFIG contains "prod".
+ * Determined by checking if NEXT_PUBLIC_SITE_CONFIG ends with "-prod".
  * @returns true if production environment.
  */
 export function isProductionEnvironment(): boolean {
   const config = process.env.NEXT_PUBLIC_SITE_CONFIG ?? "";
-  return config.includes("prod");
+  return config.endsWith("-prod");
 }
 
 /**

--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx
@@ -80,6 +80,7 @@ import {
   getBioSampleId,
   getBioSampleType,
   getConsentGroup,
+  isNRESOrUnrestrictedAccess,
   getDatasetDetails,
   getDatasetEntryId,
   getDocumentId,
@@ -1805,20 +1806,9 @@ export function hasNRESConsentGroup(
 
   if (!facet) return false;
 
-  const termsByName = facet.termsByName;
+  const consentGroups = [...facet.termsByName.keys()];
 
-  return termsByName.has("NRES") || termsByName.has("Unrestricted access");
-}
-
-/**
- * Returns true if the dataset has NRES or Unrestricted access consent group.
- * @param viewContext - View context.
- * @returns true if the dataset has NRES or Unrestricted access consent group.
- */
-export function isNRESConsentGroup(
-  viewContext: ViewContext<DatasetsResponse>
-): boolean {
-  return hasNRESConsentGroup(viewContext.fileManifestState);
+  return isNRESOrUnrestrictedAccess(consentGroups);
 }
 
 /**
@@ -1903,7 +1893,9 @@ export const renderCohortCurlDownload = (
   viewContext: ViewContext<DatasetsResponse>
 ): ComponentProps<typeof C.ConditionalComponent> => {
   return {
-    isIn: !isProductionEnvironment() || isNRESConsentGroup(viewContext),
+    isIn:
+      !isProductionEnvironment() ||
+      hasNRESConsentGroup(viewContext.fileManifestState),
   };
 };
 

--- a/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders.tsx
@@ -109,6 +109,7 @@ import { METADATA_KEY } from "../../../../components/Index/common/entities";
 import { getPluralizedMetadataLabel } from "../../../../components/Index/common/indexTransformer";
 import { SUMMARY_DISPLAY_TEXT } from "./summaryMapper/constants";
 import { mapExportSummary } from "./summaryMapper/summaryMapper";
+import { isProductionEnvironment } from "../../../../config/utils";
 
 /**
  * Build props for activity type BasicCell component from the given activities response.
@@ -1790,15 +1791,13 @@ function isFileManifestSummaryFileCountValid(
 }
 
 /**
- * Returns true if the dataset has NRES or Unrestricted access consent group.
- * @param viewContext - View context.
- * @returns true if the dataset has NRES or Unrestricted access consent group.
+ * Returns true if the file manifest state includes NRES or Unrestricted access consent group.
+ * @param fileManifestState - File manifest state.
+ * @returns true if NRES or Unrestricted access consent group is present.
  */
-export function isNRESConsentGroup(
-  viewContext: ViewContext<DatasetsResponse>
+export function hasNRESConsentGroup(
+  fileManifestState: FileManifestState
 ): boolean {
-  const { fileManifestState } = viewContext;
-
   const facet = findFacet(
     fileManifestState.filesFacets,
     ANVIL_CMG_CATEGORY_KEY.DATASET_CONSENT_GROUP
@@ -1809,6 +1808,17 @@ export function isNRESConsentGroup(
   const termsByName = facet.termsByName;
 
   return termsByName.has("NRES") || termsByName.has("Unrestricted access");
+}
+
+/**
+ * Returns true if the dataset has NRES or Unrestricted access consent group.
+ * @param viewContext - View context.
+ * @returns true if the dataset has NRES or Unrestricted access consent group.
+ */
+export function isNRESConsentGroup(
+  viewContext: ViewContext<DatasetsResponse>
+): boolean {
+  return hasNRESConsentGroup(viewContext.fileManifestState);
 }
 
 /**
@@ -1882,7 +1892,8 @@ export const renderWhenUnAuthenticated = (
 };
 
 /**
- * Renders cohort curl download component when the current query includes NRES or Unrestricted access consent groups.
+ * Renders cohort curl download component when the current query includes NRES or Unrestricted access consent groups,
+ * or when the environment is non-production.
  * @param _ - Unused.
  * @param viewContext - View context.
  * @returns model to be used as props for the ConditionalComponent component.
@@ -1891,11 +1902,14 @@ export const renderCohortCurlDownload = (
   _: unknown,
   viewContext: ViewContext<DatasetsResponse>
 ): ComponentProps<typeof C.ConditionalComponent> => {
-  return { isIn: isNRESConsentGroup(viewContext) };
+  return {
+    isIn: !isProductionEnvironment() || isNRESConsentGroup(viewContext),
+  };
 };
 
 /**
- * Renders dataset curl download components when the given dataset has NRES consent group.
+ * Renders dataset curl download components when the given dataset has NRES consent group,
+ * or when the environment is non-production.
  * @param datasetsResponse - Response model return from datasets API.
  * @returns model to be used as props for the ConditionalComponent component.
  */
@@ -1903,7 +1917,8 @@ export const renderDatasetCurlDownload = (
   datasetsResponse: DatasetsResponse
 ): React.ComponentProps<typeof C.ConditionalComponent> => {
   return {
-    isIn: isDatasetNRESConsentGroup(datasetsResponse),
+    isIn:
+      !isProductionEnvironment() || isDatasetNRESConsentGroup(datasetsResponse),
   };
 };
 

--- a/pages/[entityListType]/[...params].tsx
+++ b/pages/[entityListType]/[...params].tsx
@@ -35,6 +35,7 @@ import { ROUTES } from "../../site-config/anvil-cmg/dev/export/routes";
 
 import { getConsentGroup } from "../../app/apis/azul/anvil-cmg/common/transformers";
 import { DatasetsResponse } from "../../app/apis/azul/anvil-cmg/common/responses";
+import { isProductionEnvironment } from "../../app/config/utils";
 
 const setOfProcessedIds = new Set<string>();
 
@@ -66,8 +67,13 @@ const EntityDetailPage = (props: EntityDetailPageProps): JSX.Element => {
   const { query } = useRouter();
   if (!props.entityListType) return <></>;
   if (props.override) return <EntityGuard override={props.override} />;
-  // Curl download requires NRES consent group (AnVIL only)
-  if (isAnVIL && isCurlDownloadRoute(query) && !isNRESDataset(props.data)) {
+  // Curl download requires NRES consent group (AnVIL production only)
+  if (
+    isAnVIL &&
+    isProductionEnvironment() &&
+    isCurlDownloadRoute(query) &&
+    !isNRESDataset(props.data)
+  ) {
     return <NextError statusCode={404} />;
   }
   if (isChooseExportView(query)) return <EntityExportView {...props} />;

--- a/pages/[entityListType]/[...params].tsx
+++ b/pages/[entityListType]/[...params].tsx
@@ -33,7 +33,10 @@ import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
 import NextError from "next/error";
 import { ROUTES } from "../../site-config/anvil-cmg/dev/export/routes";
 
-import { getConsentGroup } from "../../app/apis/azul/anvil-cmg/common/transformers";
+import {
+  getConsentGroup,
+  isNRESOrUnrestrictedAccess,
+} from "../../app/apis/azul/anvil-cmg/common/transformers";
 import { DatasetsResponse } from "../../app/apis/azul/anvil-cmg/common/responses";
 import { isProductionEnvironment } from "../../app/config/utils";
 
@@ -109,14 +112,14 @@ function isCurlDownloadRoute(query: ParsedUrlQuery): boolean {
 }
 
 /**
- * Returns true if the dataset has NRES consent group.
+ * Returns true if the dataset has NRES or Unrestricted access consent group.
  * @param data - Entity response data.
- * @returns True if the dataset has NRES consent group.
+ * @returns True if the dataset has NRES or Unrestricted access consent group.
  */
 function isNRESDataset(data: AzulEntityStaticResponse | undefined): boolean {
   if (!data) return false;
   const consentGroups = getConsentGroup(data as DatasetsResponse);
-  return consentGroups.includes("NRES");
+  return isNRESOrUnrestrictedAccess(consentGroups);
 }
 
 /**

--- a/pages/export/get-curl-command.tsx
+++ b/pages/export/get-curl-command.tsx
@@ -1,6 +1,11 @@
 import { JSX } from "react";
 import { ExportMethodView } from "@databiosphere/findable-ui/lib/views/ExportMethodView/exportMethodView";
 import { GetStaticProps } from "next";
+import { useFileManifestState } from "@databiosphere/findable-ui/lib/hooks/useFileManifestState";
+import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
+import NextError from "next/error";
+import { isProductionEnvironment } from "../../app/config/utils";
+import { hasNRESConsentGroup } from "../../app/viewModelBuilders/azul/anvil-cmg/common/viewModelBuilders";
 
 export const getStaticProps: GetStaticProps = async () => {
   return {
@@ -15,6 +20,19 @@ export const getStaticProps: GetStaticProps = async () => {
  * @returns download curl command view component.
  */
 const GetCurlCommandPage = (): JSX.Element => {
+  const { config } = useConfig();
+  const { fileManifestState } = useFileManifestState();
+  const isAnVIL = config.appTitle?.includes("AnVIL");
+
+  // Curl download requires NRES consent group (AnVIL production only)
+  if (
+    isAnVIL &&
+    isProductionEnvironment() &&
+    !hasNRESConsentGroup(fileManifestState)
+  ) {
+    return <NextError statusCode={404} />;
+  }
+
   return <ExportMethodView />;
 };
 


### PR DESCRIPTION
## Ticket
Closes #4767

## Summary
- Add `isProductionEnvironment()` utility to detect production vs non-production environments based on `NEXT_PUBLIC_SITE_CONFIG`
- Update curl export visibility to always show in non-production environments (AnVIL only)
- Add runtime guards to protect curl download routes in production when NRES consent groups are not present

## Test plan
- [ ] Verify curl export option appears in dev environment regardless of consent group selection
- [ ] Verify curl export option only appears in production when NRES/Unrestricted access datasets are selected
- [ ] Verify direct navigation to `/export/get-curl-command` works in dev, returns 404 in prod without NRES
- [ ] Verify direct navigation to `/datasets/{id}/export/get-curl-command` works in dev, returns 404 in prod without NRES

🤖 Generated with [Claude Code](https://claude.ai/code)