### PR TITLE
ci: pin github actions by commit sha at current versions

### DIFF
--- a/.github/workflows/deploy-analytics.yml
+++ b/.github/workflows/deploy-analytics.yml
@@ -25,16 +25,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: "gh-pages"
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -5,8 +5,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.12.0"
       - run: |

--- a/.github/workflows/run-playwright-tests-anvil-catalog.yml
+++ b/.github/workflows/run-playwright-tests-anvil-catalog.yml
@@ -9,8 +9,8 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.12.0"
       - name: Install dependencies
@@ -28,7 +28,7 @@ jobs:
       - name: Run Playwright tests
         run: |
           npm run test:anvil-catalog
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/run-playwright-tests-anvil-cmg.yml
+++ b/.github/workflows/run-playwright-tests-anvil-cmg.yml
@@ -9,8 +9,8 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.12.0"
       - name: Install dependencies
@@ -28,7 +28,7 @@ jobs:
       - name: Check backend status again - TEST RESULTS ARE NOT VALID IF THIS FAILS
         run: |
           npm run check-system-status:anvil-cmg
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
Closes #4893

Upgrades every action reference in the workflows to its current version and converts all tag pins to commit SHA pins with version comments, exactly per the table in #4893. Each SHA was resolved and verified against the upstream tag. Same change already merged and green in anvilproject/anvil-portal#4040.

## Test plan

- Workflows that trigger on pull requests validate the new pins on this PR itself.
- Workflows that only run on push to the default branch or on dispatch complete a green run after merge, via the next natural trigger or a manual dispatch, with no Node deprecation annotations.
- After the green runs, the allowlist tightening described in #4893 (remove the actions/* wildcard) is applied and the push/dispatch workflows are re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)