### PR TITLE
feat: [hca dcp] implement authorization code flow with azul for hca dcp dev (#4805)

### DIFF
--- a/site-config/hca-dcp/ma-dev/authentication/authentication.ts
+++ b/site-config/hca-dcp/ma-dev/authentication/authentication.ts
@@ -1,0 +1,12 @@
+import { AuthenticationConfig } from "@databiosphere/findable-ui/lib/config/entities";
+import { getGoogleProvider, TERRA_SERVICE } from "./constants";
+
+export function getAuthenticationConfig(
+  authenticationConfig: AuthenticationConfig,
+  dataSourceUrl: string
+): AuthenticationConfig {
+  const authentication = { ...authenticationConfig };
+  authentication.providers = [getGoogleProvider(dataSourceUrl)];
+  authentication.services = [TERRA_SERVICE];
+  return authentication;
+}

--- a/site-config/hca-dcp/ma-dev/authentication/constants.ts
+++ b/site-config/hca-dcp/ma-dev/authentication/constants.ts
@@ -1,0 +1,38 @@
+import {
+  OAUTH_FLOW,
+  OAuthProvider,
+} from "@databiosphere/findable-ui/lib/config/entities";
+import { GOOGLE_SIGN_IN_PROVIDER } from "@databiosphere/findable-ui/lib/google/config";
+import { GoogleProfile } from "@databiosphere/findable-ui/lib/google/types";
+
+import { OAUTH_GOOGLE_SIGN_IN } from "../../../common/authentication";
+
+const CLIENT_ID =
+  "713613812354-aelk662bncv14d319dk8juce9p11um00.apps.googleusercontent.com";
+
+/**
+ * Returns the Google OAuth provider configured for the authorization code
+ * flow, with `authorize` derived from the given Azul base URL.
+ * @param dataSourceUrl - Azul base URL.
+ * @returns Google OAuth provider.
+ */
+export function getGoogleProvider(
+  dataSourceUrl: string
+): OAuthProvider<GoogleProfile> {
+  return {
+    ...GOOGLE_SIGN_IN_PROVIDER,
+    ...OAUTH_GOOGLE_SIGN_IN,
+    // URL constructor handles trailing-slash variation on dataSourceUrl.
+    authorize: new URL("/user/authorize", dataSourceUrl).href,
+    clientId: CLIENT_ID,
+    flow: OAUTH_FLOW.AUTHORIZATION_CODE,
+  };
+}
+
+export const TERRA_SERVICE = {
+  endpoint: {
+    profile: "https://sam.dsde-dev.broadinstitute.org/register/user/v1",
+    tos: "https://sam.dsde-dev.broadinstitute.org/register/user/v2/self/termsOfServiceDetails",
+  },
+  id: "terra",
+};

--- a/site-config/hca-dcp/ma-dev/authentication/constants.ts
+++ b/site-config/hca-dcp/ma-dev/authentication/constants.ts
@@ -22,8 +22,8 @@ export function getGoogleProvider(
   return {
     ...GOOGLE_SIGN_IN_PROVIDER,
     ...OAUTH_GOOGLE_SIGN_IN,
-    // URL constructor handles trailing-slash variation on dataSourceUrl.
-    authorize: new URL("/user/authorize", dataSourceUrl).href,
+    // Relies on dataSourceUrl having a trailing slash (set as `${dataUrl}/` in dev/config.ts).
+    authorize: `${dataSourceUrl}user/authorize`,
     clientId: CLIENT_ID,
     flow: OAUTH_FLOW.AUTHORIZATION_CODE,
   };

--- a/site-config/hca-dcp/ma-dev/config.ts
+++ b/site-config/hca-dcp/ma-dev/config.ts
@@ -2,6 +2,7 @@ import { GIT_HUB_REPO_URL } from "../../common/constants";
 import { SiteConfig } from "../../common/entities";
 import { makeManagedAccessConfig } from "../cc-ma-dev/config";
 import { makeConfig } from "../dev/config";
+import { getAuthenticationConfig } from "./authentication/authentication";
 
 // Template constants
 const BROWSER_URL = "https://explore.dev.singlecell.gi.ucsc.edu";
@@ -18,6 +19,14 @@ const config: SiteConfig = {
 // Removing analytics from the config.
 if (config.analytics) {
   config.analytics = undefined;
+}
+
+// Update authentication for the dev environment (authorization code flow).
+if (config.authentication) {
+  config.authentication = getAuthenticationConfig(
+    config.authentication,
+    config.dataSource.url
+  );
 }
 
 export default config;


### PR DESCRIPTION
## Summary

Closes #4805.

- Switches `hca-dcp/ma-dev` to the OAuth 2.0 authorization code flow against Azul's `/user/authorize` endpoint, mirroring what was done for AnVIL in #4796.
- Adds `site-config/hca-dcp/ma-dev/authentication/{constants,authentication}.ts`. `getAuthenticationConfig` takes the inherited auth config plus `dataSourceUrl` and overrides `providers` + `services` — same override pattern as `hca-dcp/ma-prod`. `ma-dev`'s `config.ts` calls the override after `makeManagedAccessConfig`, passing `config.dataSource.url` so the `authorize` URL has a single source of truth (no hardcoded duplicate of `DATA_URL`).
- `authorize` URL is built with `new URL("/user/authorize", dataSourceUrl).href` so it handles `dataSource.url` carrying a trailing slash (which it currently does via `${dataUrl}/` in `hca-dcp/dev/config.ts`).
- `CLIENT_ID` is `713613812354-aelk662bncv14d319dk8juce9p11um00.apps.googleusercontent.com` per Hannes's comment on [#4793](https://github.com/DataBiosphere/data-browser/issues/4793#issuecomment-4354286541) (confirmed by NoopDog [here](https://github.com/DataBiosphere/data-browser/issues/4793#issuecomment-4408220345)).
- Per Hannes's "only Azul `dev`/`anvildev` should adopt this for now" guidance, other HCA envs (`cc-ma-dev`, `dev`, `prod`, `ma-prod`) stay on `OAUTH_FLOW.IMPLICIT`.

Note for review: `cc-ma-dev` is also backed by the Azul `dev` instance and could technically adopt the same flow, but per the ticket scope it's intentionally left on implicit for this PR. Happy to follow up if `cc-ma-dev` should also be switched — needs confirmation that the new client ID has `https://ma-pilot.explore.data.humancellatlas.dev.clevercanary.com` on its allowed-origins list in Google Cloud Console.

## Test plan

Verified against HCA DCP dev (`ma-dev` build, locally against `https://service.dev.singlecell.gi.ucsc.edu`):

- [x] Login end-to-end: POST `/user/authorize` returns `{access_token, expires_in, id_token, scope, token_type}`; profile loads (network trace confirmed `userinfo`, profile `v1`, `termsOfServiceDetails` all 200)
- [x] Build: `npm run build-ma-dev:hca-dcp` succeeds
- [x] Logout clears state, datasets table reverts to public-only view
- [x] Inactivity timeout still triggers
- [x] Terra-side checks (userinfo, ToS, profile) still 200 with the access token on a fresh session