### PR TITLE
ci: read node version from .nvmrc in github workflows (#4919)

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -9,6 +9,10 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
+          cache: "npm"
+          cache-dependency-path: |
+            package-lock.json
+            files/package-lock.json
       - run: |
           npm ci
           npm run check-format

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22.12.0"
+          node-version-file: ".nvmrc"
       - run: |
           npm ci
           npm run check-format

--- a/.github/workflows/run-playwright-tests-anvil-catalog.yml
+++ b/.github/workflows/run-playwright-tests-anvil-catalog.yml
@@ -13,6 +13,10 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
+          cache: "npm"
+          cache-dependency-path: |
+            package-lock.json
+            files/package-lock.json
       - name: Install dependencies
         run: |
           npm ci

--- a/.github/workflows/run-playwright-tests-anvil-catalog.yml
+++ b/.github/workflows/run-playwright-tests-anvil-catalog.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22.12.0"
+          node-version-file: ".nvmrc"
       - name: Install dependencies
         run: |
           npm ci

--- a/.github/workflows/run-playwright-tests-anvil-cmg.yml
+++ b/.github/workflows/run-playwright-tests-anvil-cmg.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
+          cache: "npm"
+          cache-dependency-path: "package-lock.json"
       - name: Install dependencies
         run: |
           npm ci

--- a/.github/workflows/run-playwright-tests-anvil-cmg.yml
+++ b/.github/workflows/run-playwright-tests-anvil-cmg.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22.12.0"
+          node-version-file: ".nvmrc"
       - name: Install dependencies
         run: |
           npm ci

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The HCA Data Browser is built using [Next.js](https://nextjs.org/).
 
 ## Prerequisites
 
-Node.js 22.12.0 is required to run the app.
+Node.js 22.13.0 (see `.nvmrc`) is required to run the app.
 
 ### 1. Clone the Repo
 

--- a/cc-anvil-catalog-dev-deploy.sh
+++ b/cc-anvil-catalog-dev-deploy.sh
@@ -6,7 +6,7 @@ rm -rf ./out
 echo \"Deleting ./build/\"
 rm -rf ./build
 
-n 22.12.0
+n $(cat .nvmrc)
 npm ci
 export NEXT_PUBLIC_BASE_PATH="/data"
 

--- a/cc-anvil-catalog-dev-deploy.sh
+++ b/cc-anvil-catalog-dev-deploy.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Set the script to exit immediately on error
+set -e
 
 echo \"Deleting ./out/\"
 rm -rf ./out
@@ -6,7 +8,7 @@ rm -rf ./out
 echo \"Deleting ./build/\"
 rm -rf ./build
 
-n $(cat .nvmrc)
+n "$(cat .nvmrc)"
 npm ci
 export NEXT_PUBLIC_BASE_PATH="/data"
 

--- a/cc-data-browser.lungmap.dev.clevercanary.com-deploy.sh
+++ b/cc-data-browser.lungmap.dev.clevercanary.com-deploy.sh
@@ -5,7 +5,7 @@ set -e
 echo \"Deleting ./out/\"
 rm -rf ./out
 
-n $(cat .nvmrc)
+n "$(cat .nvmrc)"
 npm ci
 
 # Build

--- a/cc-data-browser.lungmap.dev.clevercanary.com-deploy.sh
+++ b/cc-data-browser.lungmap.dev.clevercanary.com-deploy.sh
@@ -5,7 +5,7 @@ set -e
 echo \"Deleting ./out/\"
 rm -rf ./out
 
-n 22.12.0
+n $(cat .nvmrc)
 npm ci
 
 # Build

--- a/cc-explore.anvilproject.dev.clevercanary.com-deploy.sh
+++ b/cc-explore.anvilproject.dev.clevercanary.com-deploy.sh
@@ -8,7 +8,7 @@ rm -rf ./out
 echo \"Deleting ./build/\"
 rm -rf ./build
 
-n $(cat .nvmrc)
+n "$(cat .nvmrc)"
 npm ci
 
 mkdir -p build/explore/anvil-cmg

--- a/cc-explore.anvilproject.dev.clevercanary.com-deploy.sh
+++ b/cc-explore.anvilproject.dev.clevercanary.com-deploy.sh
@@ -8,7 +8,7 @@ rm -rf ./out
 echo \"Deleting ./build/\"
 rm -rf ./build
 
-n 22.12.0
+n $(cat .nvmrc)
 npm ci
 
 mkdir -p build/explore/anvil-cmg

--- a/cgl-anvil-catalog-prod-deploy.sh
+++ b/cgl-anvil-catalog-prod-deploy.sh
@@ -8,7 +8,7 @@ rm -rf ./out
 echo \"Deleting ./build/\"
 rm -rf ./build
 
-n 22.12.0
+n $(cat .nvmrc)
 npm ci
 export NEXT_PUBLIC_BASE_PATH="/data"
 

--- a/cgl-anvil-catalog-prod-deploy.sh
+++ b/cgl-anvil-catalog-prod-deploy.sh
@@ -8,7 +8,7 @@ rm -rf ./out
 echo \"Deleting ./build/\"
 rm -rf ./build
 
-n $(cat .nvmrc)
+n "$(cat .nvmrc)"
 npm ci
 export NEXT_PUBLIC_BASE_PATH="/data"
 


### PR DESCRIPTION
Closes #4919

## What changed

- `run-checks.yml`, `run-playwright-tests-anvil-catalog.yml`, `run-playwright-tests-anvil-cmg.yml`: `actions/setup-node` now uses `node-version-file: ".nvmrc"` instead of a hard-coded `node-version: "22.12.0"`, and enables npm caching (`cache: "npm"`). The two workflows that install `files/` dependencies key the cache on both lockfiles; anvil-cmg keys on the root lockfile only, since it never installs `files/`.
- The four deploy scripts (`cgl-anvil-catalog-prod-deploy.sh`, `cc-anvil-catalog-dev-deploy.sh`, `cc-data-browser.lungmap.dev.clevercanary.com-deploy.sh`, `cc-explore.anvilproject.dev.clevercanary.com-deploy.sh`): `n 22.12.0` → `n $(cat .nvmrc)`, so deploys build on the same Node CI tests.
- `README.md`: prerequisite updated from 22.12.0 to 22.13.0 with a pointer to `.nvmrc`.

## Why

CI had drifted to Node 22.12.0 while the repo's pin (`package.json` engines, `.gitlab/Dockerfile`, and `.nvmrc` from #4918) is 22.13.0 — and the deploy scripts had drifted the same way, so production artifacts were built on a Node version CI never tested. Reading `.nvmrc` everywhere makes it the single source of truth: a future Node bump touches `.nvmrc`, `engines`, and the GitLab Dockerfile, and CI plus deploys follow automatically. Matches the convention in clevercanary/hca-atlas-tracker. Completes the remaining workflows item from #4876.

## Assumptions I made

- The deploy scripts always run from the repo root (they already reference `./out` and `npm ci` relative to it), so `$(cat .nvmrc)` resolves.
- Uniform npm caching is wanted in all three workflows even though it slightly grows the anvil-cmg job's setup step on cache miss; on hit it saves the full registry download.
- Playwright browser caching (a larger recurring CI cost) was deliberately left out to keep this change scoped; it's tracked as #4920.
- The triplicated setup-node block was left as-is: the repo has no composite-action convention, and three copies of six lines didn't justify introducing one.

## How to verify

Definition of done from #4919, mapped to steps:

- [ ] **All three workflows read the version from `.nvmrc`** — open the "Run checks" run for this PR, expand the `setup-node` step, and confirm it logs `Resolved .nvmrc as 22.13.0` and installs Node 22.13.0 (not 22.12.0). Repeat for either Playwright workflow run.
- [ ] **No workflow hard-codes a Node version** — `grep -rn "node-version:" .github/workflows/` returns nothing; only `node-version-file` remains.
- [ ] **npm cache is active** — in the same `setup-node` step log, confirm the npm cache is saved/restored (first run saves, re-run of the job restores).
- [ ] **Deploy scripts follow the pin** — `grep -n "^n " *.sh` shows `n $(cat .nvmrc)` in all four deploy scripts; running one locally (e.g. the anvil-catalog dev deploy up to the `npm ci` line) switches to Node 22.13.0 with no EBADENGINE warning.
- [ ] **#4876 follow-through** — with this merged, the "workflows on 22.13.0" item on #4876 is satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)