### PR TITLE
feat: make dcp59 the default catalog for HCA

### DIFF
--- a/site-config/hca-dcp/dev/config.ts
+++ b/site-config/hca-dcp/dev/config.ts
@@ -18,7 +18,7 @@ import { floating } from "./layout/floating";
 
 // Template constants
 const APP_TITLE = "HCA Data Explorer";
-const CATALOG = "dcp58";
+const CATALOG = "dcp59";
 const BROWSER_URL = "https://explore.data.humancellatlas.dev.clevercanary.com";
 const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const EXPORT_TO_TERRA_URL = "https://app.terra.bio";

--- a/site-config/hca-dcp/ma-prod/config.ts
+++ b/site-config/hca-dcp/ma-prod/config.ts
@@ -6,7 +6,7 @@ import { getAuthenticationConfig } from "./authentication/authentication";
 
 // Template constants
 const BROWSER_URL = "https://explore.data.humancellatlas.org";
-const CATALOG = "dcp58";
+const CATALOG = "dcp59";
 const DATA_URL = "https://service.azul.data.humancellatlas.org";
 const PORTAL_URL = "https://data.humancellatlas.org";
 


### PR DESCRIPTION
## Summary
- Update the default HCA catalog from `dcp58` to `dcp59` in both dev and ma-prod config files

Closes #4782

## Test plan
- [ ] Verify dev environment loads with dcp59 catalog
- [ ] Verify prod environment loads with dcp59 catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)