### PR TITLE
chore: replace zendesk support form with anvil portal help link

### DIFF
--- a/site-config/anvil-cmg/dev/config.ts
+++ b/site-config/anvil-cmg/dev/config.ts
@@ -22,7 +22,7 @@ import { datasetsEntityConfig } from "./index/datasetsEntityConfig";
 import { donorsEntityConfig } from "./index/donorsEntityConfig";
 import { filesEntityConfig } from "./index/filesEntityConfig";
 import { buildSummaries } from "./index/summaryViewModelBuilder";
-import { floating } from "./layout/floating";
+import { makeFloatingConfig } from "./layout/floating";
 
 // Template constants
 const APP_TITLE = "AnVIL Data Explorer";
@@ -175,7 +175,7 @@ export function makeConfig(
     filterSort: { sortBy: FILTER_SORT.COUNT },
     gitHubUrl,
     layout: {
-      floating,
+      floating: makeFloatingConfig(portalUrl),
       footer: {
         Branding: C.ANVILBranding({ portalURL: portalUrl }),
         navLinks: [

--- a/site-config/anvil-cmg/dev/layout/floating.ts
+++ b/site-config/anvil-cmg/dev/layout/floating.ts
@@ -1,31 +1,18 @@
-import { REQUEST_FIELD_ID } from "@databiosphere/findable-ui/lib/components/Support/components/SupportRequest/components/SupportRequestForm/common/entities";
+import { ViewSupport } from "@databiosphere/findable-ui/lib/components/Support/components/ViewSupport/viewSupport";
 import {
   ComponentConfig,
   FloatingConfig,
 } from "@databiosphere/findable-ui/lib/config/entities";
-import * as C from "app/components";
 
-const ZENDESK_FIELD_ID: Record<REQUEST_FIELD_ID, number> = {
-  DESCRIPTION: 360007369412,
-  EMAIL: 360012782111,
-  SUBJECT: 360007369392,
-  TICKET_FORM_ID: 18724494389787,
-  TYPE: 360012744452,
-};
-const ZENDESK_REQUEST_URL = "https://support.terra.bio/api/v2/requests.json";
-const ZENDESK_UPLOAD_URL = "https://support.terra.bio/api/v2/uploads";
-
-export const floating: FloatingConfig = {
-  components: [
-    {
-      component: C.SupportRequest,
-      props: {
-        supportRequest: {
-          FIELD_ID: ZENDESK_FIELD_ID,
-          requestURL: ZENDESK_REQUEST_URL,
-          uploadURL: ZENDESK_UPLOAD_URL,
+export function makeFloatingConfig(portalUrl: string): FloatingConfig {
+  return {
+    components: [
+      {
+        component: ViewSupport,
+        props: {
+          url: `${portalUrl}/help`,
         },
-      },
-    } as ComponentConfig<typeof C.SupportRequest>,
-  ],
-};
+      } as ComponentConfig<typeof ViewSupport>,
+    ],
+  };
+}


### PR DESCRIPTION
## Ticket
Closes #4872

## Summary
- Replace the Zendesk `SupportRequest` form in the AnVIL CMG floating layout with a `ViewSupport` FAB that links to the AnVIL portal help page (`{portalUrl}/help`)
- Remove Zendesk field IDs, request URL, and upload URL configuration from `floating.ts`
- Parameterize the floating config to accept `portalUrl`, reusing the existing portal URL from `makeConfig`

## Test plan
- [ ] Verify the floating support button appears on the AnVIL CMG Data Explorer
- [ ] Verify clicking the button opens `https://anvilproject.org/help` in a new tab (prod) or the dev portal equivalent
- [ ] Verify no Zendesk form is rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)