### PR TITLE
chore: extend ruff rule selection for the analytics package (#4942)

### DIFF
--- a/analytics/analytics_package/analytics/_report_utils.py
+++ b/analytics/analytics_package/analytics/_report_utils.py
@@ -137,10 +137,9 @@ def get_one_period_change_series(
     series_previous_reindexed = (
         series_previous.reindex(combined_index) * current_length / previous_length
     )
-    change = ((series_current_reindexed / series_previous_reindexed) - 1).replace(
+    return ((series_current_reindexed / series_previous_reindexed) - 1).replace(
         {np.inf: np.nan}
     )
-    return change
 
 
 def get_change_over_time_df(

--- a/analytics/analytics_package/analytics/api.py
+++ b/analytics/analytics_package/analytics/api.py
@@ -53,7 +53,7 @@ def authenticate(
     *other_service_params,
     port=None,
 ):
-    service_param_sets = (first_service_params,) + other_service_params
+    service_param_sets = (first_service_params, *other_service_params)
 
     all_scopes = {
         scope for service_params in service_param_sets for scope in service_params[0]

--- a/analytics/analytics_package/analytics/api.py
+++ b/analytics/analytics_package/analytics/api.py
@@ -189,9 +189,7 @@ def get_metrics_by_dimensions_v3_style(
             results.append(result)
             params[start_index_key] += params[max_results_key]
 
-    df = results_to_df(results)
-
-    return df
+    return results_to_df(results)
 
 
 def get_metrics_by_dimensions_v4_style(
@@ -255,9 +253,7 @@ def get_metrics_by_dimensions_v4_style(
                 offset += max_results
                 params["offset"] = offset
 
-    df = v4_results_to_df(results, dimensions, metrics)
-
-    return df
+    return v4_results_to_df(results, dimensions, metrics)
 
 
 def v4_results_to_df(results, dimensions, metrics):

--- a/analytics/analytics_package/analytics/api.py
+++ b/analytics/analytics_package/analytics/api.py
@@ -68,10 +68,7 @@ def authenticate(
     global next_port
 
     if port is None:
-        if next_port is None:
-            port = 8082
-        else:
-            port = next_port
+        port = 8082 if next_port is None else next_port
         next_port = port + 1
     elif next_port is None:
         next_port = port + 1

--- a/analytics/analytics_package/analytics/report_elements.py
+++ b/analytics/analytics_package/analytics/report_elements.py
@@ -129,8 +129,7 @@ def get_outbound_links_df(analytics_params, ignore_index=True):
 
     if not ignore_index:
         return df_all_links.set_index(dimension_aliases_to_keep)
-    else:
-        return df_all_links.reset_index(drop=True)
+    return df_all_links.reset_index(drop=True)
 
 
 def get_outbound_links_change(
@@ -288,8 +287,7 @@ def get_one_period_change_df(
         )
     if ignore_index:
         return df_current_with_changes
-    else:
-        return df_current_with_changes.reset_index()
+    return df_current_with_changes.reset_index()
 
 
 def get_page_views_over_time_df(

--- a/analytics/analytics_package/analytics/static_site/__init__.py
+++ b/analytics/analytics_package/analytics/static_site/__init__.py
@@ -3,8 +3,8 @@ from .generator import generate_site
 from .resolve import enrich_detail_records, fetch_entity_title_map
 
 __all__ = [
-    "generate_site",
-    "fetch_entity_title_map",
     "enrich_detail_records",
+    "fetch_entity_title_map",
+    "generate_site",
     "make_event_charts",
 ]

--- a/analytics/analytics_package/analytics/static_site/export.py
+++ b/analytics/analytics_package/analytics/static_site/export.py
@@ -1,9 +1,8 @@
 """Export analytics DataFrames to JSON files for the static site."""
 
-import glob
 import json
-import os
 from datetime import datetime
+from pathlib import Path
 
 import pandas as pd
 from pandas.api.types import is_object_dtype, is_string_dtype
@@ -28,7 +27,7 @@ def export_df_as_json(df, col_map, change_col, filename, output_dir):
         col_map: Dict mapping source column names to output names.
         change_col: Source column name for the change metric (may be absent).
         filename: Output JSON filename.
-        output_dir: Output directory.
+        output_dir: Output directory, as a Path.
     """
     if df is None or len(df) == 0:
         records = []
@@ -56,7 +55,7 @@ def export_df_as_json(df, col_map, change_col, filename, output_dir):
             if pd.isna(record.get("change")):
                 record["change"] = None
 
-    with open(os.path.join(output_dir, filename), "w") as f:
+    with (output_dir / filename).open("w") as f:
         json.dump(records, f, indent=2)
     print(f"  Wrote {filename} ({len(records)} records)")
 
@@ -78,12 +77,13 @@ def export_data(
         current_month: Current month string (YYYY-MM).
         analytics_start: Analytics start date string.
         custom_events: List of custom event dicts with results.
-        output_dir: Output directory for JSON files.
+        output_dir: Output directory for JSON files, as a str or Path.
     """
-    os.makedirs(output_dir, exist_ok=True)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
 
-    for old_file in glob.glob(os.path.join(output_dir, "event_*_detail.json")):
-        os.remove(old_file)
+    for old_file in output_dir.glob("event_*_detail.json"):
+        old_file.unlink()
 
     df_monthly_traffic = data["monthly_traffic"]
     dates = data.get("dates", {})
@@ -96,7 +96,7 @@ def export_data(
     traffic_data["users"] = traffic_data["users"].fillna(0).astype(int)
     traffic_data["pageviews"] = traffic_data["pageviews"].fillna(0).astype(int)
 
-    with open(os.path.join(output_dir, "monthly_traffic.json"), "w") as f:
+    with (output_dir / "monthly_traffic.json").open("w") as f:
         json.dump(traffic_data.to_dict(orient="records"), f, indent=2)
     print(f"  Wrote monthly_traffic.json ({len(traffic_data)} records)")
 
@@ -138,28 +138,28 @@ def export_data(
     # File downloads
     print("Exporting file downloads data...")
     file_downloads = data.get("file_downloads", 0)
-    with open(os.path.join(output_dir, "file_downloads.json"), "w") as f:
+    with (output_dir / "file_downloads.json").open("w") as f:
         json.dump({"total": file_downloads}, f, indent=2)
     print(f"  Wrote file_downloads.json (total: {file_downloads})")
 
     # Access requests
     print("Exporting access requests data...")
     access_requests = data.get("access_requests", [])
-    with open(os.path.join(output_dir, "access_requests.json"), "w") as f:
+    with (output_dir / "access_requests.json").open("w") as f:
         json.dump(access_requests, f, indent=2)
     print(f"  Wrote access_requests.json ({len(access_requests)} records)")
 
     # File download events (GA4 enhanced measurement)
     print("Exporting file download events data...")
     file_download_events = data.get("file_download_events", 0)
-    with open(os.path.join(output_dir, "file_download_events.json"), "w") as f:
+    with (output_dir / "file_download_events.json").open("w") as f:
         json.dump({"total": file_download_events}, f, indent=2)
     print(f"  Wrote file_download_events.json (total: {file_download_events})")
 
     # Search queries
     print("Exporting search queries data...")
     search_queries = data.get("search_queries", {"total": 0, "queries": []})
-    with open(os.path.join(output_dir, "search_queries.json"), "w") as f:
+    with (output_dir / "search_queries.json").open("w") as f:
         json.dump(search_queries, f, indent=2)
     print(
         f"  Wrote search_queries.json ({len(search_queries.get('queries', []))} queries)"
@@ -180,7 +180,7 @@ def export_data(
             event_entry["detail_file_column"] = event["detail_file_column"]
         events_output.append(event_entry)
 
-    with open(os.path.join(output_dir, "custom_events.json"), "w") as f:
+    with (output_dir / "custom_events.json").open("w") as f:
         json.dump(events_output, f, indent=2)
     print(f"  Wrote custom_events.json ({len(events_output)} events)")
 
@@ -190,7 +190,7 @@ def export_data(
         detail = data.get(f"event_{key}_detail")
         if detail is not None:
             filename = f"event_{key}_detail.json"
-            with open(os.path.join(output_dir, filename), "w") as f:
+            with (output_dir / filename).open("w") as f:
                 json.dump(detail, f, indent=2)
             print(f"  Wrote {filename} ({len(detail)} records)")
 
@@ -218,13 +218,13 @@ def export_data(
                 )
             chart_output["charts"].append(chart_data)
 
-        with open(os.path.join(output_dir, "event_charts.json"), "w") as f:
+        with (output_dir / "event_charts.json").open("w") as f:
             json.dump(chart_output, f, indent=2)
         print(f"  Wrote event_charts.json ({len(chart_output['charts'])} charts)")
 
     # Config (for the HTML template)
     print("Exporting site config...")
-    with open(os.path.join(output_dir, "config.json"), "w") as f:
+    with (output_dir / "config.json").open("w") as f:
         json.dump(config, f, indent=2)
     print("  Wrote config.json")
 
@@ -242,6 +242,6 @@ def export_data(
         "engagement_rate": data.get("engagement_rate", {}),
     }
 
-    with open(os.path.join(output_dir, "meta.json"), "w") as f:
+    with (output_dir / "meta.json").open("w") as f:
         json.dump(meta, f, indent=2)
     print("  Wrote meta.json")

--- a/analytics/analytics_package/analytics/static_site/generator.py
+++ b/analytics/analytics_package/analytics/static_site/generator.py
@@ -1,12 +1,12 @@
 """Generate a static analytics site from GA4 data."""
 
-import os
 import shutil
+from pathlib import Path
 
 from .export import export_data
 from .fetch import fetch_data
 
-TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "template")
+TEMPLATE_DIR = Path(__file__).parent / "template"
 
 
 def generate_site(
@@ -39,7 +39,7 @@ def generate_site(
         property_id: GA4 property ID.
         current_month: Current month string (YYYY-MM).
         analytics_start: Start date for all-time data (YYYY-MM-DD).
-        output_dir: Output directory for the generated site.
+        output_dir: Output directory for the generated site, as a str or Path.
         custom_events: List of dicts with "event_name" and "label" keys.
             Example: [{"event_name": "chat_submitted", "label": "Chat Submissions"}]
         historic_data_path: Path to historic UA data JSON file (optional).
@@ -55,6 +55,7 @@ def generate_site(
     """
     if custom_events is None:
         custom_events = []
+    output_dir = Path(output_dir)
 
     print("=" * 50)
     print(f"Generating analytics site: {config['site_title']}")
@@ -80,13 +81,13 @@ def generate_site(
         print("Resolving entity titles...")
         title_resolver(data)
 
-    os.makedirs(output_dir, exist_ok=True)
-    template_html = os.path.join(TEMPLATE_DIR, "index.html")
-    output_html = os.path.join(output_dir, "index.html")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    template_html = TEMPLATE_DIR / "index.html"
+    output_html = output_dir / "index.html"
     shutil.copy2(template_html, output_html)
     print(f"Copied template to {output_html}")
 
-    data_dir = os.path.join(output_dir, "data")
+    data_dir = output_dir / "data"
     export_data(
         data=data,
         config=config,
@@ -99,7 +100,7 @@ def generate_site(
 
     print("\n" + "=" * 50)
     print("Static site generation complete!")
-    print(f"Files written to: {os.path.abspath(output_dir)}")
+    print(f"Files written to: {output_dir.resolve()}")
     print("\nTo view the site locally, run:")
     print(f"  cd {output_dir} && python -m http.server 8080")
     print("Then open http://localhost:8080 in your browser.")

--- a/analytics/pyproject.toml
+++ b/analytics/pyproject.toml
@@ -18,4 +18,4 @@ analytics = { workspace = true }
 dev = ["ruff==0.16.3"]
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "I", "W", "B"]
+select = ["E4", "E7", "E9", "F", "I", "W", "B", "C4", "PIE", "UP"]

--- a/analytics/pyproject.toml
+++ b/analytics/pyproject.toml
@@ -18,4 +18,4 @@ analytics = { workspace = true }
 dev = ["ruff==0.16.3"]
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "I", "W", "B", "C4", "PIE", "UP"]
+select = ["E4", "E7", "E9", "F", "I", "W", "B", "C4", "PIE", "SIM", "UP"]

--- a/analytics/pyproject.toml
+++ b/analytics/pyproject.toml
@@ -18,4 +18,4 @@ analytics = { workspace = true }
 dev = ["ruff==0.16.3"]
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "I", "W", "B", "C4", "PIE", "RET", "RUF", "SIM", "UP"]
+select = ["E4", "E7", "E9", "F", "I", "W", "B", "C4", "PIE", "PTH", "RET", "RUF", "SIM", "UP"]

--- a/analytics/pyproject.toml
+++ b/analytics/pyproject.toml
@@ -18,4 +18,4 @@ analytics = { workspace = true }
 dev = ["ruff==0.16.3"]
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "I", "W", "B", "C4", "PIE", "SIM", "UP"]
+select = ["E4", "E7", "E9", "F", "I", "W", "B", "C4", "PIE", "RUF", "SIM", "UP"]

--- a/analytics/pyproject.toml
+++ b/analytics/pyproject.toml
@@ -18,4 +18,4 @@ analytics = { workspace = true }
 dev = ["ruff==0.16.3"]
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "I", "W", "B", "C4", "PIE", "RUF", "SIM", "UP"]
+select = ["E4", "E7", "E9", "F", "I", "W", "B", "C4", "PIE", "RET", "RUF", "SIM", "UP"]


### PR DESCRIPTION
(Text via Claude)

Closes #4942

## What changed

Extends the ruff `select` list in `analytics/pyproject.toml` from `["E4", "E7", "E9", "F", "I", "W", "B"]` to add `C4`, `PIE`, `PTH`, `RET`, `RUF`, `SIM` and `UP`, and fixes every violation the new categories surface.

One commit per rule category, each enabling the category and fixing its violations together, so each reviews independently and a regression traces back to one rule:

| Commit | Category | Violations | Change |
|---|---|---|---|
| 1 | `C4`, `PIE`, `UP` | 0 | Config only — no code touched |
| 2 | `SIM` | 1 | `SIM108`: `if`/`else` → ternary in `api.py` |
| 3 | `RUF` | 2 | `RUF005` tuple unpacking in `api.py`; `RUF022` sorted `__all__` in `static_site/__init__.py` |
| 4 | `RET` | 5 | 3× `RET504` (assign-then-return) in `_report_utils.py` and `api.py`; 2× `RET505` (`else` after `return`) in `report_elements.py` |
| 5 | `PTH` | 33 | `os.path` / `os` / `glob` → `pathlib` in `static_site/export.py` (26) and `static_site/generator.py` (7) |

The `PTH` commit is the bulk of the work and the only real refactor. `output_dir` is normalized to a `Path` at each public entry point (`generate_site` and `export_data`), so the four `generate_static_site.py` scripts keep passing plain strings; `os.makedirs` becomes `Path.mkdir(parents=True, exist_ok=True)`; the stale-detail-file sweep becomes `Path.glob` + `Path.unlink`; and every `open(os.path.join(...))` becomes `(output_dir / name).open(...)`.

## Why

#4934 / #4936 added ruff to the analytics package with a deliberately minimal rule selection — enough to catch the star-import re-export leak that motivated it, but well short of what `clevercanary/hca-validation-tools` already runs on Python. Two Clever Canary Python codebases linting to two different standards means review habits don't transfer between them, and this package silently accumulates patterns that wouldn't survive review in the other repo.

## Assumptions I made

- **`E` stays narrowed to `E4`/`E7`/`E9`** rather than taking all of `E`, which is the one intentional deviation from hca-validation-tools' selection. The non-preview rules full `E` would add over that subset are exactly `E501` (line-too-long) and `E101` (mixed-spaces-and-tabs) — both formatting concerns, and therefore `ruff format`'s job. Keeping them out means the linter never duplicates or fights the formatter.
- **Scope is the `select` list only.** hca-validation-tools' other lint settings (`per-file-ignores`, `isort.known-first-party`, `line-length`, `target-version`) are deliberately out of scope. No `per-file-ignores` entry was needed — every violation had a real fix, and no `# noqa` suppressions were added anywhere.
- **The `PTH` commit is path-handling only.** A review pass suggested collapsing the ~10 near-identical `open` → `json.dump` → `print(f"  Wrote …")` blocks in `export.py` into a shared `_write_json` helper (net ≈ −16 lines). That repetition is pre-existing — this diff converted it, it didn't create it — so it was deliberately left alone to keep the commit reviewable against the rule it's named for. Filed as a follow-up instead.
- **`output_dir` accepting either `str` or `Path`** was chosen over converting the four caller scripts. Normalizing at the library boundary keeps those scripts as declarative literals and avoids touching four out-of-scope files. The docstrings now state the accepted types, since every sibling argument in them already did.
- **Two cosmetic deltas in printed output are accepted**, both stdout-only and neither touching generated site files:
  - `os.path.abspath()` → `Path.resolve()` also resolves symlinks, so the final `Files written to: …` line may differ on a symlinked path.
  - `Path("./site")` stringifies as `site`, so `anvil-catalog`'s closing `cd ./site && …` hint now prints `cd site && …`.

## How to verify

The issue's definition of done, mapped to steps:

**1. `npm run lint:python` and `npm run check-format:python` pass clean.**

```
npm run lint:python        # expect: "All checks passed!"
npm run check-format:python # expect: "21 files already formatted"
```

**2. The same steps pass in `run-checks.yml` CI.** Check the `analytics` job on this PR. To reproduce its exact sequence locally:

```
cd analytics
uv run --locked --only-group dev ruff check .
uv run --locked --only-group dev ruff format --check .
uv sync --locked
uv run --no-sync python -c "import analytics.static_site"
```

**3. Fresh-venv `generate_static_site.py` run including `historic_data_path`, with generated site output confirmed unchanged** (per the #4913 verification convention). `PTH` rewrites path construction and file I/O in `export.py` and `generator.py`, so this checks output equality, not just importability:

- Make GA4 credentials available per `analytics/readme.md` — `.credentials/hca_ga4_credentials.json` for LungMAP.
- Set `CURRENT_MONTH` in `analytics/lungmap/constants.py` to the month you want.
- From `analytics/lungmap`, run `uv run python generate_static_site.py` and complete the browser OAuth flow. LungMAP is the right app here because it passes `historic_data_path` (`HISTORIC_UA_DATA_PATH`) and writes into `gh-pages/lungmap`, exercising the real output path.
- Diff the generated `gh-pages/lungmap` tree against the same run on `main`. **Expected: every file byte-identical except `data/meta.json`'s `generated_at` timestamp.**
- Optionally serve it: `cd gh-pages && python -m http.server 8080`, then open http://localhost:8080.

**Verification already performed:**

- The full CI sequence above passes locally after each of the 5 commits, and each commit went through the repo's pre-commit hook (prettier, eslint, tsc, ruff).
- Step 3 has been run against LungMAP with `historic_data_path`: only `generated_at` differs.
- Independently, a fixture harness drove `generate_site` (with `fetch_data` stubbed to canned data, including `historic_data_path`) and `export_data` directly, then fingerprinted every output file. Output is byte-identical between `main` at e738381d and this branch across all 13 JSON files plus `index.html`, with only `meta.json`'s `generated_at` normalized. The harness also covers the two behavior-sensitive spots: `mkdir(parents=True)` creating a missing intermediate directory, and the `glob`/`unlink` sweep removing a stale `event_*_detail.json` while leaving a neighbouring file untouched. Both match `main`.
