### PR TITLE
chore: cap static analytics detail exports at top-n rows (#4924)

### DIFF
--- a/analytics/analytics_package/analytics/static_site/README.md
+++ b/analytics/analytics_package/analytics/static_site/README.md
@@ -52,9 +52,9 @@ For apps with dataset/project detail tables, a `title_resolver` callback enriche
     ├── config.json
     ├── meta.json
     ├── monthly_traffic.json
-    ├── pageviews.json
-    ├── outbound_links.json
-    ├── filter_selected.json
+    ├── pageviews.json                # top 100 rows
+    ├── outbound_links.json           # top 100 rows
+    ├── filter_selected.json          # top 100 rows
     ├── file_downloads.json
     ├── custom_events.json
     ├── access_requests.json          # AnVIL only

--- a/analytics/analytics_package/analytics/static_site/export.py
+++ b/analytics/analytics_package/analytics/static_site/export.py
@@ -18,8 +18,16 @@ from ..entities import (
 )
 from .fetch import event_key
 
+# Row cap for the exports the template renders as a fixed slice (top 20
+# pageviews and outbound links, top 30 filter selections); 100 leaves headroom
+# for UI changes while keeping page-load payloads and monthly regen diffs
+# bounded (e.g. AnVIL Portal shipped 1,810 pageviews rows). Event detail tables,
+# access requests and search queries stay uncapped on purpose — the template
+# renders every one of their rows.
+MAX_TABLE_EXPORT_ROWS = 100
 
-def export_df_as_json(df, col_map, change_col, filename, output_dir):
+
+def export_df_as_json(df, col_map, change_col, filename, output_dir, max_rows=None):
     """Export a DataFrame to JSON with column renaming and NaN handling.
 
     Args:
@@ -28,7 +36,13 @@ def export_df_as_json(df, col_map, change_col, filename, output_dir):
         change_col: Source column name for the change metric (may be absent).
         filename: Output JSON filename.
         output_dir: Output directory, as a Path.
+        max_rows: Maximum number of rows to export; the top rows are kept, so
+            df is expected to be sorted by relevance. None exports all rows.
     """
+    total_rows = 0 if df is None else len(df)
+    if max_rows is not None and total_rows > max_rows:
+        df = df.head(max_rows)
+        print(f"  Capped {filename} at top {max_rows} of {total_rows} rows")
     if df is None or len(df) == 0:
         records = []
     else:
@@ -108,6 +122,7 @@ def export_data(
         METRIC_PAGE_VIEWS["change_alias"],
         "pageviews.json",
         output_dir,
+        max_rows=MAX_TABLE_EXPORT_ROWS,
     )
 
     print("Exporting outbound links data...")
@@ -120,6 +135,7 @@ def export_data(
         SYNTHETIC_METRIC_CLICKS["change_alias"],
         "outbound_links.json",
         output_dir,
+        max_rows=MAX_TABLE_EXPORT_ROWS,
     )
 
     print("Exporting filter selections data...")
@@ -133,6 +149,7 @@ def export_data(
         METRIC_EVENT_COUNT["change_alias"],
         "filter_selected.json",
         output_dir,
+        max_rows=MAX_TABLE_EXPORT_ROWS,
     )
 
     # File downloads

--- a/analytics/analytics_package/analytics/static_site/template/index.html
+++ b/analytics/analytics_package/analytics/static_site/template/index.html
@@ -845,6 +845,8 @@
                 tbody.innerHTML = '<tr><td colspan="3">No data available</td></tr>';
                 return;
             }
+            // The source JSON is capped at MAX_TABLE_EXPORT_ROWS (100) in
+            // export.py — raising this slice above that cap silently truncates.
             tbody.innerHTML = pageviews.slice(0, 20).map(row => `
                 <tr>
                     <td>${escapeHtml(row.page || '-')}</td>
@@ -862,6 +864,8 @@
                 tbody.innerHTML = '<tr><td colspan="3">No data available</td></tr>';
                 return;
             }
+            // The source JSON is capped at MAX_TABLE_EXPORT_ROWS (100) in
+            // export.py — raising this slice above that cap silently truncates.
             tbody.innerHTML = outbound.slice(0, 20).map(row => `
                 <tr>
                     <td class="truncate">
@@ -882,6 +886,8 @@
                 return;
             }
             card.style.display = '';
+            // The source JSON is capped at MAX_TABLE_EXPORT_ROWS (100) in
+            // export.py — raising this slice above that cap silently truncates.
             tbody.innerHTML = filters.slice(0, 30).map(row => `
                 <tr>
                     <td>${escapeHtml(row.filterName || '-')}</td>


### PR DESCRIPTION
Closes #4924

## What changed

`export_df_as_json()` gains an optional `max_rows`; when the frame exceeds it, the top rows are kept and the truncation is logged (`Capped pageviews.json at top 100 of 1810 rows`) so the cap is never silent. `MAX_TABLE_EXPORT_ROWS = 100` is applied to the three exports the template renders as a fixed slice:

| Export | Rows the template renders | Now exported |
|---|---|---|
| `pageviews.json` | `slice(0, 20)` | top 100 |
| `outbound_links.json` | `slice(0, 20)` | top 100 |
| `filter_selected.json` | `slice(0, 30)` | top 100 |

Left uncapped on purpose: event detail tables, access requests and search queries — the template renders **every** row of those (behind a "Show all N rows" toggle, or with no slice at all for search), so capping them would silently drop visible data. The constant's comment records both halves of that rule, and the README's output listing now annotates the three capped files.

Measured on a 1,810-row frame: **120KB → 7KB** (~95% smaller), which is also thousands of fewer diff lines per monthly regen.

## Why top-N is safe here

The cap keeps whichever rows come first, so it depends on the frames being sorted. That holds by construction, not by luck: all three producers pass explicit `sort_results` into `get_one_period_change_df`, which does a **stable descending** `sort_values` on the current-period metric (`report_elements.py` — `get_page_views_change`, `get_outbound_links_change`, `get_index_filter_selected_change`), and `fetch.py`'s later exclude-pages / suspicious-path filtering preserves order. The deployed JSONs are fully sorted descending. `export_df_as_json`'s docstring states the expectation for future callers.

Nothing consumes the full lists: within the template these three datasets are only ever sliced for their tables plus an emptiness check — no totals, counts or reductions are derived from them — and no other Python, notebook or TypeScript in the repo reads them. So no displayed aggregate can be skewed by the cap.

## How verified

**Manual local checks only — this PR adds no automated tests.** The repo has no Python test harness: no `test_*.py` files, `pytest` is not a declared dependency, and no workflow runs Python tests. (Since #4943 there *is* an `analytics` CI job, but it runs `ruff check`, `ruff format --check` and an `import analytics.static_site` smoke test — no tests. It passes on this branch.) Flagging that explicitly because an earlier version of this description said "unit-tested", which wrongly implied in-repo coverage.

What I actually ran: an ad-hoc script in a throwaway virtualenv that imports `export_df_as_json` and exercises it against a synthetic 1,810-row frame — capped to exactly the top 100 with order preserved and NaN changes still nulled; a below-cap frame exported untouched; no `max_rows` still exports every row (the event-detail path); `None` and empty frames still emit `[]`. That script was not committed.

Adding a real pytest suite for this module and wiring it into CI is worth doing, but it would introduce a Python test harness this repo doesn't have yet — happy to do that here or as a follow-up ticket, whichever is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


