### PR TITLE
ci: auto-merge dependabot patch bumps for dev and transitive deps (#4915)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'DataBiosphere/data-browser'
+    steps:
+      - uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        id: metadata
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      # Auto-merge only patch-level bumps of dev-only or transitive dependencies;
+      # runtime dependencies and minor/major bumps stay manual.
+      - if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' &&
+          contains(fromJSON('["direct:development", "indirect"]'), steps.metadata.outputs.dependency-type)
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #4915.

Adds a `dependabot-auto-merge` workflow. For PRs authored by `dependabot[bot]`, it reads update metadata via `dependabot/fetch-metadata` (SHA-pinned, matching this repo's convention) and, **only** when the bump is patch-level (`version-update:semver-patch`) **and** the dependency is dev-only (`direct:development`) or transitive (`indirect`), approves the PR and enables GitHub auto-merge with squash.

Everything else — runtime (`direct:production`) dependencies and any minor/major bump — is untouched and stays on manual review.

Rationale: these PRs (e.g. #4904) are lockfile-only, never ship to production, and cannot change any API the app codes against; CI is the only meaningful gate.

### Accompanying repo settings (admin, done outside this PR)

- **Allow auto-merge** enabled in repo settings (was off; `gh pr merge --auto` fails without it).
- **`build` added as a required status check** on `main` (there were previously none, so auto-merge would have merged before CI completed). `main` already required 1 approving review; the workflow's approval satisfies that for matching Dependabot PRs.

### Known caveat

Merges completed via the workflow's `GITHUB_TOKEN` do not trigger `push`-event workflows, so `release-please` will not run on these merges. Nothing is lost — it picks up the `chore(deps)` commits on the next push to `main` (or via `workflow_dispatch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)