### PR TITLE
fix: flaky download file manifest e2e — wait for nav (#4828)

### DIFF
--- a/e2e/anvil/anvil-dataset.spec.ts
+++ b/e2e/anvil/anvil-dataset.spec.ts
@@ -107,6 +107,13 @@ describe("Dataset", () => {
     // Confirm file manifest export method is visible and click it.
     await clickCard(page, TITLE_TEXT_REQUEST_FILE_MANIFEST);
 
+    // Wait for navigation to the manifest page before asserting the button —
+    // without this, the destination-page locator can poll an unmounted page
+    // for 15s and fail with "0 elements" even though the click succeeded.
+    await page.waitForURL((url) =>
+      url.pathname.endsWith(ROUTES.MANIFEST_DOWNLOAD)
+    );
+
     // Confirm the file manifest page is loaded: check there is one button to request the manifest.
     const buttons = page.locator(`${MUI_CLASSES.BUTTON}`, {
       hasText: BUTTON_TEXT_REQUEST_LINK,
@@ -145,6 +152,11 @@ describe("Dataset", () => {
 
     // Confirm Terra export method is visible and click it.
     await clickCard(page, TITLE_TEXT_ANALYZE_IN_TERRA);
+
+    // Wait for navigation to the Terra page before asserting the form — same
+    // defence as the manifest test above; the locator can otherwise poll an
+    // unmounted page for 15s and fail even though the click succeeded.
+    await page.waitForURL((url) => url.pathname.endsWith(ROUTES.TERRA));
 
     // Confirm the analyze in Terra page is loaded: check for form elements.
     await expect(page.locator(MUI_CLASSES.FORM_CONTROL).first()).toBeVisible();


### PR DESCRIPTION
## Summary

Adds an explicit `waitForURL` between `clickCard` and the destination-page assertion in two Dataset e2e tests:

- `displays download file manifest` — the test cited in the CI failure. Click navigated to `/datasets/{id}/export/download-manifest`, but the assertion on `.MuiButton-root:has-text("Request Link")` polled an unmounted page and timed out with `18 × locator resolved to 0 elements`.
- `displays analyze in Terra` — same shape (clickCard → destination-page UI assertion, no wait), so applied the same defence preemptively.

The other `clickCard` sites in the spec (`displays download file manifest selected data`, `displays analyze in Terra selected data`) are already navigation-aware via `Promise.all([waitForRequest, clickCard])`.

Inline regex was avoided — `ROUTES.MANIFEST_DOWNLOAD` and `ROUTES.TERRA` are already imported, so the wait uses a predicate (`url.pathname.endsWith(ROUTES.X)`) for clarity and DRY.

Closes #4828.

## Test plan

- [x] `npx tsc --noEmit`, `npm run check-format` pass
- [x] `npm run test:anvil-cmg` — full anvil suite, 114/114 across chromium/firefox/webkit (2.6 min)
- [ ] Watch CI over the next several runs to confirm the Firefox flake is gone

## Out of scope

A broader rewrite of `anvil-dataset.spec.ts` (test-id-based locators, role-based queries, `dispatchEvent` for click-swallowing, helper layout convention from `anvil-filters.spec.ts`) was considered and deferred — the spec is otherwise stable and the structure isn't itself flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)