### PR TITLE
chore: replace Zendesk FAB with help page link for HCA DCP

### DIFF
--- a/site-config/hca-dcp/ma-dev/layout/floating.ts
+++ b/site-config/hca-dcp/ma-dev/layout/floating.ts
@@ -1,34 +1,24 @@
-import { REQUEST_FIELD_ID } from "@databiosphere/findable-ui/lib/components/Support/components/SupportRequest/components/SupportRequestForm/common/entities";
+import { ViewSupport } from "@databiosphere/findable-ui/lib/components/Support/components/ViewSupport/viewSupport";
 import { ComponentConfig } from "@databiosphere/findable-ui/lib/config/entities";
 import * as C from "app/components";
 import * as V from "../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
 import { SiteConfig } from "../../../common/entities";
 
-const ZENDESK_FIELD_ID: Record<REQUEST_FIELD_ID, number> = {
-  DESCRIPTION: 360007369412,
-  EMAIL: 360012782111,
-  SUBJECT: 360007369392,
-  TICKET_FORM_ID: 360000932232,
-  TYPE: 360012744452,
-};
-const ZENDESK_REQUEST_URL = "https://support.terra.bio/api/v2/requests.json";
-const ZENDESK_UPLOAD_URL = "https://support.terra.bio/api/v2/uploads";
-
-export const FLOATING: SiteConfig["layout"]["floating"] = {
-  components: [
-    {
-      component: C.CookieBanner,
-      viewBuilder: V.buildCookieBanner,
-    } as ComponentConfig<typeof C.CookieBanner>,
-    {
-      component: C.SupportRequest,
-      props: {
-        supportRequest: {
-          FIELD_ID: ZENDESK_FIELD_ID,
-          requestURL: ZENDESK_REQUEST_URL,
-          uploadURL: ZENDESK_UPLOAD_URL,
+export function getFloating(
+  portalUrl: string
+): SiteConfig["layout"]["floating"] {
+  return {
+    components: [
+      {
+        component: C.CookieBanner,
+        viewBuilder: V.buildCookieBanner,
+      } as ComponentConfig<typeof C.CookieBanner>,
+      {
+        component: ViewSupport,
+        props: {
+          url: `${portalUrl}/help`,
         },
-      },
-    } as ComponentConfig<typeof C.SupportRequest>,
-  ],
-};
+      } as ComponentConfig<typeof ViewSupport>,
+    ],
+  };
+}

--- a/site-config/hca-dcp/ma-dev/layout/layout.ts
+++ b/site-config/hca-dcp/ma-dev/layout/layout.ts
@@ -1,5 +1,5 @@
 import { SiteConfig } from "../../../common/entities";
-import { FLOATING } from "./floating";
+import { getFloating } from "./floating";
 import { getFooter } from "./footer";
 import { getHeader } from "./header";
 
@@ -14,7 +14,7 @@ export function getLayout(
   portalUrl: string
 ): SiteConfig["layout"] {
   return {
-    floating: FLOATING,
+    floating: getFloating(portalUrl),
     footer: getFooter(portalUrl),
     header: getHeader(appTitle, portalUrl),
   };


### PR DESCRIPTION
## Ticket
Closes #4881

## Summary
- Replaced the Zendesk support form FAB with a `ViewSupport` link to the HCA Data Portal help page (`${portalUrl}/help`)
- Converted `FLOATING` constant to `getFloating(portalUrl)` function to accept the portal URL
- Mirrors the AnVIL CMG change from #4873

## Test plan
- [ ] Verify FAB links to the help page instead of opening a Zendesk form
- [ ] Verify cookie banner still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)