### PR TITLE
fix: point AnVIL dev and tempdev BROWSER_URL at the hosts that serve them (#4937)

### DIFF
--- a/site-config/anvil-cmg/dev/config.ts
+++ b/site-config/anvil-cmg/dev/config.ts
@@ -29,7 +29,7 @@ const APP_TITLE = "AnVIL Data Explorer";
 const DESCRIPTION =
   "Explore datasets, donors, biosamples, and files in the AnVIL Data Explorer.";
 const DATA_URL = "https://service.anvil.gi.ucsc.edu";
-const BROWSER_URL = "https://explore.anvil.gi.ucsc.edu";
+const BROWSER_URL = "https://anvil.gi.ucsc.edu";
 const PORTAL_URL = "https://anvilproject.dev.clevercanary.com";
 
 export function makeConfig(

--- a/site-config/anvil-cmg/tempdev/config.ts
+++ b/site-config/anvil-cmg/tempdev/config.ts
@@ -5,7 +5,7 @@ import { authenticationConfig } from "./authentication/authentication";
 
 const config: SiteConfig = {
   ...makeConfig(
-    "https://explore.temp.gi.ucsc.edu",
+    "https://temp.gi.ucsc.edu",
     "https://anvilproject.org",
     "https://service.temp.gi.ucsc.edu",
     GIT_HUB_REPO_URL,


### PR DESCRIPTION
Filed by Claude Code on behalf of @hannes-ucsc.

Fixes #4937.

| deployment | config | before | after |
| --- | --- | --- | --- |
| anvildev | `site-config/anvil-cmg/dev/config.ts:32` | `https://explore.anvil.gi.ucsc.edu` | `https://anvil.gi.ucsc.edu` |
| tempdev | `site-config/anvil-cmg/tempdev/config.ts:8` | `https://explore.temp.gi.ucsc.edu` | `https://temp.gi.ucsc.edu` |

Two lines. No other value touched.

Only the two AnVIL dev-tier deployments are affected; prod (`explore.anvilproject.org`) is correct and untouched.
