### PR TITLE
feat: replace file download lists with counts in static analytics pages

### DIFF
--- a/analytics/analytics_package/analytics/static_site/export.py
+++ b/analytics/analytics_package/analytics/static_site/export.py
@@ -116,10 +116,10 @@ def export_data(data, config, current_month, analytics_start, custom_events, out
 
     # File downloads
     print("Exporting file downloads data...")
-    file_downloads = data.get("file_downloads", [])
+    file_downloads = data.get("file_downloads", 0)
     with open(os.path.join(output_dir, "file_downloads.json"), "w") as f:
-        json.dump(file_downloads, f, indent=2)
-    print(f"  Wrote file_downloads.json ({len(file_downloads)} records)")
+        json.dump({"total": file_downloads}, f, indent=2)
+    print(f"  Wrote file_downloads.json (total: {file_downloads})")
 
     # Access requests
     print("Exporting access requests data...")
@@ -130,10 +130,10 @@ def export_data(data, config, current_month, analytics_start, custom_events, out
 
     # File download events (GA4 enhanced measurement)
     print("Exporting file download events data...")
-    file_download_events = data.get("file_download_events", {"total": 0, "files": []})
+    file_download_events = data.get("file_download_events", 0)
     with open(os.path.join(output_dir, "file_download_events.json"), "w") as f:
-        json.dump(file_download_events, f, indent=2)
-    print(f"  Wrote file_download_events.json ({len(file_download_events.get('files', []))} files)")
+        json.dump({"total": file_download_events}, f, indent=2)
+    print(f"  Wrote file_download_events.json (total: {file_download_events})")
 
     # Search queries
     print("Exporting search queries data...")

--- a/analytics/analytics_package/analytics/static_site/fetch.py
+++ b/analytics/analytics_package/analytics/static_site/fetch.py
@@ -6,8 +6,6 @@ from urllib.parse import urlparse, parse_qs
 from .. import sheets_elements as elements
 from .._sheets_utils import get_data_df_from_fields
 from ..entities import (
-    DIMENSION_BUILTIN_URL,
-    DIMENSION_FILE_NAME,
     METRIC_EVENT_COUNT,
     METRIC_PAGE_VIEWS,
     METRIC_SESSIONS,
@@ -16,8 +14,6 @@ from ..entities import (
     DIMENSION_PAGE_PATH_PLUS_QUERY,
     DIMENSION_CUSTOM_URL,
     DIMENSION_ENTITY_NAME,
-    DIMENSION_RELATED_ENTITY_ID,
-    DIMENSION_RELATED_ENTITY_NAME,
 )
 
 METRIC_ENGAGEMENT_RATE = {
@@ -113,21 +109,17 @@ def get_event_detail_table(event_name, params, page_path_regex=None):
 
 
 def get_file_downloads(params):
-    """Fetch file_downloaded events with entity name and related entity name.
+    """Fetch file_downloaded event count.
 
     Returns:
-        List of dicts with "entity_name", "dataset_id", "related_entity_name",
-        and "count" keys.
+        Total count of file_downloaded events (int).
     """
     df = elements.get_index_table_download_df(params)
 
     if len(df) == 0:
-        return []
+        return 0
 
-    result = df[[DIMENSION_ENTITY_NAME["alias"], DIMENSION_RELATED_ENTITY_ID["alias"], DIMENSION_RELATED_ENTITY_NAME["alias"], METRIC_EVENT_COUNT["alias"]]].copy()
-    result.columns = ["entity_name", "dataset_id", "related_entity_name", "count"]
-    result = result.sort_values("count", ascending=False)
-    return result.to_dict(orient="records")
+    return int(df[METRIC_EVENT_COUNT["alias"]].sum())
 
 
 def get_access_requests(params, url_patterns):
@@ -167,28 +159,22 @@ def get_access_requests(params, url_patterns):
 
 
 def get_file_download_events(params):
-    """Fetch GA4 enhanced measurement file_download events.
+    """Fetch GA4 enhanced measurement file_download event count.
 
     Returns:
-        Dict with "total" (int) and "files" (list of dicts with "file_name", "link_url", "count").
+        Total count of file_download events (int).
     """
     df = get_data_df_from_fields(
         [METRIC_EVENT_COUNT],
-        [DIMENSION_EVENT_NAME, DIMENSION_FILE_NAME, DIMENSION_BUILTIN_URL],
+        [DIMENSION_EVENT_NAME],
         dimension_filter="eventName==file_download",
         **params,
     )
 
     if len(df) == 0:
-        return {"total": 0, "files": []}
+        return 0
 
-    result = df[[DIMENSION_FILE_NAME["alias"], DIMENSION_BUILTIN_URL["alias"], METRIC_EVENT_COUNT["alias"]]].copy()
-    result.columns = ["file_name", "link_url", "count"]
-    result["count"] = result["count"].astype(int)
-    total = int(result["count"].sum())
-    result = result.sort_values("count", ascending=False)
-
-    return {"total": total, "files": result.to_dict(orient="records")}
+    return int(df[METRIC_EVENT_COUNT["alias"]].sum())
 
 
 def get_search_queries(params, search_path="/search"):
@@ -324,7 +310,7 @@ def fetch_data(
         file_downloads = get_file_downloads(params)
     except Exception as e:
         print(f"  Skipped (not available for this property): {e}")
-        file_downloads = []
+        file_downloads = 0
 
     access_requests = []
     if access_request_urls:
@@ -336,7 +322,7 @@ def fetch_data(
         file_download_events = get_file_download_events(params)
     except Exception as e:
         print(f"  Skipped (not available for this property): {e}")
-        file_download_events = {"total": 0, "files": []}
+        file_download_events = 0
 
     search_queries = {"total": 0, "queries": []}
     if search_path:

--- a/analytics/analytics_package/analytics/static_site/template/index.html
+++ b/analytics/analytics_package/analytics/static_site/template/index.html
@@ -764,7 +764,7 @@
         }
 
         function renderFileDownloadEvents(data) {
-            if (!data || !data.total) return;
+            if (!data || data.total == null) return;
             const section = document.getElementById('resources-section');
             section.style.display = '';
             document.getElementById('file-download-events-count').textContent = formatNumber(data.total);
@@ -786,7 +786,7 @@
 
         function renderFileDownloadsTable(downloads) {
             const card = document.getElementById('file-downloads-card');
-            if (!downloads || !downloads.total) {
+            if (!downloads || downloads.total == null) {
                 return;
             }
             card.style.display = '';

--- a/analytics/analytics_package/analytics/static_site/template/index.html
+++ b/analytics/analytics_package/analytics/static_site/template/index.html
@@ -208,25 +208,14 @@
         <div class="fui-grid-12" id="event-stats-grid"></div>
         <div id="event-detail-tables"></div>
 
-        <div class="fui-card" id="file-downloads-card" style="display: none;">
+        <div class="fui-card fui-grid-item-3" id="file-downloads-card" style="display: none;">
             <div class="fui-card-header">
                 <h3 class="fui-card-header-title fui-heading-xsmall">Direct File Downloads</h3>
             </div>
             <hr class="fui-divider" />
-            <div class="fui-card-content" style="overflow-x: auto;">
-                <table id="file-downloads-table" class="collapsible-table">
-                    <thead>
-                        <tr>
-                            <th>File</th>
-                            <th>Dataset</th>
-                            <th class="col-number">Count</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr><td colspan="3" class="fui-color-ink-light">Loading...</td></tr>
-                    </tbody>
-                </table>
-                <button class="toggle-rows" id="file-downloads-toggle" style="display: none;" onclick="toggleTable(this)">Show all</button>
+            <div class="fui-card-content" style="text-align: center;">
+                <div class="stat-value" id="file-downloads-count">0</div>
+                <div class="stat-label">Total Downloads</div>
             </div>
         </div>
 
@@ -324,23 +313,16 @@
 
         <div id="resources-section" style="display: none;">
             <h2 class="fui-heading-small">Resources</h2>
-            <div class="fui-card">
-                <div class="fui-card-header">
-                    <h3 class="fui-card-header-title fui-heading-xsmall">File Downloads <span id="file-downloads-total-label" class="fui-color-ink-light"></span></h3>
-                </div>
-                <hr class="fui-divider" />
-                <div class="fui-card-content" style="overflow-x: auto;">
-                    <table id="file-download-events-table">
-                        <thead>
-                            <tr>
-                                <th>File</th>
-                                <th class="col-number">Count</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr><td colspan="2" class="fui-color-ink-light">Loading...</td></tr>
-                        </tbody>
-                    </table>
+            <div class="fui-grid-12">
+                <div class="fui-card fui-grid-item-3">
+                    <div class="fui-card-header">
+                        <h3 class="fui-card-header-title fui-heading-xsmall">File Downloads</h3>
+                    </div>
+                    <hr class="fui-divider" />
+                    <div class="fui-card-content" style="text-align: center;">
+                        <div class="stat-value" id="file-download-events-count">0</div>
+                        <div class="stat-label">Total Downloads</div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -653,7 +635,7 @@
                 if (fileDownloadsPos != null) {
                     const fileCard = document.getElementById('file-downloads-card');
                     if (fileCard && fileCard.style.display !== 'none') {
-                        fileCard.classList.add('fui-grid-item-12');
+                        fileCard.classList.add('fui-grid-item-3');
                         const pos = Math.min(fileDownloadsPos, detailCards.length);
                         detailCards.splice(pos, 0, fileCard.outerHTML);
                         fileCard.remove();
@@ -782,17 +764,10 @@
         }
 
         function renderFileDownloadEvents(data) {
-            if (!data || !data.files || data.files.length === 0) return;
+            if (!data || !data.total) return;
             const section = document.getElementById('resources-section');
             section.style.display = '';
-            document.getElementById('file-downloads-total-label').textContent = `(${formatNumber(data.total)})`;
-            const tbody = document.querySelector('#file-download-events-table tbody');
-            tbody.innerHTML = data.files.map(row => `
-                <tr>
-                    <td>${escapeHtml(row.file_name)}</td>
-                    <td class="col-number">${formatNumber(row.count)}</td>
-                </tr>
-            `).join('');
+            document.getElementById('file-download-events-count').textContent = formatNumber(data.total);
         }
 
         function renderSearchQueries(data) {
@@ -811,32 +786,11 @@
 
         function renderFileDownloadsTable(downloads) {
             const card = document.getElementById('file-downloads-card');
-            const tbody = document.querySelector('#file-downloads-table tbody');
-            if (!downloads || downloads.length === 0) {
+            if (!downloads || !downloads.total) {
                 return;
             }
             card.style.display = '';
-            const total = downloads.reduce((sum, r) => sum + (r.count || 0), 0);
-            card.querySelector('.fui-card-header-title').textContent = `Direct File Downloads (${formatNumber(total)})`;
-            const toggle = document.getElementById('file-downloads-toggle');
-            if (downloads.length > 5) {
-                toggle.style.display = '';
-                toggle.textContent = `Show all ${downloads.length} rows`;
-            }
-            tbody.innerHTML = downloads.map(row => {
-                const entityName = row.entity_name && row.entity_name !== '(not set)' ? row.entity_name : '-';
-                const datasetName = row.related_entity_name && row.related_entity_name !== '(not set)' ? row.related_entity_name : '-';
-                const datasetCell = row.dataset_id && datasetName !== '-'
-                    ? `<a href="${safeHref(siteBase + entityPath + '/' + row.dataset_id)}" target="_blank" rel="noopener noreferrer">${escapeHtml(datasetName)}</a>`
-                    : escapeHtml(datasetName);
-                return `
-                    <tr>
-                        <td>${escapeHtml(entityName)}</td>
-                        <td>${datasetCell}</td>
-                        <td class="col-number">${formatNumber(row.count || 0)}</td>
-                    </tr>
-                `;
-            }).join('');
+            document.getElementById('file-downloads-count').textContent = formatNumber(downloads.total);
         }
 
         async function renderAccessRequestsTable() {


### PR DESCRIPTION
## Ticket
Closes #4833

## Summary
- Replace individual file name/path listings in static analytics pages with aggregate download counts
- Applies to both "Direct File Downloads" (custom `file_downloaded` events) and "File Downloads" (GA4 enhanced measurement `file_download` events)
- Simplifies data fetching to return counts only, removing per-file detail from exported JSON

## Test plan
- [x] Regenerated and verified HCA static site locally
- [x] Regenerated and verified LungMAP static site locally
- [x] Regenerated and verified AnVIL Explorer static site locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)