### PR TITLE
feat: implement authorization code flow with azul and data browser (#4793)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "3.0.1",
       "dependencies": {
-        "@databiosphere/findable-ui": "^51.1.0",
+        "@databiosphere/findable-ui": "^52.1.0",
         "@emotion/react": "^11",
         "@emotion/styled": "^11",
         "@mdx-js/loader": "^3",
@@ -1110,9 +1110,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "51.1.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-51.1.0.tgz",
-      "integrity": "sha512-aWy0zOOGim5xoJvWes1v/mqKSobBUlGmfZt4uIMp5f+oNKEFlAA27CSJ01SsbhWQKgpPdZT3f+kXxfYG0FDk+A==",
+      "version": "52.1.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-52.1.0.tgz",
+      "integrity": "sha512-kRZmj/Wd2UAfWxKwh0iJ3YYGLWim98s6q3c/P5rTGIsUgUSXuFFzEBfw2nxzP+B2OrE/MkqtnKH/y1pmUxG6lg==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"
@@ -1136,7 +1136,6 @@
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-dropzone": "^14.3.8",
-        "react-gtm-module": "^2.0.11",
         "react-idle-timer": "^5.7.2",
         "react-window": "^1.8.11",
         "rehype-raw": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "check-system-status:anvil-cmg": "esrun e2e/anvil/anvil-check-system-status.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^51.1.0",
+    "@databiosphere/findable-ui": "^52.1.0",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@mdx-js/loader": "^3",

--- a/site-config/anvil-cmg/cc-dev/authentication/constants.ts
+++ b/site-config/anvil-cmg/cc-dev/authentication/constants.ts
@@ -1,4 +1,7 @@
-import { OAuthProvider } from "@databiosphere/findable-ui/lib/config/entities";
+import {
+  OAUTH_FLOW,
+  OAuthProvider,
+} from "@databiosphere/findable-ui/lib/config/entities";
 import { GOOGLE_SIGN_IN_PROVIDER } from "@databiosphere/findable-ui/lib/google/config";
 import { GoogleProfile } from "@databiosphere/findable-ui/lib/google/types";
 
@@ -11,4 +14,5 @@ export const GOOGLE_PROVIDER: OAuthProvider<GoogleProfile> = {
   ...GOOGLE_SIGN_IN_PROVIDER,
   ...OAUTH_GOOGLE_SIGN_IN,
   clientId: CLIENT_ID,
+  flow: OAUTH_FLOW.IMPLICIT,
 };

--- a/site-config/anvil-cmg/dev/authentication/constants.ts
+++ b/site-config/anvil-cmg/dev/authentication/constants.ts
@@ -5,7 +5,7 @@ import { GoogleProfile } from "@databiosphere/findable-ui/lib/google/types";
 import { OAUTH_GOOGLE_SIGN_IN } from "../../../common/authentication";
 
 const CLIENT_ID =
-  "561542988117-9e04fhfrc9su130eb2ggea7bdppolkjq.apps.googleusercontent.com";
+  "561542988117-flam3i2fft6q27eig0me0gg2u7j57b5t.apps.googleusercontent.com";
 
 export const GOOGLE_PROVIDER: OAuthProvider<GoogleProfile> = {
   ...GOOGLE_SIGN_IN_PROVIDER,

--- a/site-config/anvil-cmg/dev/authentication/constants.ts
+++ b/site-config/anvil-cmg/dev/authentication/constants.ts
@@ -1,4 +1,7 @@
-import { OAuthProvider } from "@databiosphere/findable-ui/lib/config/entities";
+import {
+  OAUTH_FLOW,
+  OAuthProvider,
+} from "@databiosphere/findable-ui/lib/config/entities";
 import { GOOGLE_SIGN_IN_PROVIDER } from "@databiosphere/findable-ui/lib/google/config";
 import { GoogleProfile } from "@databiosphere/findable-ui/lib/google/types";
 
@@ -12,6 +15,7 @@ export const GOOGLE_PROVIDER: OAuthProvider<GoogleProfile> = {
   ...OAUTH_GOOGLE_SIGN_IN,
   authorize: "https://service.anvil.gi.ucsc.edu/user/authorize",
   clientId: CLIENT_ID,
+  flow: OAUTH_FLOW.AUTHORIZATION_CODE,
 };
 
 export const TERRA_SERVICE = {

--- a/site-config/anvil-cmg/dev/authentication/constants.ts
+++ b/site-config/anvil-cmg/dev/authentication/constants.ts
@@ -5,11 +5,12 @@ import { GoogleProfile } from "@databiosphere/findable-ui/lib/google/types";
 import { OAUTH_GOOGLE_SIGN_IN } from "../../../common/authentication";
 
 const CLIENT_ID =
-  "561542988117-flam3i2fft6q27eig0me0gg2u7j57b5t.apps.googleusercontent.com";
+  "561542988117-3cv4g8ii9enl2000ra6m02r3ne7bgnth.apps.googleusercontent.com";
 
 export const GOOGLE_PROVIDER: OAuthProvider<GoogleProfile> = {
   ...GOOGLE_SIGN_IN_PROVIDER,
   ...OAUTH_GOOGLE_SIGN_IN,
+  authorize: "https://service.anvil.gi.ucsc.edu/user/authorize",
   clientId: CLIENT_ID,
 };
 

--- a/site-config/anvil-cmg/dev/config.ts
+++ b/site-config/anvil-cmg/dev/config.ts
@@ -26,7 +26,7 @@ import { floating } from "./layout/floating";
 
 // Template constants
 const APP_TITLE = "AnVIL Data Explorer";
-const DATA_URL = "https://service.anvil.gi.ucsc.edu";
+const DATA_URL = "https://service.hannes2.anvil.gi.ucsc.edu";
 const BROWSER_URL = "https://explore.anvil.gi.ucsc.edu";
 const PORTAL_URL = "https://anvilproject.dev.clevercanary.com";
 

--- a/site-config/anvil-cmg/dev/config.ts
+++ b/site-config/anvil-cmg/dev/config.ts
@@ -26,7 +26,7 @@ import { floating } from "./layout/floating";
 
 // Template constants
 const APP_TITLE = "AnVIL Data Explorer";
-const DATA_URL = "https://service.hannes2.anvil.gi.ucsc.edu";
+const DATA_URL = "https://service.anvil.gi.ucsc.edu";
 const BROWSER_URL = "https://explore.anvil.gi.ucsc.edu";
 const PORTAL_URL = "https://anvilproject.dev.clevercanary.com";
 

--- a/site-config/anvil-cmg/prod/authentication/constants.ts
+++ b/site-config/anvil-cmg/prod/authentication/constants.ts
@@ -1,4 +1,7 @@
-import { OAuthProvider } from "@databiosphere/findable-ui/lib/config/entities";
+import {
+  OAUTH_FLOW,
+  OAuthProvider,
+} from "@databiosphere/findable-ui/lib/config/entities";
 import { GOOGLE_SIGN_IN_PROVIDER } from "@databiosphere/findable-ui/lib/google/config";
 import { GoogleProfile } from "@databiosphere/findable-ui/lib/google/types";
 
@@ -11,6 +14,7 @@ export const GOOGLE_PROVIDER: OAuthProvider<GoogleProfile> = {
   ...GOOGLE_SIGN_IN_PROVIDER,
   ...OAUTH_GOOGLE_SIGN_IN,
   clientId: CLIENT_ID,
+  flow: OAUTH_FLOW.IMPLICIT,
 };
 
 export const TERRA_SERVICE = {

--- a/site-config/anvil-cmg/tempdev/authentication/constants.ts
+++ b/site-config/anvil-cmg/tempdev/authentication/constants.ts
@@ -1,4 +1,7 @@
-import { OAuthProvider } from "@databiosphere/findable-ui/lib/config/entities";
+import {
+  OAUTH_FLOW,
+  OAuthProvider,
+} from "@databiosphere/findable-ui/lib/config/entities";
 import { GOOGLE_SIGN_IN_PROVIDER } from "@databiosphere/findable-ui/lib/google/config";
 import { GoogleProfile } from "@databiosphere/findable-ui/lib/google/types";
 
@@ -11,6 +14,7 @@ export const GOOGLE_PROVIDER: OAuthProvider<GoogleProfile> = {
   ...GOOGLE_SIGN_IN_PROVIDER,
   ...OAUTH_GOOGLE_SIGN_IN,
   clientId: CLIENT_ID,
+  flow: OAUTH_FLOW.IMPLICIT,
 };
 
 export const TERRA_SERVICE = {

--- a/site-config/hca-dcp/cc-ma-dev/authentication/constants.ts
+++ b/site-config/hca-dcp/cc-ma-dev/authentication/constants.ts
@@ -1,4 +1,7 @@
-import { OAuthProvider } from "@databiosphere/findable-ui/lib/config/entities";
+import {
+  OAUTH_FLOW,
+  OAuthProvider,
+} from "@databiosphere/findable-ui/lib/config/entities";
 import { GOOGLE_SIGN_IN_PROVIDER } from "@databiosphere/findable-ui/lib/google/config";
 import { GoogleProfile } from "@databiosphere/findable-ui/lib/google/types";
 
@@ -11,6 +14,7 @@ export const GOOGLE_PROVIDER: OAuthProvider<GoogleProfile> = {
   ...GOOGLE_SIGN_IN_PROVIDER,
   ...OAUTH_GOOGLE_SIGN_IN,
   clientId: CLIENT_ID,
+  flow: OAUTH_FLOW.IMPLICIT,
 };
 
 export const TERRA_SERVICE = {

--- a/site-config/hca-dcp/ma-prod/authentication/constants.ts
+++ b/site-config/hca-dcp/ma-prod/authentication/constants.ts
@@ -1,4 +1,7 @@
-import { OAuthProvider } from "@databiosphere/findable-ui/lib/config/entities";
+import {
+  OAUTH_FLOW,
+  OAuthProvider,
+} from "@databiosphere/findable-ui/lib/config/entities";
 import { GOOGLE_SIGN_IN_PROVIDER } from "@databiosphere/findable-ui/lib/google/config";
 import { GoogleProfile } from "@databiosphere/findable-ui/lib/google/types";
 
@@ -11,6 +14,7 @@ export const GOOGLE_PROVIDER: OAuthProvider<GoogleProfile> = {
   ...GOOGLE_SIGN_IN_PROVIDER,
   ...OAUTH_GOOGLE_SIGN_IN,
   clientId: CLIENT_ID,
+  flow: OAUTH_FLOW.IMPLICIT,
 };
 
 export const TERRA_SERVICE = {


### PR DESCRIPTION
## Summary

- Switches `anvil-cmg/dev` to the OAuth 2.0 authorization code flow against Azul's new `/user/authorize` endpoint
- Bumps the Google `CLIENT_ID` to anvildev's value (per @hannes-ucsc's Slack note) and adds an `authorize` URL on the provider, picked up by findable-ui's new code-flow branch
- Initial commit applies @hannes-ucsc's POC verbatim (DATA_URL pointed at his personal deployment); follow-up commit switches to the real anvildev endpoints and wires `authorize` through the provider config
- Per @hannes-ucsc, only DB instances backed by Azul `dev`/`anvildev` should adopt this for now; prod is unchanged

**Blocked by:** [findable-ui#905](https://github.com/DataBiosphere/findable-ui/pull/905) — needs to merge and release before this can ship (`OAuthProvider.authorize` field comes from there).

Closes #4793.

## Test plan

- [x] Verified login end-to-end on `localhost:3000` against anvildev (via local findable-ui tarball): POST `https://service.anvil.gi.ucsc.edu/user/authorize` returns `{access_token, id_token, scope, expires_in, token_type}`; profile loads
- [x] Logout clears state, datasets table reverts to public-only view
- [x] Inactivity timeout still triggers (verified at 10s)
- [x] Terra-side checks (userinfo, ToS, profile) still 200 with the access token
- [x] Bump `@databiosphere/findable-ui` to the release containing #905 before marking ready for review
- [x] CI green on the bump commit (currently expected to fail typecheck on the registry version, since `authorize` field isn't in the published package yet)