### PR TITLE
feat: add access metrics section to HCA analytics report

### DIFF
--- a/analytics/analytics_package/analytics/static_site/fetch.py
+++ b/analytics/analytics_package/analytics/static_site/fetch.py
@@ -24,6 +24,8 @@ METRIC_ENGAGEMENT_RATE = {
 
 # Regex matching page paths that are clearly not real pages (bot probes,
 # broken markdown links, asset requests, etc.).
+_ENTITY_PATH_RE = re.compile(r"^(/[^/]+/[0-9a-f-]+).*", re.IGNORECASE)
+
 SUSPICIOUS_PAGE_PATH_RE = re.compile(
     r"("
     r"^/?\].*"             # broken markdown links e.g. /](https://...)
@@ -190,6 +192,8 @@ def get_access_requests(params, url_patterns):
     result = df[[DIMENSION_PAGE_PATH["alias"], url_col, METRIC_EVENT_COUNT["alias"]]].copy()
     result.columns = ["page_path", "click_url", "count"]
     result["count"] = result["count"].astype(int)
+    # Normalize page paths to entity base path (e.g., /projects/UUID/sub-page -> /projects/UUID).
+    result["page_path"] = result["page_path"].str.replace(_ENTITY_PATH_RE, r"\1", regex=True)
     result = result.groupby(["page_path", "click_url"], as_index=False)["count"].sum()
     result = result.sort_values("count", ascending=False)
     return result.to_dict(orient="records")

--- a/analytics/analytics_package/analytics/static_site/fetch.py
+++ b/analytics/analytics_package/analytics/static_site/fetch.py
@@ -24,8 +24,6 @@ METRIC_ENGAGEMENT_RATE = {
 
 # Regex matching page paths that are clearly not real pages (bot probes,
 # broken markdown links, asset requests, etc.).
-_ENTITY_PATH_RE = re.compile(r"^(/[^/]+/[0-9a-f-]+).*", re.IGNORECASE)
-
 SUSPICIOUS_PAGE_PATH_RE = re.compile(
     r"("
     r"^/?\].*"             # broken markdown links e.g. /](https://...)
@@ -39,6 +37,8 @@ SUSPICIOUS_PAGE_PATH_RE = re.compile(
     r"|^/docs(-\w+)?/"     # CMS probes e.g. /docs/, /docs-EN/
     r")"
 )
+
+_ENTITY_PATH_RE = re.compile(r"^(/[^/]+/[0-9a-f-]+).*", re.IGNORECASE)
 
 
 def event_key(event):

--- a/analytics/analytics_package/analytics/static_site/template/index.html
+++ b/analytics/analytics_package/analytics/static_site/template/index.html
@@ -362,6 +362,12 @@
         let entityLabel = 'Dataset';
         let entityPath = '/datasets';
 
+        function serviceName(url) {
+            if (url.includes('duos.org')) return 'DUOS';
+            if (url.includes('dbgap.ncbi.nlm.nih.gov')) return 'dbGaP';
+            return url;
+        }
+
         let chartColors = {
             primary: '#1c7cc7',
             secondary: '#287555',
@@ -885,35 +891,43 @@
             const tbody = document.querySelector('#access-requests-table tbody');
             const total = data.reduce((sum, r) => sum + (r.count || 0), 0);
 
-            const duosTotal = data.filter(r => (r.click_url || '').includes('duos.org')).reduce((sum, r) => sum + (r.count || 0), 0);
-            const dbgapTotal = data.filter(r => (r.click_url || '').includes('dbgap.ncbi.nlm.nih.gov')).reduce((sum, r) => sum + (r.count || 0), 0);
+            const services = new Set(data.map(r => serviceName(r.click_url || '')));
+            const showService = services.size > 1;
 
             const statsGrid = document.getElementById('access-requests-stats');
-            statsGrid.style.display = '';
-            statsGrid.innerHTML = `
-                <div class="fui-card fui-grid-item-4" style="text-align: center;">
-                    <div class="fui-card-content">
-                        <div class="stat-value">${formatNumber(dbgapTotal)}</div>
-                        <div class="stat-label">dbGaP</div>
+            if (showService) {
+                const duosTotal = data.filter(r => serviceName(r.click_url || '') === 'DUOS').reduce((sum, r) => sum + (r.count || 0), 0);
+                const dbgapTotal = data.filter(r => serviceName(r.click_url || '') === 'dbGaP').reduce((sum, r) => sum + (r.count || 0), 0);
+                statsGrid.style.display = '';
+                statsGrid.innerHTML = `
+                    <div class="fui-card fui-grid-item-4" style="text-align: center;">
+                        <div class="fui-card-content">
+                            <div class="stat-value">${formatNumber(dbgapTotal)}</div>
+                            <div class="stat-label">dbGaP</div>
+                        </div>
                     </div>
-                </div>
-                <div class="fui-card fui-grid-item-4" style="text-align: center;">
-                    <div class="fui-card-content">
-                        <div class="stat-value">${formatNumber(duosTotal)}</div>
-                        <div class="stat-label">DUOS</div>
+                    <div class="fui-card fui-grid-item-4" style="text-align: center;">
+                        <div class="fui-card-content">
+                            <div class="stat-value">${formatNumber(duosTotal)}</div>
+                            <div class="stat-label">DUOS</div>
+                        </div>
                     </div>
-                </div>
-                <div class="fui-card fui-grid-item-4" style="text-align: center;">
-                    <div class="fui-card-content">
-                        <div class="stat-value">${formatNumber(total)}</div>
-                        <div class="stat-label">Total</div>
+                    <div class="fui-card fui-grid-item-4" style="text-align: center;">
+                        <div class="fui-card-content">
+                            <div class="stat-value">${formatNumber(total)}</div>
+                            <div class="stat-label">Total</div>
+                        </div>
                     </div>
-                </div>
-            `;
+                `;
+            }
 
             card.style.display = '';
             heading.style.display = '';
             card.querySelector('.fui-card-header-title').textContent = `Requests by ${entityLabel} (${formatNumber(total)})`;
+            card.querySelector('#access-requests-table thead th:first-child').textContent = entityLabel;
+            if (!showService) {
+                card.querySelector('#access-requests-table thead th:nth-child(2)').style.display = 'none';
+            }
 
             const toggle = document.getElementById('access-requests-toggle');
             if (data.length > 5) {
@@ -927,14 +941,11 @@
                 const datasetCell = link
                     ? `<a href="${safeHref(link)}" target="_blank" rel="noopener noreferrer">${escapeHtml(label)}</a>`
                     : escapeHtml(label);
-                const url = row.click_url || '';
-                let service = url;
-                if (url.includes('duos.org')) service = 'DUOS';
-                else if (url.includes('dbgap.ncbi.nlm.nih.gov')) service = 'dbGaP';
+                const serviceCell = showService ? `<td>${escapeHtml(serviceName(row.click_url || ''))}</td>` : '';
                 return `
                     <tr>
                         <td>${datasetCell}</td>
-                        <td>${escapeHtml(service)}</td>
+                        ${serviceCell}
                         <td class="col-number">${formatNumber(row.count || 0)}</td>
                     </tr>
                 `;

--- a/analytics/hca-explorer-sheets/generate_static_site.py
+++ b/analytics/hca-explorer-sheets/generate_static_site.py
@@ -96,4 +96,5 @@ generate_site(
     event_charts=make_event_charts("Project", "/projects", "2026-03-01"),
     title_resolver=resolve_project_titles,
     base_dimension_filter=HCA_BROWSER_ONLY_FILTER,
+    access_request_urls=["duos.org"],
 )

--- a/gh-pages/hca-explorer/data/access_requests.json
+++ b/gh-pages/hca-explorer/data/access_requests.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "page_path": "/projects/35d5b057-3daf-4ccd-8112-196194598893",
+    "click_url": "https://duos.org/dataset/DUOS-000258",
+    "count": 12,
+    "dataset_title": "Asian Immune Diversity Atlas (AIDA): Single-cell analysis of human diversity in circulating immune cells (Japan cells)"
+  },
+  {
+    "page_path": "/projects/c8503de8-d02d-4bda-ad06-4c851b37fa97",
+    "click_url": "https://duos.org/dataset/DUOS-000750",
+    "count": 4,
+    "dataset_title": "Cell atlas from human intestinal immune priming and effector sites during homeostasis"
+  },
+  {
+    "page_path": "/projects/ad04c8e7-9b7d-4cce-b8e9-01e31da10b94",
+    "click_url": "https://duos.org/dataset/DUOS-000751",
+    "count": 3,
+    "dataset_title": "Anomalous Epithelial Variations and Ectopic Inflammatory Response in Chronic Obstructive Pulmonary Disease"
+  }
+]

--- a/gh-pages/hca-explorer/data/meta.json
+++ b/gh-pages/hca-explorer/data/meta.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-04 12:47:03",
+  "generated_at": "2026-06-29 15:12:50",
   "current_month": "2026-05",
   "current_month_start": "2026-05-01",
   "current_month_end": "2026-05-31",

--- a/gh-pages/hca-explorer/index.html
+++ b/gh-pages/hca-explorer/index.html
@@ -362,6 +362,12 @@
         let entityLabel = 'Dataset';
         let entityPath = '/datasets';
 
+        function serviceName(url) {
+            if (url.includes('duos.org')) return 'DUOS';
+            if (url.includes('dbgap.ncbi.nlm.nih.gov')) return 'dbGaP';
+            return url;
+        }
+
         let chartColors = {
             primary: '#1c7cc7',
             secondary: '#287555',
@@ -550,7 +556,10 @@
             for (let i = 0; i < countCards.length; i += 2) {
                 const pair = countCards.slice(i, i + 2);
                 const rowLabel = pair[0].label.split('\n')[0];
-                html += `<h3 class="fui-heading-xsmall fui-grid-item-12">${escapeHtml(rowLabel)}</h3>`;
+                const pairSharesLabel = pair.length > 1 && pair[1].label.split('\n')[0] === rowLabel;
+                if (pairSharesLabel) {
+                    html += `<h3 class="fui-heading-xsmall fui-grid-item-12">${escapeHtml(rowLabel)}</h3>`;
+                }
 
                 // Stat cards row
                 for (const card of pair) {
@@ -882,35 +891,43 @@
             const tbody = document.querySelector('#access-requests-table tbody');
             const total = data.reduce((sum, r) => sum + (r.count || 0), 0);
 
-            const duosTotal = data.filter(r => (r.click_url || '').includes('duos.org')).reduce((sum, r) => sum + (r.count || 0), 0);
-            const dbgapTotal = data.filter(r => (r.click_url || '').includes('dbgap.ncbi.nlm.nih.gov')).reduce((sum, r) => sum + (r.count || 0), 0);
+            const services = new Set(data.map(r => serviceName(r.click_url || '')));
+            const showService = services.size > 1;
 
             const statsGrid = document.getElementById('access-requests-stats');
-            statsGrid.style.display = '';
-            statsGrid.innerHTML = `
-                <div class="fui-card fui-grid-item-4" style="text-align: center;">
-                    <div class="fui-card-content">
-                        <div class="stat-value">${formatNumber(dbgapTotal)}</div>
-                        <div class="stat-label">dbGaP</div>
+            if (showService) {
+                const duosTotal = data.filter(r => serviceName(r.click_url || '') === 'DUOS').reduce((sum, r) => sum + (r.count || 0), 0);
+                const dbgapTotal = data.filter(r => serviceName(r.click_url || '') === 'dbGaP').reduce((sum, r) => sum + (r.count || 0), 0);
+                statsGrid.style.display = '';
+                statsGrid.innerHTML = `
+                    <div class="fui-card fui-grid-item-4" style="text-align: center;">
+                        <div class="fui-card-content">
+                            <div class="stat-value">${formatNumber(dbgapTotal)}</div>
+                            <div class="stat-label">dbGaP</div>
+                        </div>
                     </div>
-                </div>
-                <div class="fui-card fui-grid-item-4" style="text-align: center;">
-                    <div class="fui-card-content">
-                        <div class="stat-value">${formatNumber(duosTotal)}</div>
-                        <div class="stat-label">DUOS</div>
+                    <div class="fui-card fui-grid-item-4" style="text-align: center;">
+                        <div class="fui-card-content">
+                            <div class="stat-value">${formatNumber(duosTotal)}</div>
+                            <div class="stat-label">DUOS</div>
+                        </div>
                     </div>
-                </div>
-                <div class="fui-card fui-grid-item-4" style="text-align: center;">
-                    <div class="fui-card-content">
-                        <div class="stat-value">${formatNumber(total)}</div>
-                        <div class="stat-label">Total</div>
+                    <div class="fui-card fui-grid-item-4" style="text-align: center;">
+                        <div class="fui-card-content">
+                            <div class="stat-value">${formatNumber(total)}</div>
+                            <div class="stat-label">Total</div>
+                        </div>
                     </div>
-                </div>
-            `;
+                `;
+            }
 
             card.style.display = '';
             heading.style.display = '';
             card.querySelector('.fui-card-header-title').textContent = `Requests by ${entityLabel} (${formatNumber(total)})`;
+            card.querySelector('#access-requests-table thead th:first-child').textContent = entityLabel;
+            if (!showService) {
+                card.querySelector('#access-requests-table thead th:nth-child(2)').style.display = 'none';
+            }
 
             const toggle = document.getElementById('access-requests-toggle');
             if (data.length > 5) {
@@ -924,14 +941,11 @@
                 const datasetCell = link
                     ? `<a href="${safeHref(link)}" target="_blank" rel="noopener noreferrer">${escapeHtml(label)}</a>`
                     : escapeHtml(label);
-                const url = row.click_url || '';
-                let service = url;
-                if (url.includes('duos.org')) service = 'DUOS';
-                else if (url.includes('dbgap.ncbi.nlm.nih.gov')) service = 'dbGaP';
+                const serviceCell = showService ? `<td>${escapeHtml(serviceName(row.click_url || ''))}</td>` : '';
                 return `
                     <tr>
                         <td>${datasetCell}</td>
-                        <td>${escapeHtml(service)}</td>
+                        ${serviceCell}
                         <td class="col-number">${formatNumber(row.count || 0)}</td>
                     </tr>
                 `;


### PR DESCRIPTION
## Ticket
Closes #4879

## Summary
- Add DUOS access request tracking to HCA analytics report via `access_request_urls=["duos.org"]`
- Normalize page paths to entity base path so counts are grouped by project (e.g., `/projects/UUID/get-curl-command` and `/projects/UUID/project-metadata` merge into `/projects/UUID`)
- Conditionally hide summary cards and Service column when only one access request service exists (HCA has DUOS only; Anvil keeps both cards and column since it has DUOS + dbGaP)
- Dynamic entity label in table header (shows "Project" for HCA, "Dataset" for Anvil)

## Test plan
- [x] Regenerated HCA analytics site and verified access requests table renders with 3 grouped project rows
- [x] Verified no summary cards appear (single service)
- [x] Verified Service column is hidden (single service)
- [x] Verified table header shows "Project" not "Dataset"

🤖 Generated with [Claude Code](https://claude.com/claude-code)