### PR TITLE
feat: support excluding anomalous dates from static analytics reports (#4907)

### DIFF
--- a/analytics/analytics_package/analytics/static_site/fetch.py
+++ b/analytics/analytics_package/analytics/static_site/fetch.py
@@ -363,6 +363,9 @@ def fetch_data(
         custom_events = []
 
     if exclude_dates:
+        for d in exclude_dates:
+            if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", d):
+                raise ValueError(f"exclude_dates entries must be YYYY-MM-DD, got: {d!r}")
         base_dimension_filter = parse_filter_expressions(
             [
                 base_dimension_filter,

--- a/analytics/analytics_package/analytics/static_site/fetch.py
+++ b/analytics/analytics_package/analytics/static_site/fetch.py
@@ -4,6 +4,7 @@ import re
 from urllib.parse import urlparse, parse_qs
 
 from .. import sheets_elements as elements
+from ..api import parse_filter_expressions
 from .._sheets_utils import get_data_df_from_fields
 from ..entities import (
     DIMENSION_YEAR_MONTH,
@@ -337,6 +338,7 @@ def fetch_data(
     exclude_pages=None,
     base_dimension_filter=None,
     search_path=None,
+    exclude_dates=None,
 ):
     """Fetch all analytics data for the static site.
 
@@ -350,12 +352,25 @@ def fetch_data(
         exclude_pages: Optional list of page paths to exclude from pageview data.
         base_dimension_filter: Optional GA4 dimension filter dict applied to all queries.
         search_path: Optional search page path to extract search queries from (e.g., "/search").
+        exclude_dates: Optional list of dates (YYYY-MM-DD) to exclude from all queries,
+            e.g. days with known synthetic/bot traffic. Applies to GA4 queries only,
+            not to data merged from historic_data_path.
 
     Returns:
         Dict containing DataFrames and stats for each data type.
     """
     if custom_events is None:
         custom_events = []
+
+    if exclude_dates:
+        base_dimension_filter = parse_filter_expressions(
+            [
+                base_dimension_filter,
+                ";".join(f"date!={d.replace('-', '')}" for d in exclude_dates),
+            ],
+            False,
+        )
+        print(f"Excluding dates from all queries: {', '.join(exclude_dates)}")
 
     report_dates = elements.get_bounds_for_month_and_prev(current_month)
     start_date_current = report_dates["start_current"]

--- a/analytics/analytics_package/analytics/static_site/fetch.py
+++ b/analytics/analytics_package/analytics/static_site/fetch.py
@@ -1,6 +1,7 @@
 """Fetch analytics data from GA4 for the static site."""
 
 import re
+from datetime import date
 from urllib.parse import urlparse, parse_qs
 
 from .. import sheets_elements as elements
@@ -366,6 +367,7 @@ def fetch_data(
         for d in exclude_dates:
             if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", d):
                 raise ValueError(f"exclude_dates entries must be YYYY-MM-DD, got: {d!r}")
+            date.fromisoformat(d)
         base_dimension_filter = parse_filter_expressions(
             [
                 base_dimension_filter,

--- a/analytics/analytics_package/analytics/static_site/generator.py
+++ b/analytics/analytics_package/analytics/static_site/generator.py
@@ -24,6 +24,7 @@ def generate_site(
     exclude_pages=None,
     base_dimension_filter=None,
     search_path=None,
+    exclude_dates=None,
 ):
     """Generate a static analytics site.
 
@@ -48,6 +49,9 @@ def generate_site(
         base_dimension_filter: Optional GA4 dimension filter dict applied to all queries
             (e.g., an audience filter to exclude bot/tutorial traffic).
         search_path: Optional search page path to extract search queries from (e.g., "/search").
+        exclude_dates: Optional list of dates (YYYY-MM-DD) to exclude from all queries,
+            e.g. days with known synthetic/bot traffic. Applies to GA4 queries only,
+            not to data merged from historic_data_path.
     """
     if custom_events is None:
         custom_events = []
@@ -69,6 +73,7 @@ def generate_site(
         exclude_pages=exclude_pages,
         base_dimension_filter=base_dimension_filter,
         search_path=search_path,
+        exclude_dates=exclude_dates,
     )
 
     if title_resolver:

--- a/analytics/anvil-explorer-sheets/constants.py
+++ b/analytics/anvil-explorer-sheets/constants.py
@@ -7,6 +7,9 @@ PARENT_FOLDER_NAME = "July 2026"
 # The name of the spreadsheet with the report
 SHEET_NAME = "AnVIL Explorer"
 ANVIL_EXPLORER_ID = "383267328"
+# Dates of known synthetic/bot traffic (headless-browser burst, likely a load test)
+# to exclude from reports; see DataBiosphere/data-browser#4907.
+EXCLUDE_BOT_TRAFFIC_DATES = ["2025-02-10", "2025-02-11"]
 SECRET_NAME = 'ANVIL_ANALYTICS_REPORTING_CLIENT_SECRET_PATH'
 GA_PROPERTY_PORTAL = "368678391" # AnVIL Explorer - GA4
 ANALYTICS_START = "2024-01-01"

--- a/analytics/anvil-explorer-sheets/generate_static_site.py
+++ b/analytics/anvil-explorer-sheets/generate_static_site.py
@@ -5,7 +5,7 @@ import os
 
 import analytics.api as ga
 from analytics.static_site import generate_site, enrich_detail_records, make_event_charts
-from constants import CURRENT_MONTH, ANVIL_EXPLORER_ID, SECRET_NAME, ANALYTICS_START, OAUTH_PORT
+from constants import CURRENT_MONTH, ANVIL_EXPLORER_ID, SECRET_NAME, ANALYTICS_START, OAUTH_PORT, EXCLUDE_BOT_TRAFFIC_DATES
 from utils import fetch_dataset_title_map
 
 os.environ.setdefault(SECRET_NAME, "../../.credentials/anvil_ga4_credentials.json")
@@ -95,4 +95,5 @@ generate_site(
     event_charts=make_event_charts("Dataset", "/datasets", "2026-03-01"),
     title_resolver=resolve_dataset_titles,
     access_request_urls=["duos.org", "dbgap.ncbi.nlm.nih.gov"],
+    exclude_dates=EXCLUDE_BOT_TRAFFIC_DATES,
 )

--- a/gh-pages/anvil-explorer/data/meta.json
+++ b/gh-pages/anvil-explorer/data/meta.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-06 22:50:04",
+  "generated_at": "2026-08-07 01:01:11",
   "current_month": "2026-07",
   "current_month_start": "2026-07-01",
   "current_month_end": "2026-07-31",

--- a/gh-pages/anvil-explorer/data/monthly_traffic.json
+++ b/gh-pages/anvil-explorer/data/monthly_traffic.json
@@ -86,8 +86,8 @@
   },
   {
     "month": "2025-02",
-    "users": 9480,
-    "pageviews": 19951
+    "users": 277,
+    "pageviews": 2239
   },
   {
     "month": "2025-01",


### PR DESCRIPTION
Closes #4907

## What changed

- `analytics/analytics_package/analytics/static_site/fetch.py`: `fetch_data()` gains an optional `exclude_dates` parameter (list of YYYY-MM-DD strings). When set, the dates are compiled into a GA4 dimension filter via the package's existing filter DSL (`date!=YYYYMMDD;...` through `parse_filter_expressions`) and AND-merged into `base_dimension_filter`, so every query the dashboard makes excludes those days.
- `analytics/analytics_package/analytics/static_site/generator.py`: passes the new parameter through `generate_site()`.
- `analytics/anvil-explorer-sheets/constants.py` + `generate_static_site.py`: new `EXCLUDE_BOT_TRAFFIC_DATES = ["2025-02-10", "2025-02-11"]` constant, passed as `exclude_dates`.
- `gh-pages/anvil-explorer/`: regenerated. Only `monthly_traffic.json` (Feb 2025: 9,480 → 277 users, 19,951 → 2,239 pageviews) and `meta.json` (timestamp) changed; all other data files are byte-identical.

## Why

GA4 recorded a synthetic traffic burst on 2025-02-10/11: ~9,160 "users" sharing one fingerprint (headless-Chrome 800×600 viewport, single geolocation, every session a first visit) hammering the site — likely a load test. It shows as a bogus spike in the dashboard's monthly traffic chart. GA4 cannot retroactively remove data, so the report queries exclude those dates instead. Excluding at query time (rather than post-processing) keeps GA's user deduplication correct — daily user counts are not additive, so client-side subtraction would corrupt user metrics.

## Assumptions I made

- Date exclusion (losing the ~50–70 real users on those two days) was chosen over fingerprint-based filtering, which would silently drop matching traffic forever; the two days are ~0.1% of the chart's range.
- The dates live in per-site constants (property-specific facts), not in the package.
- The exclusion applies to GA4 queries only, not to `historic_data_path` (pre-GA4 UA history) — documented in both docstrings; no current caller combines the two in an affected range.
- The regenerated data was verified equivalent to a direct GA4 Data API query with the same filter before committing, so no other data files needed to change.
- anvil-portal will consume this via its `analytics` dependency on this repo's `main` for the same fix there (anvilproject/anvil-portal#4077).

## How to verify

Definition of done from #4907: (1) the package supports excluding dates from report queries, (2) the AnVIL Explorer report excludes 2025-02-10/11, (3) the regenerated site no longer shows the spike.

1. Open `gh-pages/anvil-explorer/data/monthly_traffic.json` and find the `2025-02` entry: it should read 277 users / 2,239 pageviews (previously 9,480 / 19,951). Cross-check in the GA4 UI: AnVIL Explorer property, Feb 2025, exclude Feb 10–11.
2. Serve the site locally (`cd gh-pages/anvil-explorer && python -m http.server 8080`) and look at the Monthly Traffic Over Time chart: February 2025 should look like an ordinary month, no spike.
3. Confirm every other file under `gh-pages/anvil-explorer/data/` is unchanged in this diff (only `meta.json`'s `generated_at` moved) — the exclusion touched nothing outside those two days.
4. Optionally regenerate end-to-end: `cd analytics/anvil-explorer-sheets && python generate_static_site.py` (requires GA4 OAuth); the console prints "Excluding dates from all queries: 2025-02-10, 2025-02-11".

🤖 Generated with [Claude Code](https://claude.com/claude-code)