### PR TITLE
chore: [hca dcp] refresh cellxgene → hca project mapping (#4847)

### DIFF
--- a/site-config/hca-dcp/ma-dev/scripts/out/cellxgene-projects.json
+++ b/site-config/hca-dcp/ma-dev/scripts/out/cellxgene-projects.json
@@ -4,6 +4,10 @@
     "hcaProjectId": "01aacb68-4076-4fd9-9eb9-aba0f48c1b5a"
   },
   {
+    "cellxgeneId": "7b9ae565-a781-433d-98d4-430394e7802a",
+    "hcaProjectId": "032880e5-2b44-4bfb-8eef-25bb48e7453f"
+  },
+  {
     "cellxgeneId": "793fdaec-5067-428a-a9db-ecefe135c945",
     "hcaProjectId": "04ad400c-58cb-40a5-bc2b-2279e13a910b"
   },
@@ -36,6 +40,10 @@
     "hcaProjectId": "16e99159-78bc-44aa-b479-55a5e903bf50"
   },
   {
+    "cellxgeneId": "7855daa4-3f34-4aae-b65a-87720c02e7cd",
+    "hcaProjectId": "1c5eaabf-075b-4b7a-a9e6-07792c2034b3"
+  },
+  {
     "cellxgeneId": "2f4c738f-e2f3-4553-9db2-0582a38ea4dc",
     "hcaProjectId": "1dddae6e-3753-48af-b20e-fa22abad125d"
   },
@@ -54,6 +62,10 @@
   {
     "cellxgeneId": "fc77d2ae-247d-44d7-aa24-3f4859254c2c",
     "hcaProjectId": "21ea8ddb-525f-4f1f-a820-31f0360399a2"
+  },
+  {
+    "cellxgeneId": "8f17ac63-aaba-44b5-9b78-60f121da4c2f",
+    "hcaProjectId": "2245bca0-6563-4e88-ab26-f2b8f60383a7"
   },
   {
     "cellxgeneId": "3a2af25b-2338-4266-aad3-aa8d07473f50",
@@ -96,6 +108,10 @@
     "hcaProjectId": "34cba5e9-ecb1-4d81-bf08-48987cd63073"
   },
   {
+    "cellxgeneId": "ced320a1-29f3-47c1-a735-513c7084d508",
+    "hcaProjectId": "35d5b057-3daf-4ccd-8112-196194598893"
+  },
+  {
     "cellxgeneId": "16c1e722-96ae-4bf6-b408-cd7f8918484f",
     "hcaProjectId": "38449aea-70b5-40db-84b3-1e08f32efe34"
   },
@@ -118,6 +134,10 @@
   {
     "cellxgeneId": "24d42e5e-ce6d-45ff-a66b-a3b3b715deaf",
     "hcaProjectId": "4a95101c-9ffc-4f30-a809-f04518a23803"
+  },
+  {
+    "cellxgeneId": "4c6eaf5c-6d57-4c76-b1e9-60df8c655f1e",
+    "hcaProjectId": "4bcc16b5-7a47-45bb-b9c0-be9d5336df2d"
   },
   {
     "cellxgeneId": "bd5230f4-cd76-4d35-9ee5-89b3e7475659",
@@ -160,8 +180,16 @@
     "hcaProjectId": "5f607e50-ba22-4598-b1e9-f3d9d7a35dcc"
   },
   {
+    "cellxgeneId": "cc431242-35ea-41e1-a100-41e0dec2665b",
+    "hcaProjectId": "6179c38c-9987-4e7c-a4bb-d34cf33a3c3f"
+  },
+  {
     "cellxgeneId": "5d445965-6f1a-4b68-ba3a-b8f765155d3a",
     "hcaProjectId": "6936da41-3692-46bb-bca1-cd0f507991e9"
+  },
+  {
+    "cellxgeneId": "4d82bd8e-8827-410b-8fc7-685b7dd92585",
+    "hcaProjectId": "6f03e4ad-9305-4bfa-a5b6-929ffb1d94bd"
   },
   {
     "cellxgeneId": "59c9ecfe-c47d-4a6a-bab0-895cc0c1942b",
@@ -174,6 +202,10 @@
   {
     "cellxgeneId": "64b24fda-6591-4ce1-89e7-33eb6c43ad7b",
     "hcaProjectId": "73769e0a-5fcd-41f4-9083-41ae08bfa4c1"
+  },
+  {
+    "cellxgeneId": "2600aac1-ef5e-4dcd-bbc9-f9f3d8a613ea",
+    "hcaProjectId": "77780d56-03c0-481f-aade-2038490cef9f"
   },
   {
     "cellxgeneId": "f8057c47-fcd8-4fcf-88b0-e2f930080f6e",
@@ -194,6 +226,10 @@
   {
     "cellxgeneId": "3472f32d-4a33-48e2-aad5-666d4631bf4c",
     "hcaProjectId": "8185730f-4113-40d3-9cc3-929271784c2b"
+  },
+  {
+    "cellxgeneId": "d2684035-a36e-458e-96af-8e37930bfdf6",
+    "hcaProjectId": "838d4660-3d62-4b08-b32d-dc5cbd93919d"
   },
   {
     "cellxgeneId": "7681c7d7-0168-4892-a547-6f02a6430ace",
@@ -220,6 +256,10 @@
     "hcaProjectId": "8ab8726d-81b9-4bd2-acc2-4d50bee786b4"
   },
   {
+    "cellxgeneId": "579203e2-182f-47bc-8230-7aa47247e2a4",
+    "hcaProjectId": "8dcbd84a-6243-4501-a684-0dcd084bb536"
+  },
+  {
     "cellxgeneId": "f7cecffa-00b4-4560-a29a-8ad626b8ee08",
     "hcaProjectId": "8f1f653d-3ea1-4d8e-b4a7-b97dc852c2b1"
   },
@@ -238,6 +278,10 @@
   {
     "cellxgeneId": "9e4e8f1d-d905-4d4f-b343-84889d0f9ffe",
     "hcaProjectId": "9762d70c-9b27-4f57-8cbc-377b9b92ea9b"
+  },
+  {
+    "cellxgeneId": "4624894f-6cf7-45d2-91ff-51fff9da9f13",
+    "hcaProjectId": "984ce0a2-682d-47a3-b80e-1354dfe51ca3"
   },
   {
     "cellxgeneId": "99f1515b-46a2-4bc4-94c3-f62659dc1eb4",


### PR DESCRIPTION
## Summary

Closes #4847

Regenerated `site-config/hca-dcp/ma-dev/scripts/out/cellxgene-projects.json` by running `npm run get-cellxgene-projects-hca`. The file was last refreshed in #4361 (2025-01-31).

The refresh added **11 new CELLxGENE → HCA project mappings** (no removals, no modifications to existing entries) — these correspond to new CELLxGENE collections that have linked to HCA projects since the last refresh.

## Test plan

- [x] Verify the diff is additive only (sorted insertions by `hcaProjectId`)
- [x] Confirm the file matches the output of running `npm run get-cellxgene-projects-hca` against the current upstream API

<img width="2038" height="1053" alt="image" src="https://github.com/user-attachments/assets/0fb92317-6b98-40ef-a235-fd9c8f905615" />
