### PR TITLE
feat: implement authorization code flow for anvil prod (anvil-cmg/prod) (#4851)

### DIFF
--- a/site-config/anvil-cmg/prod/authentication/constants.ts
+++ b/site-config/anvil-cmg/prod/authentication/constants.ts
@@ -8,13 +8,14 @@ import { GoogleProfile } from "@databiosphere/findable-ui/lib/google/types";
 import { OAUTH_GOOGLE_SIGN_IN } from "../../../common/authentication";
 
 const CLIENT_ID =
-  "1055427471534-r7j5sdnhv47cuq10nsdejrc0pajd1qqv.apps.googleusercontent.com";
+  "1055427471534-8ee4mhig5j40n6n366j7uul26bbbhp2p.apps.googleusercontent.com";
 
 export const GOOGLE_PROVIDER: OAuthProvider<GoogleProfile> = {
   ...GOOGLE_SIGN_IN_PROVIDER,
   ...OAUTH_GOOGLE_SIGN_IN,
+  authorize: "https://service.explore.anvilproject.org/user/authorize",
   clientId: CLIENT_ID,
-  flow: OAUTH_FLOW.IMPLICIT,
+  flow: OAUTH_FLOW.AUTHORIZATION_CODE,
 };
 
 export const TERRA_SERVICE = {


### PR DESCRIPTION
## Summary

- Switches AnVIL prod (anvil-cmg/prod) Google OAuth from implicit to authorization code flow.
- New client ID provisioned for the auth-code flow on the same Google Cloud project.
- Adds the \`authorize\` endpoint URL targeting prod Azul (\`https://service.explore.anvilproject.org/user/authorize\`).
- Mirrors the anvil-cmg/dev migration; \`authentication/authentication.ts\` and \`config.ts\` are unchanged because the const-export pattern is preserved.

Closes #4851

## Test plan
- [ ] Sign in to prod AnVIL Data Browser and complete the Terra OAuth round-trip
- [ ] Sign out cleanly
- [ ] Refresh-token flow exercised end-to-end via Azul (verifies the auth-code intent — critical-path for the mirror-MA effort in DataBiosphere/azul-private#359)

🤖 Generated with [Claude Code](https://claude.com/claude-code)