### PR TITLE
chore: upgrade findable-ui to v52.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "3.1.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^52.1.0",
+        "@databiosphere/findable-ui": "^52.2.0",
         "@emotion/react": "^11",
         "@emotion/styled": "^11",
         "@mdx-js/loader": "^3",
@@ -1110,9 +1110,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "52.1.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-52.1.0.tgz",
-      "integrity": "sha512-kRZmj/Wd2UAfWxKwh0iJ3YYGLWim98s6q3c/P5rTGIsUgUSXuFFzEBfw2nxzP+B2OrE/MkqtnKH/y1pmUxG6lg==",
+      "version": "52.2.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-52.2.0.tgz",
+      "integrity": "sha512-k9r6pMJ/J4rGBCvnm1e0vba232xEv+u0xyOHiQQCPQf8EE6pYTuUSMk2A0t7zLLNBLt1NPDZfVTAZy4Q+5JhSw==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "check-system-status:anvil-cmg": "esrun e2e/anvil/anvil-check-system-status.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^52.1.0",
+    "@databiosphere/findable-ui": "^52.2.0",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@mdx-js/loader": "^3",


### PR DESCRIPTION
## Ticket
Closes #4823

## Summary
- Upgrade `@databiosphere/findable-ui` from `^52.1.0` to `^52.2.0` (resolves to `52.2.0`)

## Test plan
- [ ] Verify the app builds successfully
- [ ] Smoke test navigation and core UI across data-browser apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)