### PR TITLE
chore: update default catalog to anvil14

### DIFF
--- a/site-config/anvil-cmg/prod/config.ts
+++ b/site-config/anvil-cmg/prod/config.ts
@@ -9,7 +9,7 @@ const config: SiteConfig = {
     "https://anvilproject.org",
     "https://service.explore.anvilproject.org",
     GIT_HUB_REPO_URL,
-    "anvil13"
+    "anvil14"
   ),
   exportToTerraUrl: "https://anvil.terra.bio/",
 };


### PR DESCRIPTION
## Summary
- Updates AnVIL default catalog from `anvil13` to `anvil14`

Closes #4883

## Test plan
- [ ] Verify AnVIL explorer loads with anvil14 catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)