### PR TITLE
chore: prettier-ignore tsconfig.json so next build reformatting doesn't fail check-format (#4885)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,6 +13,8 @@ coverage
 # next.js
 .next
 out
+# managed/reformatted by `next build` into a shape prettier rejects (see #4885)
+tsconfig.json
 
 # production
 build


### PR DESCRIPTION
## Summary

Closes #4885.

`next build` / `next dev` rewrites `tsconfig.json` into a multiline shape (expanded arrays + a `.next/dev/types/**/*.ts` include entry) that **fails `prettier --check`**. Because the pre-commit hook runs `check-format` (`prettier --check .`) across the whole repo, committing after a build fails the hook on `tsconfig.json` — forcing a `--no-verify` bypass — and the file shows as perpetually "modified" in `git status`.

`tsconfig.json` is a Next-managed file, so this adds it to `.prettierignore`, letting Next own its format without prettier fighting it. The committed `tsconfig.json` itself is already prettier-clean and is left unchanged.

## Change

- `.prettierignore`: add `tsconfig.json` under the existing `# next.js` section.

## Verification

- [x] With `tsconfig.json` in its build-modified (multiline) state, `npm run check-format` now exits 0 (previously failed)
- [x] Committed `tsconfig.json` unchanged and still prettier-clean
- [x] Pre-commit hook (check-format + lint + tsc) passes without `--no-verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)