### PR TITLE
chore: make dcp60 the default catalog on hca

### DIFF
--- a/site-config/hca-dcp/ma-prod/config.ts
+++ b/site-config/hca-dcp/ma-prod/config.ts
@@ -4,7 +4,7 @@ import { getAuthentication } from "./authentication/authentication";
 
 // Template constants
 const BROWSER_URL = "https://explore.data.humancellatlas.org";
-const CATALOG = "dcp59";
+const CATALOG = "dcp60";
 export const DATA_URL = "https://service.azul.data.humancellatlas.org";
 export const PORTAL_URL = "https://data.humancellatlas.org";
 


### PR DESCRIPTION
## Ticket
Closes #4869

## Summary
- Update default HCA DCP catalog from `dcp59` to `dcp60` in ma-prod config

## Test plan
- [ ] Verify HCA Data Explorer loads with dcp60 catalog
- [ ] Confirm project listings and data render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)