### PR TITLE
fix: hca-dcp matrices tab honours project access gating (#4858)

### DIFF
--- a/site-config/hca-dcp/ma-dev/entities/projects/entity/detail.ts
+++ b/site-config/hca-dcp/ma-dev/entities/projects/entity/detail.ts
@@ -1,7 +1,7 @@
 import { EntityConfig } from "@databiosphere/findable-ui/lib/config/entities";
 import { PROJECT_ENTITY_ROUTE } from "./routes";
 import { EXPORT } from "./tab/export";
-import { mainColumn as matricesMainColumn } from "./tab/matricesMainColumn";
+import { MATRICES } from "./tab/matrices";
 import { METADATA } from "./tab/metadata";
 import { mainColumn as overviewMainColumn } from "./tab/overviewMainColumn";
 import { sideColumn as overviewSideColumn } from "./tab/overviewSideColumn";
@@ -25,7 +25,7 @@ export const DETAIL: EntityConfig["detail"] = {
     },
     {
       label: "Matrices",
-      mainColumn: matricesMainColumn,
+      mainColumn: MATRICES,
       route: PROJECT_ENTITY_ROUTE.PROJECT_MATRICES,
     },
     {

--- a/site-config/hca-dcp/ma-dev/entities/projects/entity/tab/matrices.ts
+++ b/site-config/hca-dcp/ma-dev/entities/projects/entity/tab/matrices.ts
@@ -1,0 +1,15 @@
+import { ComponentConfig } from "@databiosphere/findable-ui/lib/config/entities";
+import { ProjectsResponse } from "../../../../../../../app/apis/azul/hca-dcp/common/responses";
+import * as C from "../../../../../../../app/components";
+import * as V from "../../../../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
+import { PROJECT_ACCESS_WARNING } from "./accessWarning";
+import { mainColumn } from "./matricesMainColumn";
+
+export const MATRICES: ComponentConfig[] = [
+  ...PROJECT_ACCESS_WARNING,
+  {
+    children: mainColumn,
+    component: C.ConditionalComponent,
+    viewBuilder: V.renderExportEntity,
+  } as ComponentConfig<typeof C.ConditionalComponent, ProjectsResponse>,
+];


### PR DESCRIPTION
## Summary
- Matrices tab on hca-dcp project detail pages now applies the same access-required guard already used by Download / Export / Metadata: the `PROJECT_ACCESS_WARNING` alert renders when the user lacks project access, and the matrix list is not rendered behind it.
- Implemented by introducing `site-config/hca-dcp/ma-dev/entities/projects/entity/tab/matrices.ts` that wraps `matricesMainColumn` in a `ConditionalComponent` gated by `renderExportEntity`, with `PROJECT_ACCESS_WARNING` spread in front.
- `detail.ts` updated to use the new `MATRICES` config. ma-prod inherits via `makeConfig`.

Closes #4858.

## Test plan
- [x] Signed-in user without access to an "Access Required" project visits `/projects/<id>/project-matrices` → sees the "To export this project, please sign in and, if necessary, request access." warning. No matrix rows render.
- [x] Same user on a project they DO have access to → matrices render normally.
- [x] Unsigned user → same warning (existing behaviour).
- [x] Build (`npm run build-ma-dev:hca-dcp`) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2004" height="1257" alt="image" src="https://github.com/user-attachments/assets/f552f7e0-d2d8-4688-98fc-79c2a7b66500" />
