### PR TITLE
feat: add monthly trend charts for export events in static analytics

### DIFF
--- a/analytics/analytics_package/analytics/static_site/__init__.py
+++ b/analytics/analytics_package/analytics/static_site/__init__.py
@@ -1,4 +1,5 @@
+from .charts import make_event_charts
 from .generator import generate_site
 from .resolve import fetch_entity_title_map, enrich_detail_records
 
-__all__ = ["generate_site", "fetch_entity_title_map", "enrich_detail_records"]
+__all__ = ["generate_site", "fetch_entity_title_map", "enrich_detail_records", "make_event_charts"]

--- a/analytics/analytics_package/analytics/static_site/charts.py
+++ b/analytics/analytics_package/analytics/static_site/charts.py
@@ -1,0 +1,41 @@
+"""Shared chart configuration for static analytics sites."""
+
+
+def make_event_charts(entity_label, entity_path, chart_start):
+    """Build the standard event_charts config for a static analytics site.
+
+    Args:
+        entity_label: Display label for the entity type (e.g., "Dataset" or "Project").
+        entity_path: URL path segment for entities (e.g., "/datasets" or "/projects").
+        chart_start: Start date for chart data (YYYY-MM-DD).
+
+    Returns:
+        Dict with "chart_start" and "charts" keys, ready to pass to generate_site.
+    """
+    path_segment = entity_path.strip("/")
+    return {
+        "chart_start": chart_start,
+        "charts": [
+            {
+                "title": "Export to Terra",
+                "series": [
+                    {"label": f"Single {entity_label}", "event_key": "dataset_analyze_in_terra_requested", "event_name": "dataset_analyze_in_terra_requested"},
+                    {"label": "Cross-Dataset", "event_key": "index_analyze_in_terra_requested", "event_name": "index_analyze_in_terra_requested"},
+                ],
+            },
+            {
+                "title": "curl Command",
+                "series": [
+                    {"label": f"Single {entity_label}", "event_key": "dataset_bulk_download_requested", "event_name": "bulk_download_requested", "page_path_regex": rf"^/{path_segment}/[0-9a-f-]+"},
+                    {"label": "Cross-Dataset", "event_key": "index_bulk_download_requested", "event_name": "bulk_download_requested", "page_path_regex": rf"^(?!/{path_segment}/[0-9a-f-]+)"},
+                ],
+            },
+            {
+                "title": "File Manifest",
+                "series": [
+                    {"label": f"Single {entity_label}", "event_key": "dataset_file_manifest_requested", "event_name": "dataset_file_manifest_requested"},
+                    {"label": "Cross-Dataset", "event_key": "index_file_manifest_requested", "event_name": "index_file_manifest_requested"},
+                ],
+            },
+        ],
+    }

--- a/analytics/analytics_package/analytics/static_site/export.py
+++ b/analytics/analytics_package/analytics/static_site/export.py
@@ -55,7 +55,7 @@ def export_df_as_json(df, col_map, change_col, filename, output_dir):
     print(f"  Wrote {filename} ({len(records)} records)")
 
 
-def export_data(data, config, current_month, analytics_start, custom_events, output_dir):
+def export_data(data, config, current_month, analytics_start, custom_events, output_dir, event_charts=None):
     """Export all analytics data to JSON files.
 
     Args:
@@ -167,6 +167,32 @@ def export_data(data, config, current_month, analytics_start, custom_events, out
             with open(os.path.join(output_dir, filename), "w") as f:
                 json.dump(detail, f, indent=2)
             print(f"  Wrote {filename} ({len(detail)} records)")
+
+    # Event charts (monthly trend data)
+    if event_charts:
+        print("Exporting event chart data...")
+        chart_output = {
+            "chart_start": event_charts.get("chart_start", analytics_start),
+            "charts": [],
+        }
+        for chart in event_charts.get("charts", []):
+            chart_data = {
+                "title": chart["title"],
+                "series": [],
+            }
+            for series in chart.get("series", []):
+                key = series["event_key"]
+                monthly_counts = data.get(f"event_chart_{key}", [])
+                chart_data["series"].append({
+                    "label": series["label"],
+                    "event_key": key,
+                    "data": monthly_counts,
+                })
+            chart_output["charts"].append(chart_data)
+
+        with open(os.path.join(output_dir, "event_charts.json"), "w") as f:
+            json.dump(chart_output, f, indent=2)
+        print(f"  Wrote event_charts.json ({len(chart_output['charts'])} charts)")
 
     # Config (for the HTML template)
     print("Exporting site config...")

--- a/analytics/analytics_package/analytics/static_site/fetch.py
+++ b/analytics/analytics_package/analytics/static_site/fetch.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse, parse_qs
 from .. import sheets_elements as elements
 from .._sheets_utils import get_data_df_from_fields
 from ..entities import (
+    DIMENSION_YEAR_MONTH,
     METRIC_EVENT_COUNT,
     METRIC_PAGE_VIEWS,
     METRIC_SESSIONS,
@@ -214,12 +215,83 @@ def get_search_queries(params, search_path="/search"):
     return {"total": total, "queries": queries}
 
 
+def _generate_month_range(start_date, end_date):
+    """Generate a list of YYYY-MM strings covering the given date range."""
+    from datetime import datetime
+    start = datetime.strptime(start_date[:7], "%Y-%m")
+    end = datetime.strptime(end_date[:7], "%Y-%m")
+    months = []
+    current = start
+    while current <= end:
+        months.append(current.strftime("%Y-%m"))
+        if current.month == 12:
+            current = current.replace(year=current.year + 1, month=1)
+        else:
+            current = current.replace(month=current.month + 1)
+    return months
+
+
+def _monthly_counts_from_df(df, start_date, end_date, page_path_regex=None):
+    """Aggregate a DataFrame of event counts into monthly totals.
+
+    Args:
+        df: DataFrame with DIMENSION_YEAR_MONTH and METRIC_EVENT_COUNT columns.
+        start_date: Start date string (YYYY-MM-DD) for filling missing months.
+        end_date: End date string (YYYY-MM-DD) for filling missing months.
+        page_path_regex: Optional regex to filter by page path before aggregating.
+
+    Returns:
+        List of dicts with "month" (YYYY-MM) and "count" keys, sorted by month.
+    """
+    all_months = _generate_month_range(start_date, end_date)
+
+    if len(df) == 0:
+        return [{"month": m, "count": 0} for m in all_months]
+
+    if page_path_regex:
+        pattern = re.compile(page_path_regex)
+        df = df[df[DIMENSION_PAGE_PATH["alias"]].str.match(pattern, na=False)]
+
+    month_col = DIMENSION_YEAR_MONTH["alias"]
+    count_col = METRIC_EVENT_COUNT["alias"]
+    grouped = df.groupby(month_col, as_index=False)[count_col].sum()
+    grouped[month_col] = grouped[month_col].apply(
+        lambda m: f"{m[:4]}-{m[4:]}" if len(m) == 6 and "-" not in m else m
+    )
+    counts_by_month = dict(zip(grouped[month_col], grouped[count_col].astype(int)))
+    return [{"month": m, "count": counts_by_month.get(m, 0)} for m in all_months]
+
+
+def _fetch_event_monthly_df(event_name, params, needs_page_path=False):
+    """Fetch raw monthly event data from GA4.
+
+    Args:
+        event_name: GA4 event name.
+        params: Analytics params including start_date and end_date.
+        needs_page_path: Whether to include DIMENSION_PAGE_PATH for regex filtering.
+
+    Returns:
+        DataFrame with year-month and event count columns.
+    """
+    dimensions = [DIMENSION_EVENT_NAME, DIMENSION_YEAR_MONTH]
+    if needs_page_path:
+        dimensions.append(DIMENSION_PAGE_PATH)
+
+    return get_data_df_from_fields(
+        [METRIC_EVENT_COUNT],
+        dimensions,
+        dimension_filter=f"eventName=={event_name}",
+        **params,
+    )
+
+
 def fetch_data(
     ga_authentication,
     property_id,
     current_month,
     analytics_start,
     custom_events=None,
+    event_charts=None,
     historic_data_path=None,
     access_request_urls=None,
     exclude_pages=None,
@@ -370,6 +442,28 @@ def fetch_data(
                 event["event_name"], params,
                 page_path_regex=event.get("page_path_regex"),
             )
+
+    if event_charts:
+        chart_start = event_charts.get("chart_start", analytics_start)
+        params_chart = {**params, "start_date": chart_start, "end_date": end_date_current}
+        data["event_chart_config"] = event_charts
+
+        # Group series by event_name to avoid duplicate API calls
+        series_by_event = {}
+        for chart in event_charts.get("charts", []):
+            for series in chart.get("series", []):
+                event_name = series.get("event_name", series["event_key"])
+                series_by_event.setdefault(event_name, []).append(series)
+
+        for event_name, series_list in series_by_event.items():
+            needs_page_path = any(s.get("page_path_regex") for s in series_list)
+            print(f"Fetching monthly counts for {event_name}...")
+            df = _fetch_event_monthly_df(event_name, params_chart, needs_page_path)
+            for series in series_list:
+                data[f"event_chart_{series['event_key']}"] = _monthly_counts_from_df(
+                    df, chart_start, end_date_current,
+                    page_path_regex=series.get("page_path_regex"),
+                )
 
     print("Data fetching complete!")
     return data

--- a/analytics/analytics_package/analytics/static_site/generator.py
+++ b/analytics/analytics_package/analytics/static_site/generator.py
@@ -17,6 +17,7 @@ def generate_site(
     analytics_start,
     output_dir="site",
     custom_events=None,
+    event_charts=None,
     historic_data_path=None,
     title_resolver=None,
     access_request_urls=None,
@@ -62,6 +63,7 @@ def generate_site(
         current_month=current_month,
         analytics_start=analytics_start,
         custom_events=custom_events,
+        event_charts=event_charts,
         historic_data_path=historic_data_path,
         access_request_urls=access_request_urls,
         exclude_pages=exclude_pages,
@@ -87,6 +89,7 @@ def generate_site(
         analytics_start=analytics_start,
         custom_events=custom_events,
         output_dir=data_dir,
+        event_charts=event_charts,
     )
 
     print("\n" + "=" * 50)

--- a/analytics/analytics_package/analytics/static_site/template/index.html
+++ b/analytics/analytics_package/analytics/static_site/template/index.html
@@ -378,7 +378,7 @@
 
         async function loadData() {
             try {
-                const [configRes, trafficRes, pageviewsRes, outboundRes, filtersRes, downloadsRes, eventsRes, metaRes, searchRes, fileDownloadEventsRes] = await Promise.all([
+                const [configRes, trafficRes, pageviewsRes, outboundRes, filtersRes, downloadsRes, eventsRes, metaRes, searchRes, fileDownloadEventsRes, eventChartsRes] = await Promise.all([
                     fetch('data/config.json'),
                     fetch('data/monthly_traffic.json'),
                     fetch('data/pageviews.json'),
@@ -389,6 +389,7 @@
                     fetch('data/meta.json'),
                     fetch('data/search_queries.json').catch(() => null),
                     fetch('data/file_download_events.json').catch(() => null),
+                    fetch('data/event_charts.json').catch(() => null),
                 ]);
 
                 const [config, traffic, pageviews, outbound, filters, downloads, events, meta] = await Promise.all([
@@ -397,6 +398,7 @@
                 ]);
                 const searchQueries = searchRes ? await searchRes.json().catch(() => null) : null;
                 const fileDownloadEvents = fileDownloadEventsRes ? await fileDownloadEventsRes.json().catch(() => null) : null;
+                const eventCharts = eventChartsRes && eventChartsRes.ok ? await eventChartsRes.json().catch(() => null) : null;
 
                 applyConfig(config);
                 renderMeta(meta);
@@ -411,7 +413,7 @@
                 renderAccessRequestsTable();
                 renderSearchQueries(searchQueries);
                 renderFileDownloadEvents(fileDownloadEvents);
-                renderEventCounts(config, events);
+                renderEventCounts(config, events, eventCharts);
                 await renderEventStats(events, config);
             } catch (error) {
                 console.error('Error loading data:', error);
@@ -524,7 +526,7 @@
                 );
         }
 
-        function renderEventCounts(config, events) {
+        function renderEventCounts(config, events, eventCharts) {
             const grid = document.getElementById('event-counts-grid');
             const countCards = config.event_counts;
             if (!countCards || countCards.length === 0 || !events) return;
@@ -532,38 +534,104 @@
             const eventsByKey = {};
             for (const e of events) eventsByKey[e.event_name] = e;
 
-            let lastRowLabel = '';
-            const cards = countCards.map(card => {
-                const e = eventsByKey[card.event_key] || {};
-                const current = e.current || 0;
-                const prior = e.prior || 0;
-                let change = 0;
-                if (prior > 0) {
-                    change = ((current - prior) / prior * 100).toFixed(1);
+            // Build lookup from event_key to monthly data from eventCharts
+            const chartDataByKey = {};
+            if (eventCharts && eventCharts.charts) {
+                for (const chart of eventCharts.charts) {
+                    for (const series of chart.series) {
+                        chartDataByKey[series.event_key] = series.data;
+                    }
                 }
-                const rowLabel = card.label.split('\n')[0];
-                let heading = '';
-                if (rowLabel !== lastRowLabel) {
-                    heading = `<h3 class="fui-heading-xsmall fui-grid-item-12">${escapeHtml(rowLabel)}</h3>`;
-                    lastRowLabel = rowLabel;
-                }
-                return heading + `
-                    <div class="fui-card fui-grid-item-6" style="text-align: center;">
-                        <div class="fui-card-content">
-                            <div class="stat-value">${formatNumber(current)}</div>
-                            <div class="stat-label">${card.label.split('\n').map(l => escapeHtml(l)).join('<br>')}</div>
-                            <div class="stat-change ${change >= 0 ? 'positive' : 'negative'}">
-                                ${change >= 0 ? '+' : ''}${change}% vs prior month
+            }
+
+            // Group cards into pairs by row label, then emit: heading, stats row, charts row
+            let html = '';
+            let chartIndex = 0;
+            for (let i = 0; i < countCards.length; i += 2) {
+                const pair = countCards.slice(i, i + 2);
+                const rowLabel = pair[0].label.split('\n')[0];
+                html += `<h3 class="fui-heading-xsmall fui-grid-item-12">${escapeHtml(rowLabel)}</h3>`;
+
+                // Stat cards row
+                for (const card of pair) {
+                    const e = eventsByKey[card.event_key] || {};
+                    const current = e.current || 0;
+                    const prior = e.prior || 0;
+                    let change = 0;
+                    if (prior > 0) {
+                        change = ((current - prior) / prior * 100).toFixed(1);
+                    }
+                    html += `
+                        <div class="fui-card fui-grid-item-6" style="text-align: center;">
+                            <div class="fui-card-content">
+                                <div class="stat-value">${formatNumber(current)}</div>
+                                <div class="stat-label">${card.label.split('\n').map(l => escapeHtml(l)).join('<br>')}</div>
+                                <div class="stat-change ${change >= 0 ? 'positive' : 'negative'}">
+                                    ${change >= 0 ? '+' : ''}${change}% vs prior month
+                                </div>
                             </div>
                         </div>
-                    </div>
-                `;
-            }).join('');
+                    `;
+                }
+
+                // Chart cards row
+                for (const card of pair) {
+                    if (chartDataByKey[card.event_key] && chartDataByKey[card.event_key].length > 0) {
+                        const canvasId = `event-trend-chart-${chartIndex++}`;
+                        const parts = card.label.split('\n');
+                        const chartTitle = escapeHtml(rowLabel) + ' Over Time' + (parts[1] ? ` (${escapeHtml(parts[1].replace(/[()]/g, ''))})` : '');
+                        html += `
+                            <div class="fui-card fui-grid-item-6">
+                                <div class="fui-card-header">
+                                    <h3 class="fui-card-header-title fui-heading-xsmall">${chartTitle}</h3>
+                                </div>
+                                <hr class="fui-divider" />
+                                <div class="fui-card-content">
+                                    <div class="chart-container" style="height: 200px;">
+                                        <canvas id="${canvasId}" data-event-key="${card.event_key}"></canvas>
+                                    </div>
+                                </div>
+                            </div>
+                        `;
+                    }
+                }
+            }
 
             grid.style.display = '';
-            grid.innerHTML = cards;
+            grid.innerHTML = html;
             document.getElementById('key-metrics-heading').style.display = '';
             document.getElementById('key-metric-detail-heading').style.display = '';
+
+            // Render Chart.js instances for each trend chart
+            grid.querySelectorAll('canvas[data-event-key]').forEach(canvas => {
+                const key = canvas.dataset.eventKey;
+                const data = chartDataByKey[key] || [];
+                const months = data.map(d => d.month);
+                const counts = data.map(d => d.count);
+
+                new Chart(canvas.getContext('2d'), {
+                    type: 'bar',
+                    data: {
+                        labels: months,
+                        datasets: [{
+                            label: 'Requests',
+                            data: counts,
+                            backgroundColor: chartColors.primary,
+                            borderRadius: 4,
+                            maxBarThickness: 15,
+                        }],
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        scales: {
+                            y: { beginAtZero: true, grid: { color: '#e1e3e5' }, ticks: { precision: 0 } },
+                            x: { grid: { display: false } },
+                        },
+                        plugins: { legend: { display: false } },
+                    },
+                });
+            });
         }
 
         async function renderEventStats(events, config) {

--- a/analytics/anvil-explorer-sheets/generate_static_site.py
+++ b/analytics/anvil-explorer-sheets/generate_static_site.py
@@ -4,7 +4,7 @@
 import os
 
 import analytics.api as ga
-from analytics.static_site import generate_site, enrich_detail_records
+from analytics.static_site import generate_site, enrich_detail_records, make_event_charts
 from constants import CURRENT_MONTH, ANVIL_EXPLORER_ID, SECRET_NAME, ANALYTICS_START, OAUTH_PORT
 from utils import fetch_dataset_title_map
 
@@ -92,6 +92,7 @@ generate_site(
             "detail_table": True,
         },
     ],
+    event_charts=make_event_charts("Dataset", "/datasets", "2026-03-01"),
     title_resolver=resolve_dataset_titles,
     access_request_urls=["duos.org", "dbgap.ncbi.nlm.nih.gov"],
 )

--- a/analytics/hca-explorer-sheets/generate_static_site.py
+++ b/analytics/hca-explorer-sheets/generate_static_site.py
@@ -4,7 +4,7 @@
 import os
 
 import analytics.api as ga
-from analytics.static_site import generate_site, fetch_entity_title_map, enrich_detail_records
+from analytics.static_site import generate_site, fetch_entity_title_map, enrich_detail_records, make_event_charts
 from constants import CURRENT_MONTH, HCA_ID, SECRET_NAME, ANALYTICS_START, OAUTH_PORT, HCA_BROWSER_ONLY_FILTER
 
 AZUL_PROJECTS_URL = "https://service.azul.data.humancellatlas.org/index/projects"
@@ -93,6 +93,7 @@ generate_site(
             "detail_table": True,
         },
     ],
+    event_charts=make_event_charts("Project", "/projects", "2026-03-01"),
     title_resolver=resolve_project_titles,
     base_dimension_filter=HCA_BROWSER_ONLY_FILTER,
 )

--- a/analytics/lungmap-analytics/sheets/generate_static_site.py
+++ b/analytics/lungmap-analytics/sheets/generate_static_site.py
@@ -4,7 +4,7 @@
 import os
 
 import analytics.api as ga
-from analytics.static_site import generate_site, fetch_entity_title_map, enrich_detail_records
+from analytics.static_site import generate_site, fetch_entity_title_map, enrich_detail_records, make_event_charts
 from constants import CURRENT_MONTH, LUNGMAP_ID, SECRET_NAME, ANALYTICS_START, OAUTH_PORT, HISTORIC_UA_DATA_PATH
 
 AZUL_PROJECTS_URL = "https://service.azul.data.humancellatlas.org/index/projects"
@@ -93,6 +93,7 @@ generate_site(
             "detail_table": True,
         },
     ],
+    event_charts=make_event_charts("Project", "/projects", "2026-03-01"),
     historic_data_path=HISTORIC_UA_DATA_PATH,
     title_resolver=resolve_project_titles,
 )


### PR DESCRIPTION
## Ticket
Closes #4825

## Summary
- Add bar charts showing monthly trends for export/download events (Export to Terra, curl Command, File Manifest) in the static analytics pages
- Charts appear below the corresponding stat cards in the Key Metrics section, showing both single-entity and cross-dataset series
- Shared `make_event_charts()` factory function eliminates config duplication across HCA, AnVIL, and LungMAP generators
- Consolidated GA4 API calls for series sharing the same event name (e.g., `bulk_download_requested` with different page path filters), reducing API calls from 6 to 5 per app
- Missing months are filled with zero counts to ensure all months in the range appear on charts

## Test plan
- [x] Regenerated and verified HCA static site locally
- [x] Regenerated and verified AnVIL Explorer static site locally
- [x] Regenerated and verified LungMAP static site locally
- [x] Verified charts render correctly with both zero and non-zero months

🤖 Generated with [Claude Code](https://claude.com/claude-code)