### PR TITLE
feat: [anvil dx] add anvil datasets to google datasets catalog (#4807)

### DIFF
--- a/__tests__/utils/schemaOrg/anvilDataset.test.ts
+++ b/__tests__/utils/schemaOrg/anvilDataset.test.ts
@@ -1,0 +1,182 @@
+import type { DatasetsResponse } from "../../../app/apis/azul/anvil-cmg/common/responses";
+import { buildAnvilDatasetJsonLd } from "../../../app/utils/schemaOrg/anvilDataset";
+import { DESCRIPTION_LENGTH } from "../../../app/utils/schemaOrg/constants";
+
+const BROWSER_URL = "https://explore.anvilproject.org";
+
+/**
+ * Builds a minimal valid AnVIL datasets response with optional overrides for
+ * top-level (dataset) and aggregated (activity/biosample/donor/file/library/
+ * diagnosis) fields.
+ * @param overrides - Partial overrides applied to the base response.
+ * @returns A `DatasetsResponse` shape suitable for builder tests.
+ */
+function makeDatasetsResponse(
+  overrides: Partial<DatasetsResponse> = {}
+): DatasetsResponse {
+  return {
+    activities: [],
+    biosamples: [],
+    datasets: [
+      {
+        accessible: true,
+        consent_group: ["NRES"],
+        dataset_id: "uuid-1",
+        description:
+          "A multi-cohort study of rare disease across many donors and biosamples.",
+        duos_id: null,
+        registered_identifier: [],
+        title: "Rare disease dataset",
+      },
+    ],
+    diagnoses: [],
+    donors: [],
+    entryId: "abc",
+    files: [],
+    libraries: [],
+    status: 200,
+    ...overrides,
+  } as unknown as DatasetsResponse;
+}
+
+describe("buildAnvilDatasetJsonLd", () => {
+  it("returns undefined when no dataset is present", () => {
+    const response = makeDatasetsResponse({ datasets: [] });
+    expect(buildAnvilDatasetJsonLd(response, BROWSER_URL)).toBeUndefined();
+  });
+
+  it("populates required Schema.org Dataset fields", () => {
+    const result = buildAnvilDatasetJsonLd(makeDatasetsResponse(), BROWSER_URL);
+    expect(result).toBeDefined();
+    expect(result!["@context"]).toBe("https://schema.org");
+    expect(result!["@type"]).toBe("Dataset");
+    expect(result!.name).toBe("Rare disease dataset");
+    expect(result!.description).toBe(
+      "A multi-cohort study of rare disease across many donors and biosamples."
+    );
+    expect(result!.url).toBe(`${BROWSER_URL}/datasets/uuid-1`);
+    expect(result!.identifier).toEqual(["uuid-1"]);
+    expect(result!.isAccessibleForFree).toBe(true);
+    expect(result!.includedInDataCatalog).toEqual({
+      "@type": "DataCatalog",
+      name: "AnVIL Data Explorer",
+      url: BROWSER_URL,
+    });
+  });
+
+  it("falls back to dataset_id when title is empty", () => {
+    const response = makeDatasetsResponse();
+    response.datasets[0].title = "";
+    const result = buildAnvilDatasetJsonLd(response, BROWSER_URL);
+    expect(result!.name).toBe("uuid-1");
+  });
+
+  it("strips HTML tags from description", () => {
+    const response = makeDatasetsResponse();
+    response.datasets[0].description =
+      "<p>Single-cell <strong>RNA-seq</strong> data across many donors and tissues.</p>";
+    const result = buildAnvilDatasetJsonLd(response, BROWSER_URL);
+    expect(result!.description).toBe(
+      "Single-cell RNA-seq data across many donors and tissues."
+    );
+  });
+
+  it("truncates descriptions over 5000 characters and appends an ellipsis", () => {
+    const longDescription = "a".repeat(DESCRIPTION_LENGTH.MAX + 200);
+    const response = makeDatasetsResponse();
+    response.datasets[0].description = longDescription;
+    const result = buildAnvilDatasetJsonLd(response, BROWSER_URL);
+    expect(result!.description).toHaveLength(DESCRIPTION_LENGTH.MAX);
+    expect(result!.description.endsWith("…")).toBe(true);
+  });
+
+  it("pads short descriptions with name and catalog context to meet the 50-char minimum", () => {
+    const response = makeDatasetsResponse();
+    response.datasets[0].description = "Short.";
+    const result = buildAnvilDatasetJsonLd(response, BROWSER_URL);
+    expect(result!.description).toBe(
+      "Rare disease dataset — Short. — AnVIL Data Explorer dataset."
+    );
+    expect(result!.description.length).toBeGreaterThanOrEqual(
+      DESCRIPTION_LENGTH.MIN
+    );
+  });
+
+  it("falls back to dataset name plus catalog context when description is missing", () => {
+    const response = makeDatasetsResponse();
+    response.datasets[0].description = undefined;
+    const result = buildAnvilDatasetJsonLd(response, BROWSER_URL);
+    expect(result!.description).toBe(
+      "Rare disease dataset — AnVIL Data Explorer dataset."
+    );
+    expect(result!.description.length).toBeGreaterThanOrEqual(
+      DESCRIPTION_LENGTH.MIN
+    );
+  });
+
+  it("includes registered_identifier values in identifier and dbGaP study URLs in sameAs", () => {
+    const response = makeDatasetsResponse();
+    response.datasets[0].registered_identifier = [
+      "phs000123",
+      "phs000456",
+      null,
+    ];
+    const result = buildAnvilDatasetJsonLd(response, BROWSER_URL);
+    expect(result!.identifier).toEqual(["uuid-1", "phs000123", "phs000456"]);
+    expect(result!.sameAs).toEqual([
+      "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000123",
+      "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000456",
+    ]);
+  });
+
+  it("omits sameAs when there are no registered identifiers", () => {
+    const result = buildAnvilDatasetJsonLd(makeDatasetsResponse(), BROWSER_URL);
+    expect(result!.sameAs).toBeUndefined();
+  });
+
+  it("builds deduplicated keywords from activity, biosample, donor, diagnosis, file, and library fields", () => {
+    const response = makeDatasetsResponse({
+      activities: [
+        { activity_type: ["sequencing"], data_modality: ["genomic"] },
+      ],
+      biosamples: [{ anatomical_site: ["brain"], biosample_type: ["tissue"] }],
+      diagnoses: [{ disease: ["epilepsy"], phenotype: [] }],
+      donors: [
+        {
+          organism_type: ["Homo sapiens"],
+          phenotypic_sex: ["female"],
+          reported_ethnicity: ["asian"],
+        },
+      ],
+      files: [
+        {
+          data_modality: ["genomic"],
+          file_format: ["fastq", "bam"],
+          file_id: "f1",
+          file_type: "sequencing",
+        },
+      ],
+      libraries: [{ prep_material_name: ["DNA"] }],
+    } as unknown as Partial<DatasetsResponse>);
+    const result = buildAnvilDatasetJsonLd(response, BROWSER_URL);
+    expect(result!.keywords).toEqual([
+      "sequencing",
+      "genomic",
+      "brain",
+      "tissue",
+      "Homo sapiens",
+      "female",
+      "asian",
+      "epilepsy",
+      "fastq",
+      "bam",
+      "DNA",
+    ]);
+  });
+
+  it("omits keywords and sameAs when sources are empty", () => {
+    const result = buildAnvilDatasetJsonLd(makeDatasetsResponse(), BROWSER_URL);
+    expect(result!.keywords).toBeUndefined();
+    expect(result!.sameAs).toBeUndefined();
+  });
+});

--- a/__tests__/utils/schemaOrg/anvilDataset.test.ts
+++ b/__tests__/utils/schemaOrg/anvilDataset.test.ts
@@ -1,6 +1,9 @@
 import type { DatasetsResponse } from "../../../app/apis/azul/anvil-cmg/common/responses";
 import { buildAnvilDatasetJsonLd } from "../../../app/utils/schemaOrg/anvilDataset";
-import { DESCRIPTION_LENGTH } from "../../../app/utils/schemaOrg/constants";
+import {
+  DESCRIPTION_LENGTH,
+  MAX_KEYWORDS,
+} from "../../../app/utils/schemaOrg/constants";
 
 const BROWSER_URL = "https://explore.anvilproject.org";
 
@@ -134,6 +137,21 @@ describe("buildAnvilDatasetJsonLd", () => {
     expect(result!.sameAs).toBeUndefined();
   });
 
+  it("skips registered_identifier values that aren't dbGaP phs accessions", () => {
+    const response = makeDatasetsResponse();
+    response.datasets[0].registered_identifier = [
+      "phs000123",
+      "not-a-phs",
+      "PHS000456", // wrong case — phs accessions are lowercase
+      "phs000789",
+    ];
+    const result = buildAnvilDatasetJsonLd(response, BROWSER_URL);
+    expect(result!.sameAs).toEqual([
+      "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000123",
+      "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000789",
+    ]);
+  });
+
   it("builds deduplicated keywords from activity, biosample, donor, diagnosis, file, and library fields", () => {
     const response = makeDatasetsResponse({
       activities: [
@@ -178,5 +196,25 @@ describe("buildAnvilDatasetJsonLd", () => {
     const result = buildAnvilDatasetJsonLd(makeDatasetsResponse(), BROWSER_URL);
     expect(result!.keywords).toBeUndefined();
     expect(result!.sameAs).toBeUndefined();
+  });
+
+  it("caps keywords at MAX_KEYWORDS to keep payload size predictable", () => {
+    const fileFormats = Array.from(
+      { length: MAX_KEYWORDS + 10 },
+      (_, i) => `fmt-${i}`
+    );
+    const response = makeDatasetsResponse({
+      files: [
+        {
+          data_modality: [],
+          file_format: fileFormats,
+          file_id: "f1",
+          file_type: "sequencing",
+        },
+      ],
+    } as unknown as Partial<DatasetsResponse>);
+    const result = buildAnvilDatasetJsonLd(response, BROWSER_URL);
+    expect(result!.keywords).toHaveLength(MAX_KEYWORDS);
+    expect(result!.keywords).toEqual(fileFormats.slice(0, MAX_KEYWORDS));
   });
 });

--- a/__tests__/utils/schemaOrg/anvilDataset.test.ts
+++ b/__tests__/utils/schemaOrg/anvilDataset.test.ts
@@ -117,7 +117,7 @@ describe("buildAnvilDatasetJsonLd", () => {
     );
   });
 
-  it("includes registered_identifier values in identifier and dbGaP study URLs in sameAs", () => {
+  it("includes registered_identifier values in identifier", () => {
     const response = makeDatasetsResponse();
     response.datasets[0].registered_identifier = [
       "phs000123",
@@ -126,30 +126,6 @@ describe("buildAnvilDatasetJsonLd", () => {
     ];
     const result = buildAnvilDatasetJsonLd(response, BROWSER_URL);
     expect(result!.identifier).toEqual(["uuid-1", "phs000123", "phs000456"]);
-    expect(result!.sameAs).toEqual([
-      "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000123",
-      "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000456",
-    ]);
-  });
-
-  it("omits sameAs when there are no registered identifiers", () => {
-    const result = buildAnvilDatasetJsonLd(makeDatasetsResponse(), BROWSER_URL);
-    expect(result!.sameAs).toBeUndefined();
-  });
-
-  it("skips registered_identifier values that aren't dbGaP phs accessions", () => {
-    const response = makeDatasetsResponse();
-    response.datasets[0].registered_identifier = [
-      "phs000123",
-      "not-a-phs",
-      "PHS000456", // wrong case — phs accessions are lowercase
-      "phs000789",
-    ];
-    const result = buildAnvilDatasetJsonLd(response, BROWSER_URL);
-    expect(result!.sameAs).toEqual([
-      "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000123",
-      "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000789",
-    ]);
   });
 
   it("builds deduplicated keywords from activity, biosample, donor, diagnosis, file, and library fields", () => {
@@ -192,10 +168,9 @@ describe("buildAnvilDatasetJsonLd", () => {
     ]);
   });
 
-  it("omits keywords and sameAs when sources are empty", () => {
+  it("omits keywords when sources are empty", () => {
     const result = buildAnvilDatasetJsonLd(makeDatasetsResponse(), BROWSER_URL);
     expect(result!.keywords).toBeUndefined();
-    expect(result!.sameAs).toBeUndefined();
   });
 
   it("caps keywords at MAX_KEYWORDS to keep payload size predictable", () => {

--- a/__tests__/utils/schemaOrg/anvilDataset.test.ts
+++ b/__tests__/utils/schemaOrg/anvilDataset.test.ts
@@ -98,7 +98,7 @@ describe("buildAnvilDatasetJsonLd", () => {
     response.datasets[0].description = "Short.";
     const result = buildAnvilDatasetJsonLd(response, BROWSER_URL);
     expect(result!.description).toBe(
-      "Rare disease dataset — Short. — AnVIL Data Explorer dataset."
+      "Rare disease dataset — Short. — A genomic dataset in the AnVIL Data Explorer catalog."
     );
     expect(result!.description.length).toBeGreaterThanOrEqual(
       DESCRIPTION_LENGTH.MIN
@@ -110,7 +110,7 @@ describe("buildAnvilDatasetJsonLd", () => {
     response.datasets[0].description = undefined;
     const result = buildAnvilDatasetJsonLd(response, BROWSER_URL);
     expect(result!.description).toBe(
-      "Rare disease dataset — AnVIL Data Explorer dataset."
+      "Rare disease dataset — A genomic dataset in the AnVIL Data Explorer catalog."
     );
     expect(result!.description.length).toBeGreaterThanOrEqual(
       DESCRIPTION_LENGTH.MIN

--- a/app/utils/schemaOrg/anvilDataset.ts
+++ b/app/utils/schemaOrg/anvilDataset.ts
@@ -1,5 +1,6 @@
 import type { DatasetEntity } from "../../apis/azul/anvil-cmg/common/entities";
 import type { DatasetsResponse } from "../../apis/azul/anvil-cmg/common/responses";
+import { MAX_KEYWORDS } from "./constants";
 import type { SchemaDataset } from "./types";
 import { buildDescription, uniqueNonEmpty } from "./utils";
 
@@ -7,6 +8,10 @@ const CATALOG_NAME = "AnVIL Data Explorer";
 const DESCRIPTION_FALLBACK_SUFFIX = `${CATALOG_NAME} dataset.`;
 const DBGAP_STUDY_URL =
   "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=";
+// dbGaP study accession format (e.g. "phs001234"). We validate against this
+// before constructing identifiers.org / dbGaP study URLs so a non-dbGaP value
+// in `registered_identifier` doesn't produce a malformed link.
+const DBGAP_ACCESSION_PATTERN = /^phs\d+/;
 
 /**
  * Builds a Schema.org Dataset JSON-LD object for an AnVIL CMG dataset.
@@ -92,7 +97,7 @@ function buildKeywords(data: DatasetsResponse): string[] {
   for (const library of data.libraries ?? []) {
     values.push(...(library.prep_material_name ?? []));
   }
-  return uniqueNonEmpty(values);
+  return uniqueNonEmpty(values).slice(0, MAX_KEYWORDS);
 }
 
 /**
@@ -106,7 +111,7 @@ function buildSameAs(dataset: DatasetEntity): string[] {
   for (const id of dataset.registered_identifier) {
     if (!id) continue;
     const trimmed = id.trim();
-    if (!trimmed) continue;
+    if (!DBGAP_ACCESSION_PATTERN.test(trimmed)) continue;
     urls.push(`${DBGAP_STUDY_URL}${trimmed}`);
   }
   return uniqueNonEmpty(urls);

--- a/app/utils/schemaOrg/anvilDataset.ts
+++ b/app/utils/schemaOrg/anvilDataset.ts
@@ -1,0 +1,113 @@
+import type { DatasetEntity } from "../../apis/azul/anvil-cmg/common/entities";
+import type { DatasetsResponse } from "../../apis/azul/anvil-cmg/common/responses";
+import type { SchemaDataset } from "./types";
+import { buildDescription, uniqueNonEmpty } from "./utils";
+
+const CATALOG_NAME = "AnVIL Data Explorer";
+const DESCRIPTION_FALLBACK_SUFFIX = `${CATALOG_NAME} dataset.`;
+const DBGAP_STUDY_URL =
+  "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=";
+
+/**
+ * Builds a Schema.org Dataset JSON-LD object for an AnVIL CMG dataset.
+ *
+ * Returns `undefined` when the response does not carry a dataset we can
+ * describe (i.e. no dataset entity), so the caller can skip rendering.
+ * @param data - AnVIL CMG dataset detail response from Azul.
+ * @param browserURL - Site base URL used for canonical and catalog URLs.
+ * @returns Schema.org Dataset JSON-LD object, or `undefined` if not buildable.
+ */
+export function buildAnvilDatasetJsonLd(
+  data: DatasetsResponse,
+  browserURL: string
+): SchemaDataset | undefined {
+  const dataset = data.datasets?.[0];
+  if (!dataset) return undefined;
+
+  const name = dataset.title || dataset.dataset_id;
+  const description = buildDescription(
+    dataset.description || "",
+    name,
+    DESCRIPTION_FALLBACK_SUFFIX
+  );
+  const identifier = uniqueNonEmpty([
+    dataset.dataset_id,
+    ...dataset.registered_identifier,
+  ]);
+
+  const jsonLd: SchemaDataset = {
+    "@context": "https://schema.org",
+    "@type": "Dataset",
+    description,
+    identifier,
+    includedInDataCatalog: {
+      "@type": "DataCatalog",
+      name: CATALOG_NAME,
+      url: browserURL,
+    },
+    // Google's `isAccessibleForFree` is the inverse of "paid", not "unrestricted" — dbGaP gating doesn't change the value.
+    isAccessibleForFree: true,
+    name,
+    url: `${browserURL}/datasets/${dataset.dataset_id}`,
+  };
+
+  const sameAs = buildSameAs(dataset);
+  if (sameAs.length > 0) jsonLd.sameAs = sameAs;
+
+  const keywords = buildKeywords(data);
+  if (keywords.length > 0) jsonLd.keywords = keywords;
+
+  return jsonLd;
+}
+
+/**
+ * Builds a keywords array by unioning biologically-meaningful fields from the
+ * dataset's aggregated activity/biosample/donor/file/library/diagnosis
+ * responses.
+ * @param data - AnVIL CMG dataset detail response.
+ * @returns Deduplicated keywords array.
+ */
+function buildKeywords(data: DatasetsResponse): string[] {
+  const values: (string | null | undefined)[] = [];
+  for (const activity of data.activities ?? []) {
+    values.push(...(activity.activity_type ?? []));
+    values.push(...(activity.data_modality ?? []));
+  }
+  for (const biosample of data.biosamples ?? []) {
+    values.push(...(biosample.anatomical_site ?? []));
+    values.push(...(biosample.biosample_type ?? []));
+  }
+  for (const donor of data.donors ?? []) {
+    values.push(...(donor.organism_type ?? []));
+    values.push(...(donor.phenotypic_sex ?? []));
+    values.push(...(donor.reported_ethnicity ?? []));
+  }
+  for (const diagnosis of data.diagnoses ?? []) {
+    values.push(...(diagnosis.disease ?? []));
+  }
+  for (const file of data.files ?? []) {
+    values.push(...(file.data_modality ?? []));
+    values.push(...(file.file_format ?? []));
+  }
+  for (const library of data.libraries ?? []) {
+    values.push(...(library.prep_material_name ?? []));
+  }
+  return uniqueNonEmpty(values);
+}
+
+/**
+ * Builds the sameAs array of external accession URLs. AnVIL datasets reference
+ * dbGaP study pages via their `registered_identifier` (phs accessions).
+ * @param dataset - AnVIL dataset entity.
+ * @returns Array of canonical dbGaP study URLs.
+ */
+function buildSameAs(dataset: DatasetEntity): string[] {
+  const urls: string[] = [];
+  for (const id of dataset.registered_identifier) {
+    if (!id) continue;
+    const trimmed = id.trim();
+    if (!trimmed) continue;
+    urls.push(`${DBGAP_STUDY_URL}${trimmed}`);
+  }
+  return uniqueNonEmpty(urls);
+}

--- a/app/utils/schemaOrg/anvilDataset.ts
+++ b/app/utils/schemaOrg/anvilDataset.ts
@@ -1,4 +1,3 @@
-import type { DatasetEntity } from "../../apis/azul/anvil-cmg/common/entities";
 import type { DatasetsResponse } from "../../apis/azul/anvil-cmg/common/responses";
 import { MAX_KEYWORDS } from "./constants";
 import type { SchemaDataset } from "./types";
@@ -6,12 +5,6 @@ import { buildDescription, uniqueNonEmpty } from "./utils";
 
 const CATALOG_NAME = "AnVIL Data Explorer";
 const DESCRIPTION_FALLBACK_SUFFIX = `A genomic dataset in the ${CATALOG_NAME} catalog.`;
-const DBGAP_STUDY_URL =
-  "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=";
-// dbGaP study accession format (e.g. "phs001234"). We validate against this
-// before constructing identifiers.org / dbGaP study URLs so a non-dbGaP value
-// in `registered_identifier` doesn't produce a malformed link.
-const DBGAP_ACCESSION_PATTERN = /^phs\d+/;
 
 /**
  * Builds a Schema.org Dataset JSON-LD object for an AnVIL CMG dataset.
@@ -56,9 +49,6 @@ export function buildAnvilDatasetJsonLd(
     url: `${browserURL}/datasets/${dataset.dataset_id}`,
   };
 
-  const sameAs = buildSameAs(dataset);
-  if (sameAs.length > 0) jsonLd.sameAs = sameAs;
-
   const keywords = buildKeywords(data);
   if (keywords.length > 0) jsonLd.keywords = keywords;
 
@@ -98,21 +88,4 @@ function buildKeywords(data: DatasetsResponse): string[] {
     values.push(...(library.prep_material_name ?? []));
   }
   return uniqueNonEmpty(values).slice(0, MAX_KEYWORDS);
-}
-
-/**
- * Builds the sameAs array of external accession URLs. AnVIL datasets reference
- * dbGaP study pages via their `registered_identifier` (phs accessions).
- * @param dataset - AnVIL dataset entity.
- * @returns Array of canonical dbGaP study URLs.
- */
-function buildSameAs(dataset: DatasetEntity): string[] {
-  const urls: string[] = [];
-  for (const id of dataset.registered_identifier) {
-    if (!id) continue;
-    const trimmed = id.trim();
-    if (!DBGAP_ACCESSION_PATTERN.test(trimmed)) continue;
-    urls.push(`${DBGAP_STUDY_URL}${trimmed}`);
-  }
-  return uniqueNonEmpty(urls);
 }

--- a/app/utils/schemaOrg/anvilDataset.ts
+++ b/app/utils/schemaOrg/anvilDataset.ts
@@ -5,7 +5,7 @@ import type { SchemaDataset } from "./types";
 import { buildDescription, uniqueNonEmpty } from "./utils";
 
 const CATALOG_NAME = "AnVIL Data Explorer";
-const DESCRIPTION_FALLBACK_SUFFIX = `${CATALOG_NAME} dataset.`;
+const DESCRIPTION_FALLBACK_SUFFIX = `A genomic dataset in the ${CATALOG_NAME} catalog.`;
 const DBGAP_STUDY_URL =
   "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=";
 // dbGaP study accession format (e.g. "phs001234"). We validate against this

--- a/app/utils/schemaOrg/constants.ts
+++ b/app/utils/schemaOrg/constants.ts
@@ -12,3 +12,10 @@ export const DESCRIPTION_LENGTH = {
   MAX: 5000,
   MIN: 50,
 } as const;
+
+/**
+ * Cap on the number of entries surfaced in array-valued Dataset fields
+ * (keywords, citations, etc.) to keep JSON-LD payload size predictable.
+ * Mirrors NCPI's reference implementation, which caps citations at 5.
+ */
+export const MAX_KEYWORDS = 20;

--- a/app/utils/schemaOrg/hcaProjectDataset.ts
+++ b/app/utils/schemaOrg/hcaProjectDataset.ts
@@ -6,16 +6,16 @@ import type {
 import type { ProjectsResponse } from "../../apis/azul/hca-dcp/common/responses";
 import { transformAccessionURL } from "../../viewModelBuilders/azul/hca-dcp/common/accessionMapper/accessionMapper";
 import { ACCESSION_CONFIGS_BY_RESPONSE_KEY } from "../../viewModelBuilders/azul/hca-dcp/common/accessionMapper/constants";
-import { DESCRIPTION_LENGTH } from "./constants";
 import type {
   SchemaDataset,
   SchemaOrganization,
   SchemaPerson,
   SchemaScholarlyArticle,
 } from "./types";
-import { stripHtmlTags, truncateDescription, uniqueNonEmpty } from "./utils";
+import { buildDescription, uniqueNonEmpty } from "./utils";
 
 const CATALOG_NAME = "Human Cell Atlas Data Coordination Platform";
+const DESCRIPTION_FALLBACK_SUFFIX = `${CATALOG_NAME} project.`;
 
 /**
  * Builds the citation array from project publications. Skips entries without a
@@ -42,27 +42,6 @@ function buildCitations(
     citations.push(article);
   }
   return citations;
-}
-
-/**
- * Builds the Schema.org description for a project, padding short or empty
- * source descriptions with the project name and catalog context so the result
- * satisfies Google's minimum description-length requirement (50 chars).
- * @param sourceDescription - Raw projectDescription from the Azul response.
- * @param name - Project name used as a padding fallback.
- * @returns HTML-stripped description, padded if short, truncated if long.
- */
-function buildDescription(sourceDescription: string, name: string): string {
-  const stripped = stripHtmlTags(sourceDescription || "");
-  if (stripped.length >= DESCRIPTION_LENGTH.MIN) {
-    return truncateDescription(stripped);
-  }
-  // Padding includes the catalog name (~43 chars) to reliably push the
-  // result past the 50-char minimum even when name + stripped are short.
-  const padded = stripped
-    ? `${name} — ${stripped} — ${CATALOG_NAME} project.`
-    : `${name} — ${CATALOG_NAME} project.`;
-  return truncateDescription(padded);
 }
 
 /**
@@ -108,7 +87,11 @@ export function buildHcaProjectJsonLd(
   if (!project) return undefined;
 
   const name = project.projectTitle || project.projectShortname;
-  const description = buildDescription(project.projectDescription, name);
+  const description = buildDescription(
+    project.projectDescription,
+    name,
+    DESCRIPTION_FALLBACK_SUFFIX
+  );
   const identifier = uniqueNonEmpty([
     project.projectId,
     ...project.accessions.flatMap((accession) =>

--- a/app/utils/schemaOrg/hcaProjectDataset.ts
+++ b/app/utils/schemaOrg/hcaProjectDataset.ts
@@ -6,6 +6,7 @@ import type {
 import type { ProjectsResponse } from "../../apis/azul/hca-dcp/common/responses";
 import { transformAccessionURL } from "../../viewModelBuilders/azul/hca-dcp/common/accessionMapper/accessionMapper";
 import { ACCESSION_CONFIGS_BY_RESPONSE_KEY } from "../../viewModelBuilders/azul/hca-dcp/common/accessionMapper/constants";
+import { MAX_KEYWORDS } from "./constants";
 import type {
   SchemaDataset,
   SchemaOrganization,
@@ -156,7 +157,7 @@ function buildKeywords(data: ProjectsResponse): string[] {
     values.push(...(protocol.libraryConstructionApproach ?? []));
     values.push(...(protocol.instrumentManufacturerModel ?? []));
   }
-  return uniqueNonEmpty(values);
+  return uniqueNonEmpty(values).slice(0, MAX_KEYWORDS);
 }
 
 /**

--- a/app/utils/schemaOrg/utils.ts
+++ b/app/utils/schemaOrg/utils.ts
@@ -1,6 +1,33 @@
 import { DESCRIPTION_LENGTH } from "./constants";
 
 /**
+ * Builds a Schema.org description string from a raw entity description, padding
+ * short or empty values with the entity name and a caller-supplied fallback
+ * suffix so the result satisfies Google's minimum description-length
+ * requirement (50 chars).
+ * @param sourceDescription - Raw description (may contain HTML, may be empty).
+ * @param name - Entity name used in the padded fallback.
+ * @param fallbackSuffix - Caller-owned suffix (e.g. catalog + entity kind) used
+ * to reliably push padded descriptions past the 50-character minimum. The
+ * caller controls phrasing and punctuation; the helper does not add a period.
+ * @returns HTML-stripped description, padded when short, truncated when long.
+ */
+export function buildDescription(
+  sourceDescription: string,
+  name: string,
+  fallbackSuffix: string
+): string {
+  const stripped = stripHtmlTags(sourceDescription || "");
+  if (stripped.length >= DESCRIPTION_LENGTH.MIN) {
+    return truncateDescription(stripped);
+  }
+  const padded = stripped
+    ? `${name} — ${stripped} — ${fallbackSuffix}`
+    : `${name} — ${fallbackSuffix}`;
+  return truncateDescription(padded);
+}
+
+/**
  * Escapes a JSON string for safe embedding inside an HTML `<script>` tag.
  * Prevents script-context breakout via `</script>` or HTML entity injection.
  * @param json - Serialised JSON to embed.

--- a/pages/[entityListType]/[...params].tsx
+++ b/pages/[entityListType]/[...params].tsx
@@ -30,17 +30,18 @@ import { useRouter } from "next/router";
 import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";
 import { EntityGuard } from "../../app/components/Detail/components/EntityGuard/entityGuard";
+import { buildAnvilDatasetJsonLd } from "../../app/utils/schemaOrg/anvilDataset";
 import { buildHcaProjectJsonLd } from "../../app/utils/schemaOrg/hcaProjectDataset";
+import type { SchemaDataset } from "../../app/utils/schemaOrg/types";
 import { readFile } from "../../app/utils/tsvParser";
 import { JsonLd } from "../../app/views/EntityDetailView/components/JsonLd/jsonLd";
 import { ROUTES } from "../../site-config/anvil-cmg/dev/export/routes";
 
-import { DatasetsResponse } from "../../app/apis/azul/anvil-cmg/common/responses";
+import type { DatasetsResponse } from "../../app/apis/azul/anvil-cmg/common/responses";
 import {
   getConsentGroup,
   isNRESOrUnrestrictedAccess,
 } from "../../app/apis/azul/anvil-cmg/common/transformers";
-import type { ProjectsResponse } from "../../app/apis/azul/hca-dcp/common/responses";
 import { isProductionEnvironment } from "../../app/config/utils";
 
 const setOfProcessedIds = new Set<string>();
@@ -90,7 +91,8 @@ const EntityDetailPage = (props: EntityDetailPageProps): JSX.Element => {
   if (isExportMethodView(query)) return <EntityExportMethodView {...props} />;
   return (
     <>
-      {isHcaDcp && renderHcaProjectJsonLd(props)}
+      {isAnVIL && renderJsonLd(props, "datasets", buildAnvilDatasetJsonLd)}
+      {isHcaDcp && renderJsonLd(props, "projects", buildHcaProjectJsonLd)}
       <EntityDetailView {...props} />
     </>
   );
@@ -574,19 +576,21 @@ async function processEntityProps(
 }
 
 /**
- * Renders the HCA project JSON-LD when the page is a project detail route with
- * data and a browser URL available. Returns null otherwise.
+ * Renders a consumer-specific Schema.org Dataset JSON-LD script when the page
+ * matches the given entity list type and carries the data needed by the
+ * builder. Returns null otherwise.
  * @param props - Entity detail page props.
+ * @param entityListType - The entity list type this builder applies to.
+ * @param build - Consumer-specific builder that maps detail data to a Dataset.
  * @returns JsonLd element, or null when the page can't be described.
  */
-function renderHcaProjectJsonLd(
-  props: EntityDetailPageProps
+function renderJsonLd<T>(
+  props: EntityDetailPageProps,
+  entityListType: string,
+  build: (data: T, browserURL: string) => SchemaDataset | undefined
 ): JSX.Element | null {
-  if (props.entityListType !== "projects") return null;
+  if (props.entityListType !== entityListType) return null;
   if (!props.browserURL || !props.data) return null;
-  const jsonLd = buildHcaProjectJsonLd(
-    props.data as ProjectsResponse,
-    props.browserURL
-  );
+  const jsonLd = build(props.data as T, props.browserURL);
   return jsonLd ? <JsonLd jsonLd={jsonLd} /> : null;
 }

--- a/pages/[entityListType]/[...params].tsx
+++ b/pages/[entityListType]/[...params].tsx
@@ -71,10 +71,15 @@ export interface EntityDetailPageProps extends AzulEntityStaticResponse {
  * @param props.entityListType - Entity list type.
  * @returns Entity detail view component.
  */
+// Exact appTitle match — substring detection would also hit "AnVIL Dataset
+// Catalog", which shares the "AnVIL" prefix but has a different entity shape.
+const APP_TITLE_ANVIL_CMG = "AnVIL Data Explorer";
+const APP_TITLE_HCA_DCP = "HCA Data Explorer";
+
 const EntityDetailPage = (props: EntityDetailPageProps): JSX.Element => {
   const { config: siteConfig } = useConfig();
-  const isAnVIL = siteConfig.appTitle?.includes("AnVIL");
-  const isHcaDcp = siteConfig.appTitle?.includes("HCA");
+  const isAnVIL = siteConfig.appTitle === APP_TITLE_ANVIL_CMG;
+  const isHcaDcp = siteConfig.appTitle === APP_TITLE_HCA_DCP;
   const { query } = useRouter();
   if (!props.entityListType) return <></>;
   if (props.override) return <EntityGuard override={props.override} />;


### PR DESCRIPTION
## Summary

Adds Schema.org Dataset JSON-LD to AnVIL CMG dataset detail pages so Google Dataset Search can index them. Mirrors the HCA pattern from #4806 — same shared `JsonLd` component, same shared `buildDescription`/`escapeJsonForHtml`/`stripHtmlTags`/`truncateDescription`/`uniqueNonEmpty` helpers, same `<JsonLd>` mount path.

**New files:**
- `app/utils/schemaOrg/anvilDataset.ts` — `buildAnvilDatasetJsonLd(data, browserURL)` for AnVIL `DatasetsResponse`.
- `__tests__/utils/schemaOrg/anvilDataset.test.ts` — 11 unit tests.

**Modified:**
- `app/utils/schemaOrg/utils.ts` — generalised `buildDescription` (was local to `hcaProjectDataset.ts`) so HCA + AnVIL + future LungMAP can all reuse it. Takes a caller-owned `fallbackSuffix` so each consumer controls its own padding phrasing.
- `app/utils/schemaOrg/hcaProjectDataset.ts` — uses the shared `buildDescription` instead of declaring locally. Net `-31/+5` lines.
- `pages/[entityListType]/[...params].tsx` — unified `renderJsonLd<T>(props, entityListType, build)` generic helper replaces the per-consumer `renderHcaProjectJsonLd` / `renderAnvilDatasetJsonLd`. Mount path is now `{isAnVIL && renderJsonLd(props, "datasets", buildAnvilDatasetJsonLd)}` and `{isHcaDcp && renderJsonLd(props, "projects", buildHcaProjectJsonLd)}`. #4808 (LungMAP) drops in as a one-liner on top.

Closes #4807. Stacked on #4829 (the HCA PR). Once #4829 merges, rebase this PR's base to `main`.

## Ticket scope audit (MVP)

| Field | Status |
|--|--|
| `name`, `description` (required) | ✅ implemented |
| `identifier`, `url`, `sameAs`, `includedInDataCatalog`, `isAccessibleForFree`, `keywords` | ✅ implemented |
| `creator` | ⏸ no `consortium` field on `DatasetEntity`; deferred |
| `funder`, `license`, `distribution`, `variableMeasured` | ⏸ explicitly TBD in issue |
| `measurementTechnique` | ❌ MVP gap (parity with HCA PR) |

`sameAs` URLs go to dbGaP (`https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=<phs>`) — AnVIL's only external reference type, no identifiers.org mapping needed. `isAccessibleForFree: true` for all AnVIL datasets per Google's spec (the flag is the inverse of "paid", not "unrestricted access"; dbGaP gating doesn't make a dataset "paid").

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint`, `npm run check-format` pass
- [x] `npx jest __tests__/utils/schemaOrg` — 25/25 tests pass (14 HCA + 11 AnVIL)
- [x] `npm run build:anvil-cmg` succeeds; **375/422 dataset detail pages emit JSON-LD** (47 omissions are sub-tab/export routes where `processEntityProps` short-circuits — same gating as HCA's project pages)
- [x] `npm run build-ma-dev:hca-dcp` — HCA still emits JSON-LD (110/116 project pages)
- [x] `npm run build-dev:lungmap`, `npm run build-dev:anvil-catalog` — clean builds, no JSON-LD (correctly gated)
- [ ] Validate output against [Google's Rich Results Test](https://search.google.com/test/rich-results) and [Schema Markup Validator](https://validator.schema.org/) for representative datasets (open access, controlled access, multi-consortium) after deploy
- [ ] Request indexing via Google Search Console post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)