### PR TITLE
fix: revert providers outside ErrorBoundary and upgrade findable-ui to v51.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "3.0.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^51.0.0",
+        "@databiosphere/findable-ui": "^51.1.0",
         "@emotion/react": "^11",
         "@emotion/styled": "^11",
         "@mdx-js/loader": "^3",
@@ -1110,9 +1110,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "51.0.1",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-51.0.1.tgz",
-      "integrity": "sha512-kHHf38QoQUJP+LQAPFKmGuOdZWWeb8Fjer+1CgIa8CryAnGI4HGNQT1KetrnMP0KuPRVOw3VmQOtzsynSdauKg==",
+      "version": "51.1.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-51.1.0.tgz",
+      "integrity": "sha512-aWy0zOOGim5xoJvWes1v/mqKSobBUlGmfZt4uIMp5f+oNKEFlAA27CSJ01SsbhWQKgpPdZT3f+kXxfYG0FDk+A==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "check-system-status:anvil-cmg": "esrun e2e/anvil/anvil-check-system-status.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^51.0.0",
+    "@databiosphere/findable-ui": "^51.1.0",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@mdx-js/loader": "^3",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -95,33 +95,33 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
                       >
                         <Header {...header} />
                       </ThemeProvider>
-                      <Main>
-                        <ErrorBoundary
-                          fallbackRender={({
-                            error,
-                            reset,
-                          }: {
-                            error: DataExplorerError;
-                            reset: () => void;
-                          }): JSX.Element => (
-                            <Error
-                              errorMessage={error.message}
-                              requestUrlMessage={error.requestUrlMessage}
-                              rootPath={redirectRootToPath}
-                              onReset={reset}
-                            />
-                          )}
-                        >
-                          <ExploreStateProvider entityListType={entityListType}>
-                            <DataDictionaryStateProvider>
+                      <ExploreStateProvider entityListType={entityListType}>
+                        <DataDictionaryStateProvider>
+                          <Main>
+                            <ErrorBoundary
+                              fallbackRender={({
+                                error,
+                                reset,
+                              }: {
+                                error: DataExplorerError;
+                                reset: () => void;
+                              }): JSX.Element => (
+                                <Error
+                                  errorMessage={error.message}
+                                  requestUrlMessage={error.requestUrlMessage}
+                                  rootPath={redirectRootToPath}
+                                  onReset={reset}
+                                />
+                              )}
+                            >
                               <FileManifestStateProvider>
                                 <Component {...pageProps} />
                                 <Floating {...floating} />
                               </FileManifestStateProvider>
-                            </DataDictionaryStateProvider>
-                          </ExploreStateProvider>
-                        </ErrorBoundary>
-                      </Main>
+                            </ErrorBoundary>
+                          </Main>
+                        </DataDictionaryStateProvider>
+                      </ExploreStateProvider>
                       <Footer {...footer} />
                     </AppLayout>
                   </LayoutDimensionsProvider>


### PR DESCRIPTION
## Summary

Reverts the provider move from #4783 and upgrades findable-ui to v51.1.0, which fixes the infinite crash loop at the library level.

### Why revert

PR #4783 moved `ExploreStateProvider` and `DataDictionaryStateProvider` inside the `ErrorBoundary` to catch reducer crashes. This fixed the crash loop but caused **state loss** when navigating to non-entity-list pages — the providers would unmount and lose explore state.

### Why this works without the provider move

findable-ui v51.1.0 ([PR #899](https://github.com/DataBiosphere/findable-ui/pull/899)) fixes the root cause at the library level:

- **`parseFilterParam`** — safely validates filter URL params without throwing. Called from reducers above the ErrorBoundary, prevents the crash that caused the re-render loop.
- **`useValidateFilterParam`** hook — runs inside ExploreView (inside the ErrorBoundary), validates the URL filter param directly, and throws `DataExplorerError` for invalid filters so the error page renders.
- **`ErrorBoundary`** — fixes `this.render` → `this.reset` typo.
- **`useAsync.run()`** — clears stale error on new request.

### Provider layout (restored to original)

```
ExploreStateProvider              ← outside ErrorBoundary (preserves state)
  DataDictionaryStateProvider     ← outside ErrorBoundary
    Main
      ErrorBoundary
        FileManifestStateProvider ← inside ErrorBoundary
          Component
```

Closes #4786

## Reference

- Umbrella: DataBiosphere/findable-ui#900
- Findable-ui fix: https://github.com/DataBiosphere/findable-ui/pull/899
- Original bug: #4776
- Provider move being reverted: #4783

## Test plan
- [x] Malformed JSON filter → error page, no loop
- [x] Wrong shape filter → error page, no loop
- [x] Valid shape, invalid values → API error page, no loop
- [x] Valid filters work normally
- [x] Navigation between entity list and detail pages preserves state
- [x] Unit tests pass
- [x] e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)