### PR TITLE
fix: anvil-dataset e2e times out on firefox (#4840)

### DIFF
--- a/e2e/anvil/anvil-dataset.spec.ts
+++ b/e2e/anvil/anvil-dataset.spec.ts
@@ -104,15 +104,13 @@ describe("Dataset", () => {
     // Confirm export button is visible and click it.
     await clickLink(page, BUTTON_TEXT_EXPORT);
 
-    // Confirm file manifest export method is visible and click it.
-    await clickCard(page, TITLE_TEXT_REQUEST_FILE_MANIFEST);
-
-    // Wait for navigation to the manifest page before asserting the button —
-    // without this, the destination-page locator can poll an unmounted page
-    // for 15s and fail with "0 elements" even though the click succeeded.
-    await page.waitForURL((url) =>
-      url.pathname.endsWith(ROUTES.MANIFEST_DOWNLOAD)
-    );
+    // Click the file manifest card and wait for navigation in a single race —
+    // attaching the URL listener before the click avoids a Firefox-only flake
+    // where the SPA navigation completes before the listener can register.
+    await Promise.all([
+      page.waitForURL((url) => url.pathname.endsWith(ROUTES.MANIFEST_DOWNLOAD)),
+      clickCard(page, TITLE_TEXT_REQUEST_FILE_MANIFEST),
+    ]);
 
     // Confirm the file manifest page is loaded: check there is one button to request the manifest.
     const buttons = page.locator(`${MUI_CLASSES.BUTTON}`, {
@@ -150,13 +148,14 @@ describe("Dataset", () => {
     // Confirm export button is visible and click it.
     await clickLink(page, BUTTON_TEXT_EXPORT);
 
-    // Confirm Terra export method is visible and click it.
-    await clickCard(page, TITLE_TEXT_ANALYZE_IN_TERRA);
-
-    // Wait for navigation to the Terra page before asserting the form — same
-    // defence as the manifest test above; the locator can otherwise poll an
-    // unmounted page for 15s and fail even though the click succeeded.
-    await page.waitForURL((url) => url.pathname.endsWith(ROUTES.TERRA));
+    // Click the Terra card and wait for navigation in a single race — same
+    // defence as the manifest test above: attaching the URL listener before
+    // the click avoids a Firefox-only flake where the SPA navigation
+    // completes before the listener can register.
+    await Promise.all([
+      page.waitForURL((url) => url.pathname.endsWith(ROUTES.TERRA)),
+      clickCard(page, TITLE_TEXT_ANALYZE_IN_TERRA),
+    ]);
 
     // Confirm the analyze in Terra page is loaded: check for form elements.
     await expect(page.locator(MUI_CLASSES.FORM_CONTROL).first()).toBeVisible();


### PR DESCRIPTION
## Summary

Closes #4840.

The "Dataset > displays download file manifest" e2e test was timing out on Firefox at `page.waitForURL(...)`. The `page.waitForURL` listener was being attached **after** `clickCard` already resolved — on Firefox, the SPA navigation can complete in that window, so the listener never sees the URL change and the wait blocks until the 180s test timeout.

Wraps the click + URL wait in `Promise.all` so the listener attaches before the click — matching the existing pattern used by the sibling tests in the same file (lines 136-141, 172-177).

Applied to both affected tests:

- `displays download file manifest` (was line 108 + 113)
- `displays analyze in Terra` (was line 154 + 159 — same shape, same latent bug)

## Test plan

- [x] CI passes on Firefox, Chromium, WebKit.
- [x] Local: `npx playwright test e2e/anvil/anvil-dataset.spec.ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)