### PR TITLE
fix: generalize access-request service classification and stat cards in analytics template (#4922)

### DIFF
--- a/analytics/analytics_package/analytics/static_site/template/index.html
+++ b/analytics/analytics_package/analytics/static_site/template/index.html
@@ -907,10 +907,12 @@
             const heading = document.getElementById('access-requests-heading');
             const tbody = document.querySelector('#access-requests-table tbody');
 
+            // Null prototype: a service named like an Object.prototype member
+            // (e.g. a "constructor" hostname) must not collide with inherited keys.
             const countsByService = data.reduce((counts, r) => {
                 counts[r.service] = (counts[r.service] || 0) + r.count;
                 return counts;
-            }, {});
+            }, Object.create(null));
             const total = Object.values(countsByService).reduce((sum, count) => sum + count, 0);
             const showService = Object.keys(countsByService).length > 1;
 

--- a/analytics/analytics_package/analytics/static_site/template/index.html
+++ b/analytics/analytics_package/analytics/static_site/template/index.html
@@ -149,6 +149,8 @@
 
         @media (max-width: 767px) {
             .fui-card[class*="fui-grid-item"] { grid-column: 1 / -1; }
+            /* !important: beats the inline grid-template-columns set per-render */
+            #access-requests-stats { grid-template-columns: 1fr !important; }
         }
     </style>
 </head>
@@ -363,9 +365,20 @@
         let entityPath = '/datasets';
 
         function serviceName(url) {
-            if (url.includes('duos.org')) return 'DUOS';
-            if (url.includes('dbgap.ncbi.nlm.nih.gov')) return 'dbGaP';
-            return url;
+            if (typeof url !== 'string' || !url) return 'Other';
+            // Match case-insensitively — the Python generator filters click URLs
+            // with case=False (fetch.py), so classification must be no stricter.
+            const normalizedUrl = url.toLowerCase();
+            if (normalizedUrl.includes('duos.org')) return 'DUOS';
+            if (normalizedUrl.includes('dbgap.ncbi.nlm.nih.gov')) return 'dbGaP';
+            try {
+                // Tolerate schemeless URLs, and strip "www." so host variants
+                // of one service land in the same bucket.
+                const withScheme = normalizedUrl.includes('://') ? normalizedUrl : `https://${normalizedUrl}`;
+                return new URL(withScheme).hostname.replace(/^www\./, '') || 'Other';
+            } catch (e) {
+                return 'Other';
+            }
         }
 
         let chartColors = {
@@ -384,7 +397,7 @@
 
         async function loadData() {
             try {
-                const [configRes, trafficRes, pageviewsRes, outboundRes, filtersRes, downloadsRes, eventsRes, metaRes, searchRes, fileDownloadEventsRes, eventChartsRes] = await Promise.all([
+                const [configRes, trafficRes, pageviewsRes, outboundRes, filtersRes, downloadsRes, eventsRes, metaRes, searchRes, fileDownloadEventsRes, eventChartsRes, accessRequestsRes] = await Promise.all([
                     fetch('data/config.json'),
                     fetch('data/monthly_traffic.json'),
                     fetch('data/pageviews.json'),
@@ -396,6 +409,7 @@
                     fetch('data/search_queries.json').catch(() => null),
                     fetch('data/file_download_events.json').catch(() => null),
                     fetch('data/event_charts.json').catch(() => null),
+                    fetch('data/access_requests.json').catch(() => null),
                 ]);
 
                 const [config, traffic, pageviews, outbound, filters, downloads, events, meta] = await Promise.all([
@@ -405,6 +419,7 @@
                 const searchQueries = searchRes ? await searchRes.json().catch(() => null) : null;
                 const fileDownloadEvents = fileDownloadEventsRes ? await fileDownloadEventsRes.json().catch(() => null) : null;
                 const eventCharts = eventChartsRes && eventChartsRes.ok ? await eventChartsRes.json().catch(() => null) : null;
+                const accessRequests = accessRequestsRes && accessRequestsRes.ok ? await accessRequestsRes.json().catch(() => null) : null;
 
                 applyConfig(config);
                 renderMeta(meta);
@@ -416,7 +431,13 @@
                 renderOutboundTable(outbound);
                 renderFiltersTable(filters);
                 renderFileDownloadsTable(downloads);
-                renderAccessRequestsTable();
+                try {
+                    // Access requests are optional/best-effort — a bad payload
+                    // must not blank the rest of the report.
+                    renderAccessRequestsTable(accessRequests);
+                } catch (accessRequestsError) {
+                    console.error('Error rendering access requests:', accessRequestsError);
+                }
                 renderSearchQueries(searchQueries);
                 renderFileDownloadEvents(fileDownloadEvents);
                 renderEventCounts(config, events, eventCharts);
@@ -875,50 +896,39 @@
             document.getElementById('file-downloads-count').textContent = formatNumber(downloads.total);
         }
 
-        async function renderAccessRequestsTable() {
-            let data;
-            try {
-                const res = await fetch('data/access_requests.json');
-                if (!res.ok) return;
-                data = await res.json();
-            } catch (e) {
-                return;
-            }
-            if (!data || data.length === 0) return;
+        function renderAccessRequestsTable(accessRequests) {
+            if (!Array.isArray(accessRequests)) return;
+            const data = accessRequests
+                .filter(r => r && typeof r === 'object')
+                .map(r => ({ ...r, count: Number(r.count) || 0, service: serviceName(r.click_url) }));
+            if (data.length === 0) return;
 
             const card = document.getElementById('access-requests-card');
             const heading = document.getElementById('access-requests-heading');
             const tbody = document.querySelector('#access-requests-table tbody');
-            const total = data.reduce((sum, r) => sum + (r.count || 0), 0);
 
-            const services = new Set(data.map(r => serviceName(r.click_url || '')));
-            const showService = services.size > 1;
+            const countsByService = data.reduce((counts, r) => {
+                counts[r.service] = (counts[r.service] || 0) + r.count;
+                return counts;
+            }, {});
+            const total = Object.values(countsByService).reduce((sum, count) => sum + count, 0);
+            const showService = Object.keys(countsByService).length > 1;
 
             const statsGrid = document.getElementById('access-requests-stats');
             if (showService) {
-                const duosTotal = data.filter(r => serviceName(r.click_url || '') === 'DUOS').reduce((sum, r) => sum + (r.count || 0), 0);
-                const dbgapTotal = data.filter(r => serviceName(r.click_url || '') === 'dbGaP').reduce((sum, r) => sum + (r.count || 0), 0);
+                const statCards = Object.entries(countsByService)
+                    .sort(([a], [b]) => a.localeCompare(b))
+                    .concat([['Total', total]]);
                 statsGrid.style.display = '';
-                statsGrid.innerHTML = `
-                    <div class="fui-card fui-grid-item-4" style="text-align: center;">
+                statsGrid.style.gridTemplateColumns = `repeat(${statCards.length}, 1fr)`;
+                statsGrid.innerHTML = statCards.map(([label, count]) => `
+                    <div class="fui-card" style="text-align: center;">
                         <div class="fui-card-content">
-                            <div class="stat-value">${formatNumber(dbgapTotal)}</div>
-                            <div class="stat-label">dbGaP</div>
+                            <div class="stat-value">${formatNumber(count)}</div>
+                            <div class="stat-label">${escapeHtml(label)}</div>
                         </div>
                     </div>
-                    <div class="fui-card fui-grid-item-4" style="text-align: center;">
-                        <div class="fui-card-content">
-                            <div class="stat-value">${formatNumber(duosTotal)}</div>
-                            <div class="stat-label">DUOS</div>
-                        </div>
-                    </div>
-                    <div class="fui-card fui-grid-item-4" style="text-align: center;">
-                        <div class="fui-card-content">
-                            <div class="stat-value">${formatNumber(total)}</div>
-                            <div class="stat-label">Total</div>
-                        </div>
-                    </div>
-                `;
+                `).join('');
             }
 
             card.style.display = '';
@@ -941,12 +951,12 @@
                 const datasetCell = link
                     ? `<a href="${safeHref(link)}" target="_blank" rel="noopener noreferrer">${escapeHtml(label)}</a>`
                     : escapeHtml(label);
-                const serviceCell = showService ? `<td>${escapeHtml(serviceName(row.click_url || ''))}</td>` : '';
+                const serviceCell = showService ? `<td>${escapeHtml(row.service)}</td>` : '';
                 return `
                     <tr>
                         <td>${datasetCell}</td>
                         ${serviceCell}
-                        <td class="col-number">${formatNumber(row.count || 0)}</td>
+                        <td class="col-number">${formatNumber(row.count)}</td>
                     </tr>
                 `;
             }).join('');

--- a/analytics/analytics_package/analytics/static_site/template/index.html
+++ b/analytics/analytics_package/analytics/static_site/template/index.html
@@ -364,21 +364,33 @@
         let entityLabel = 'Dataset';
         let entityPath = '/datasets';
 
+        // True when hostname is domain itself or one of its subdomains, so that
+        // "notduos.org.example.com" and "evil.com/?ref=duos.org" don't match.
+        function isHost(hostname, domain) {
+            return hostname === domain || hostname.endsWith(`.${domain}`);
+        }
+
         function serviceName(url) {
             if (typeof url !== 'string' || !url) return 'Other';
-            // Match case-insensitively — the Python generator filters click URLs
-            // with case=False (fetch.py), so classification must be no stricter.
+            // Classify on the parsed hostname, not the raw URL. Matching is
+            // case-insensitive — the Python generator filters click URLs with
+            // case=False (fetch.py), so classification must be no stricter.
             const normalizedUrl = url.toLowerCase();
-            if (normalizedUrl.includes('duos.org')) return 'DUOS';
-            if (normalizedUrl.includes('dbgap.ncbi.nlm.nih.gov')) return 'dbGaP';
+            let hostname;
             try {
                 // Tolerate schemeless URLs, and strip "www." so host variants
                 // of one service land in the same bucket.
                 const withScheme = normalizedUrl.includes('://') ? normalizedUrl : `https://${normalizedUrl}`;
-                return new URL(withScheme).hostname.replace(/^www\./, '') || 'Other';
+                hostname = new URL(withScheme).hostname.replace(/^www\./, '');
             } catch (e) {
                 return 'Other';
             }
+            // Require a dot so garbage ("not-a-url") buckets as Other rather
+            // than becoming its own service label.
+            if (!hostname.includes('.')) return 'Other';
+            if (isHost(hostname, 'duos.org')) return 'DUOS';
+            if (isHost(hostname, 'dbgap.ncbi.nlm.nih.gov')) return 'dbGaP';
+            return hostname;
         }
 
         let chartColors = {


### PR DESCRIPTION
Closes #4922

## What changed

All changes are in the shared static analytics template (`analytics/analytics_package/analytics/static_site/template/index.html`), fixing items 1–4 of #4909:

- **`serviceName()` generalized and hardened**: matches known services case-insensitively (parity with `fetch.py`'s `case=False` filtering), buckets unknown services by hostname (tolerating schemeless URLs, stripping `www.` so host variants merge), and returns "Other" for missing, non-string, or unparseable URLs.
- **Stats cards generic over N services**: the access-requests stats grid is built from a single service→count reduce — one card per present service plus Total, alphabetically sorted, laid out with `grid-template-columns: repeat(N, 1fr)` so any card count fills the row evenly (with a mobile override so cards still stack under 768px). Previously exactly dbGaP/DUOS/Total were hardcoded, so a third service was counted in Total but got no card.
- **Robust data handling**: `access_requests.json` is now fetched in `loadData`'s `Promise.all` alongside the other optional files (no extra serialized round-trip), rows are validated (`Array.isArray`, non-object rows filtered, counts coerced with `Number(...) || 0`), `total` is derived from the per-service counts so the cards always sum, and the render call is isolated in its own try/catch so a bad optional payload can't blank the rest of the report.

## How verified

- Node logic tests for `serviceName()` (mixed-case, schemeless, `www.` variants, non-hierarchical URLs, non-strings, null/undefined) and the count/grid arithmetic.
- Playwright rendering tests against a local server: synthetic multi-service data with hostile rows (string count, numeric `click_url`, null row) — 5 cards on one even row, totals sum correctly (15+2+2+3=22, table header agrees); real anvil-explorer data — single-service behavior unchanged (no stats grid, no Service column); object-instead-of-array payload — section hidden, rest of report intact, zero JS errors.
- Two `/code-review` rounds; all confirmed findings fixed. One deliberate skip: moving the DUOS/dbGaP label mapping into the Python export layer (changes the data contract; candidate follow-up ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
