### PR TITLE
feat: [anvil explorer] collapsible registration completion reminder (#4816)

### DIFF
--- a/site-config/anvil-cmg/dev/ui/entityView.ts
+++ b/site-config/anvil-cmg/dev/ui/entityView.ts
@@ -10,5 +10,6 @@ export const entityViewSlot: ComponentsConfig = [
   } as ComponentConfig<typeof C.NIHAccountExpiryWarning>,
   {
     component: C.TerraSetUpForm,
+    props: { collapsible: true },
   } as ComponentConfig<typeof C.TerraSetUpForm>,
 ];


### PR DESCRIPTION
## Summary

- Opt the AnVIL Explorer `TerraSetUpForm` into the new `collapsible` prop (findable-ui v53.1.0), so the registration completion reminder can be collapsed/expanded while browsing.
- Collapsed state is held in-memory by `TerraSetUpUIProvider` (mounted under `TerraProfileProvider` in `_app.tsx`), so it persists across SPA navigations within a session and resets on full reload / new tab / browser close. No `localStorage`/`sessionStorage`.

Closes #4816

## Test plan

- [x] Sign in to AnVIL Explorer as a user with incomplete registration; reminder renders expanded by default.
- [x] Collapse the reminder; navigate between entity list / detail pages — reminder stays collapsed.
- [x] Confirm HCA-DCP `TerraSetUpForm` still renders in its default (non-collapsible) state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1366" height="1127" alt="image" src="https://github.com/user-attachments/assets/cd803606-5227-499e-a8a3-cfd2d78c9855" />

<img width="1368" height="1126" alt="image" src="https://github.com/user-attachments/assets/03b1d945-18bd-4bf4-b92c-29966a915ad6" />

<img width="1366" height="1160" alt="image" src="https://github.com/user-attachments/assets/61157cf4-7694-4fc7-bf36-424699bd6a67" />

<img width="1367" height="1143" alt="image" src="https://github.com/user-attachments/assets/855aa7fc-1590-402c-9133-a503ca01e7fb" />


