### PR TITLE
chore: update default catalog to anvil15 (#4902)

### DIFF
--- a/site-config/anvil-cmg/prod/config.ts
+++ b/site-config/anvil-cmg/prod/config.ts
@@ -3,13 +3,15 @@ import { SiteConfig } from "../../common/entities";
 import { makeConfig } from "../dev/config";
 import { authenticationConfig } from "./authentication/authentication";
 
+const CATALOG = "anvil15";
+
 const config: SiteConfig = {
   ...makeConfig(
     "https://explore.anvilproject.org",
     "https://anvilproject.org",
     "https://service.explore.anvilproject.org",
     GIT_HUB_REPO_URL,
-    "anvil14"
+    CATALOG
   ),
   exportToTerraUrl: "https://anvil.terra.bio/",
 };


### PR DESCRIPTION
Closes #4902

## What changed

Updated the catalog pinned for the production AnVIL Explorer from `anvil14` to `anvil15` in `site-config/anvil-cmg/prod/config.ts`, and extracted the value into a named `CATALOG` constant to match the pattern used by the hca-dcp and lungmap prod configs.

## Why

The Azul backend team released the anvil15 catalog and confirmed on #4902 that it is ready (the mirroring blocker was removed since there is no new public data to mirror). The prod Explorer must point at the new catalog to serve it.

## Assumptions I made

- The definition of done (inferred — the issue body is empty) is that the prod AnVIL Explorer queries the `anvil15` catalog, matching how the anvil13→anvil14 release (#4883/#4887) was done.
- Only the prod config pins a catalog; dev/cc-dev environments intentionally fall back to the backend default and were left unchanged.
- No frontend code changes are needed for anvil15 — per Hannes on the issue, there is no new public data, and no schema/field changes were mentioned.

## How to verify

The issue has no definition-of-done checklist; the inferred criterion is: **prod AnVIL Explorer serves the anvil15 catalog.**

1. Build or deploy this branch with the prod config (`npm run build:anvil-cmg`), or wait for the prod deploy.
2. Open the Datasets list on the deployed Explorer and confirm data loads without errors.
3. In the browser dev tools Network tab, confirm requests to `https://service.explore.anvilproject.org` include `catalog=anvil15`.
4. Spot-check a dataset detail page and a file export flow to confirm the new catalog responds normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
