### PR TITLE
feat: implement authorization code flow for hca prod (ma-prod) (#4850)

### DIFF
--- a/site-config/hca-dcp/ma-prod/authentication/authentication.ts
+++ b/site-config/hca-dcp/ma-prod/authentication/authentication.ts
@@ -1,14 +1,15 @@
 import { AuthenticationConfig } from "@databiosphere/findable-ui/lib/config/entities";
 import * as MDX from "../../../../app/components/common/MDXContent/hca-dcp";
-import { GOOGLE_PROVIDER, TERRA_SERVICE } from "./constants";
+import { getGoogleProvider, TERRA_SERVICE } from "./constants";
 
 /**
  * Returns the authentication config for HCA DCP MA-PROD environment.
+ * @param dataSourceUrl - Data source URL.
  * @returns - Authentication config for HCA DCP MA-PROD environment.
  */
-export function getAuthentication(): AuthenticationConfig {
+export function getAuthentication(dataSourceUrl: string): AuthenticationConfig {
   return {
-    providers: [GOOGLE_PROVIDER],
+    providers: [getGoogleProvider(dataSourceUrl)],
     services: [TERRA_SERVICE],
     termsOfService: MDX.LoginTermsOfService({}),
     text: MDX.LoginText({}),

--- a/site-config/hca-dcp/ma-prod/authentication/constants.ts
+++ b/site-config/hca-dcp/ma-prod/authentication/constants.ts
@@ -8,14 +8,25 @@ import { GoogleProfile } from "@databiosphere/findable-ui/lib/google/types";
 import { OAUTH_GOOGLE_SIGN_IN } from "../../../common/authentication";
 
 const CLIENT_ID =
-  "473200283737-4pt6e9lraf5jbb650f9kp7ethelv4a8l.apps.googleusercontent.com";
+  "473200283737-h5e1l7neunbuesrtgjf8b12lb7o3jf1m.apps.googleusercontent.com";
 
-export const GOOGLE_PROVIDER: OAuthProvider<GoogleProfile> = {
-  ...GOOGLE_SIGN_IN_PROVIDER,
-  ...OAUTH_GOOGLE_SIGN_IN,
-  clientId: CLIENT_ID,
-  flow: OAUTH_FLOW.IMPLICIT,
-};
+/**
+ * Returns the Google OAuth provider configured for the authorization code
+ * flow, with `authorize` derived from the given Azul base URL.
+ * @param dataSourceUrl - Azul base URL.
+ * @returns Google OAuth provider.
+ */
+export function getGoogleProvider(
+  dataSourceUrl: string
+): OAuthProvider<GoogleProfile> {
+  return {
+    ...GOOGLE_SIGN_IN_PROVIDER,
+    ...OAUTH_GOOGLE_SIGN_IN,
+    authorize: `${dataSourceUrl}/user/authorize`,
+    clientId: CLIENT_ID,
+    flow: OAUTH_FLOW.AUTHORIZATION_CODE,
+  };
+}
 
 export const TERRA_SERVICE = {
   endpoint: {

--- a/site-config/hca-dcp/ma-prod/config.ts
+++ b/site-config/hca-dcp/ma-prod/config.ts
@@ -14,7 +14,7 @@ const config = makeConfig(
   DATA_URL,
   GIT_HUB_REPO_URL,
   CATALOG,
-  getAuthentication()
+  getAuthentication(DATA_URL)
 );
 
 // Configure analytics for the prod environment.


### PR DESCRIPTION
## Summary

- Switches HCA prod (ma-prod) Google OAuth from implicit to authorization code flow.
- New client ID provisioned for the auth-code flow on the same Google Cloud project.
- Mirrors the ma-dev migration: replaces \`GOOGLE_PROVIDER\` const with a \`getGoogleProvider(dataSourceUrl)\` factory that derives the \`authorize\` endpoint from the Azul base URL (\`https://service.azul.data.humancellatlas.org/user/authorize\`).
- Propagates \`dataSourceUrl\` through \`getAuthentication\` and \`config.ts\` (\`makeConfig\` now passes \`DATA_URL\` into \`getAuthentication\`).

Closes #4850

## Test plan
- [ ] Sign in to prod HCA Data Browser and complete the Terra OAuth round-trip
- [ ] Sign out cleanly
- [ ] Refresh-token flow exercised end-to-end via Azul

🤖 Generated with [Claude Code](https://claude.com/claude-code)